### PR TITLE
feat(abilities): register community-domain abilities (#24)

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -57,6 +57,10 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/main-site-comments.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/subforum-button-classes.php';
 
+	require_once plugin_dir_path( __FILE__ ) . 'inc/abilities/community-drafts.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/abilities/community-upvote.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/abilities/community-taxonomy-counts.php';
+
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/upvote.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/upvote-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/forum-badges.php';

--- a/inc/abilities/community-drafts.php
+++ b/inc/abilities/community-drafts.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/community-drafts
+ *
+ * Retrieve a stored bbPress topic or reply draft for the current user.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_community_register_community_drafts_ability' );
+
+/**
+ * Register the community-drafts ability.
+ */
+function extrachill_community_register_community_drafts_ability(): void {
+
+	wp_register_ability(
+		'extrachill/community-drafts',
+		array(
+			'label'       => __( 'Get Community Drafts', 'extrachill-community' ),
+			'description' => __( 'Retrieve a stored bbPress topic or reply draft for the current user.', 'extrachill-community' ),
+			'category'    => 'extrachill-community',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'type'              => array(
+						'type'        => 'string',
+						'enum'        => array( 'topic', 'reply' ),
+						'description' => 'Draft type: topic or reply.',
+					),
+					'forum_id'          => array(
+						'type'        => 'integer',
+						'description' => 'Forum ID (required for topic drafts).',
+					),
+					'topic_id'          => array(
+						'type'        => 'integer',
+						'description' => 'Topic ID (required for reply drafts).',
+					),
+					'reply_to'          => array(
+						'type'        => 'integer',
+						'description' => 'Parent reply ID for nested replies.',
+					),
+					'prefer_unassigned' => array(
+						'type'        => 'boolean',
+						'description' => 'Fall back to forum_id=0 draft when no exact match.',
+					),
+				),
+				'required'   => array( 'type' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'draft' => array(
+						'anyOf' => array(
+							array( 'type' => 'object' ),
+							array( 'type' => 'null' ),
+						),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_community_ability_community_drafts',
+			'permission_callback' => static function (): bool {
+				return is_user_logged_in();
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Retrieve a bbPress draft for the current user.
+ *
+ * Validates context (type + required IDs), then delegates to the existing
+ * draft-retrieval helper already registered in this plugin.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_community_ability_community_drafts( array $input ): array|WP_Error {
+	$type     = isset( $input['type'] ) ? (string) $input['type'] : '';
+	$forum_id = isset( $input['forum_id'] ) ? (int) $input['forum_id'] : 0;
+	$topic_id = isset( $input['topic_id'] ) ? (int) $input['topic_id'] : 0;
+
+	// --- Context validation (mirrors REST route logic) ---
+	if ( 'topic' === $type ) {
+		if ( ! isset( $input['forum_id'] ) ) {
+			return new WP_Error( 'missing_forum_id', 'forum_id is required for topic drafts.', array( 'status' => 400 ) );
+		}
+		if ( $forum_id < 0 ) {
+			return new WP_Error( 'invalid_forum_id', 'forum_id must be >= 0.', array( 'status' => 400 ) );
+		}
+	} elseif ( 'reply' === $type ) {
+		if ( $topic_id <= 0 ) {
+			return new WP_Error( 'invalid_topic_id', 'topic_id is required for reply drafts.', array( 'status' => 400 ) );
+		}
+	} else {
+		return new WP_Error( 'invalid_type', 'Invalid type.', array( 'status' => 400 ) );
+	}
+
+	// --- Build context and retrieve draft ---
+	$user_id = extrachill_community_resolve_user_id( $input );
+	if ( ! $user_id ) {
+		$user_id = get_current_user_id();
+	}
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'A valid user is required.', array( 'status' => 401 ) );
+	}
+
+	$draft_input = array(
+		'user_id'           => $user_id,
+		'type'              => $type,
+		'blog_id'           => (int) get_current_blog_id(),
+		'forum_id'          => $forum_id,
+		'topic_id'          => $topic_id,
+		'reply_to'          => isset( $input['reply_to'] ) ? (int) $input['reply_to'] : 0,
+		'prefer_unassigned' => ! empty( $input['prefer_unassigned'] ),
+	);
+
+	$draft = extrachill_community_ability_get_bbpress_draft( $draft_input );
+
+	if ( is_wp_error( $draft ) ) {
+		return $draft;
+	}
+
+	return array( 'draft' => $draft );
+}

--- a/inc/abilities/community-taxonomy-counts.php
+++ b/inc/abilities/community-taxonomy-counts.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/community-taxonomy-counts
+ *
+ * Return forum URL and topic count for a taxonomy term.
+ * Used by cross-site linking — community forums are location hubs.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_community_register_community_taxonomy_counts_ability' );
+
+/**
+ * Register the community-taxonomy-counts ability.
+ */
+function extrachill_community_register_community_taxonomy_counts_ability(): void {
+
+	wp_register_ability(
+		'extrachill/community-taxonomy-counts',
+		array(
+			'label'       => __( 'Community Taxonomy Counts', 'extrachill-community' ),
+			'description' => __( 'Return forum URL and topic count for a taxonomy term (cross-site linking).', 'extrachill-community' ),
+			'category'    => 'extrachill-community',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'taxonomy' => array(
+						'type'        => 'string',
+						'description' => 'Taxonomy to query (e.g. location).',
+					),
+					'slug'     => array(
+						'type'        => 'string',
+						'description' => 'Term slug to look up.',
+					),
+				),
+				'required'   => array( 'taxonomy', 'slug' ),
+			),
+			'output_schema' => array(
+				'anyOf' => array(
+					array(
+						'type'       => 'object',
+						'properties' => array(
+							'slug'  => array( 'type' => 'string' ),
+							'name'  => array( 'type' => 'string' ),
+							'count' => array( 'type' => 'integer' ),
+							'url'   => array( 'type' => 'string' ),
+						),
+					),
+					array( 'type' => 'null' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_community_ability_community_taxonomy_counts',
+			'permission_callback' => '__return_true',
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Return forum data for a taxonomy term.
+ *
+ * Forums are location hubs, so we return the forum permalink and topic count
+ * rather than a taxonomy archive URL.
+ *
+ * @param array $input Ability input with 'taxonomy' and 'slug'.
+ * @return array|null|WP_Error Forum data or null if not found.
+ */
+function extrachill_community_ability_community_taxonomy_counts( array $input ): array|null|WP_Error {
+	$taxonomy = isset( $input['taxonomy'] ) ? sanitize_text_field( (string) $input['taxonomy'] ) : '';
+	$slug     = isset( $input['slug'] ) ? sanitize_title( (string) $input['slug'] ) : '';
+
+	if ( '' === $taxonomy || '' === $slug ) {
+		return new WP_Error( 'missing_params', 'Both taxonomy and slug are required.', array( 'status' => 400 ) );
+	}
+
+	if ( ! taxonomy_exists( $taxonomy ) ) {
+		return null;
+	}
+
+	$term = get_term_by( 'slug', $slug, $taxonomy );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return null;
+	}
+
+	$forums = get_posts(
+		array(
+			'post_type'      => 'forum',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				array(
+					'taxonomy' => $taxonomy,
+					'field'    => 'term_id',
+					'terms'    => $term->term_id,
+				),
+			),
+		)
+	);
+
+	if ( empty( $forums ) ) {
+		return null;
+	}
+
+	$forum = $forums[0];
+
+	$topic_query = new WP_Query(
+		array(
+			'post_type'      => 'topic',
+			'post_status'    => 'publish',
+			'post_parent'    => $forum->ID,
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => false,
+		)
+	);
+	$topic_count = $topic_query->found_posts;
+
+	return array(
+		'slug'  => $term->slug,
+		'name'  => $term->name,
+		'count' => (int) $topic_count,
+		'url'   => get_permalink( $forum ),
+	);
+}

--- a/inc/abilities/community-upvote.php
+++ b/inc/abilities/community-upvote.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+/**
+ * Ability: extrachill/community-upvote
+ *
+ * Toggle an upvote on a bbPress topic or reply for the current user.
+ * Canonical implementation — the REST route in extrachill-api refactors
+ * to a thin shim that delegates here.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'wp_abilities_api_init', 'extrachill_community_register_community_upvote_ability' );
+
+/**
+ * Register the community-upvote ability.
+ */
+function extrachill_community_register_community_upvote_ability(): void {
+
+	wp_register_ability(
+		'extrachill/community-upvote',
+		array(
+			'label'       => __( 'Community Upvote', 'extrachill-community' ),
+			'description' => __( 'Toggle an upvote on a bbPress topic or reply for the current user.', 'extrachill-community' ),
+			'category'    => 'extrachill-community',
+			'input_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'post_id' => array(
+						'type'        => 'integer',
+						'description' => 'bbPress topic or reply post ID.',
+					),
+					'type'    => array(
+						'type'        => 'string',
+						'enum'        => array( 'topic', 'reply' ),
+						'description' => 'Post type to upvote.',
+					),
+				),
+				'required'   => array( 'post_id', 'type' ),
+			),
+			'output_schema' => array(
+				'type'       => 'object',
+				'properties' => array(
+					'message'   => array( 'type' => 'string' ),
+					'new_count' => array( 'type' => 'integer' ),
+					'upvoted'   => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_community_ability_community_upvote',
+			'permission_callback' => static function (): bool {
+				return is_user_logged_in();
+			},
+			'meta' => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => false,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+// ─── Execute callback ──────────────────────────────────────────────────────────
+
+/**
+ * Toggle an upvote on a topic or reply.
+ *
+ * Delegates to extrachill_process_upvote() — the canonical business-logic
+ * helper already in this plugin (inc/social/upvote.php).
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_community_ability_community_upvote( array $input ): array|WP_Error {
+	$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+	$type    = isset( $input['type'] ) ? (string) $input['type'] : '';
+	$user_id = get_current_user_id();
+
+	if ( $post_id <= 0 ) {
+		return new WP_Error( 'missing_post_id', 'A valid post_id is required.', array( 'status' => 400 ) );
+	}
+	if ( ! in_array( $type, array( 'topic', 'reply' ), true ) ) {
+		return new WP_Error( 'invalid_type', 'Type must be "topic" or "reply".', array( 'status' => 400 ) );
+	}
+	if ( ! $user_id ) {
+		return new WP_Error( 'not_logged_in', 'A valid user is required.', array( 'status' => 401 ) );
+	}
+
+	if ( ! function_exists( 'extrachill_process_upvote' ) ) {
+		return new WP_Error( 'upvote_unavailable', 'Upvote system is not loaded.', array( 'status' => 500 ) );
+	}
+
+	$result = extrachill_process_upvote( $post_id, $type, $user_id );
+
+	if ( ! $result['success'] ) {
+		return new WP_Error( 'upvote_failed', $result['message'], array( 'status' => 400 ) );
+	}
+
+	return array(
+		'message'   => $result['message'],
+		'new_count' => $result['new_count'],
+		'upvoted'   => $result['upvoted'],
+	);
+}

--- a/inc/social/upvote-abilities.php
+++ b/inc/social/upvote-abilities.php
@@ -17,42 +17,8 @@ add_action( 'wp_abilities_api_init', 'extrachill_community_register_upvote_abili
  */
 function extrachill_community_register_upvote_abilities() {
 
-	wp_register_ability(
-		'extrachill/community-upvote',
-		array(
-			'label'               => __( 'Community Upvote', 'extrachill-community' ),
-			'description'         => __( 'Toggle an upvote on a topic or reply for a user.', 'extrachill-community' ),
-			'category'            => 'extrachill-community',
-			'input_schema'        => array(
-				'type'       => 'object',
-				'properties' => array(
-					'post_id' => array( 'type' => 'integer', 'description' => 'bbPress topic or reply post ID' ),
-					'type'    => array( 'type' => 'string', 'enum' => array( 'topic', 'reply' ), 'description' => 'Post type' ),
-					'user_id' => array( 'type' => 'integer', 'description' => 'User performing the upvote (defaults to current user)' ),
-				),
-				'required'   => array( 'post_id', 'type' ),
-			),
-			'output_schema'       => array(
-				'type'       => 'object',
-				'properties' => array(
-					'success'   => array( 'type' => 'boolean' ),
-					'message'   => array( 'type' => 'string' ),
-					'new_count' => array( 'type' => 'integer' ),
-					'upvoted'   => array( 'type' => 'boolean' ),
-				),
-			),
-			'execute_callback'    => 'extrachill_community_ability_upvote',
-			'permission_callback' => '__return_true',
-			'meta'                => array(
-				'show_in_rest' => false,
-				'annotations'  => array(
-					'readonly'    => false,
-					'idempotent'  => false,
-					'destructive' => false,
-				),
-			),
-		)
-	);
+	// Note: extrachill/community-upvote moved to inc/abilities/community-upvote.php
+	// with show_in_rest: true (see issue #24).
 
 	wp_register_ability(
 		'extrachill/community-get-upvotes',


### PR DESCRIPTION
## Summary

Registers 3 community-domain abilities with canonical `execute_callback` implementations per issue #24:

- **`extrachill/community-drafts`** — retrieve a stored bbPress topic/reply draft for the current user (readonly)
- **`extrachill/community-upvote`** — toggle an upvote on a topic or reply (mutating)
- **`extrachill/community-taxonomy-counts`** — return forum URL and topic count for a taxonomy term (readonly, public)

All have `meta.show_in_rest: true` so they're auto-callable via core's universal abilities REST controller.

## Changes

- `inc/abilities/community-drafts.php` — new ability file with context validation + draft retrieval
- `inc/abilities/community-upvote.php` — new ability file, delegates to `extrachill_process_upvote()`
- `inc/abilities/community-taxonomy-counts.php` — new ability file, ports taxonomy query from REST handler
- `extrachill-community.php` — bootstrap loader updated to `require_once` the 3 new files
- `inc/social/upvote-abilities.php` — removed duplicate `extrachill/community-upvote` registration (moved to `inc/abilities/`)

## Architecture

Per [WP core's `wp_register_core_abilities()`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/abilities.php): the ability is the source of truth. The branded `/extrachill/v1/community/*` REST routes in extrachill-api refactor to thin shims separately.

## Verification

```bash
find inc/abilities -name '*.php' -exec php -l {} \;
```

All files pass `php -l` lint.

Closes #24.