### PR TITLE
fix: enforce user identity at bbPress draft ability permission_callback (closes #28 part 1)

### DIFF
--- a/inc/content/editor/draft-abilities.php
+++ b/inc/content/editor/draft-abilities.php
@@ -38,7 +38,7 @@ function extrachill_community_register_draft_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_community_ability_get_bbpress_draft',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_bbpress_draft_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -72,7 +72,7 @@ function extrachill_community_register_draft_abilities() {
 			),
 			'output_schema'       => array( 'type' => 'object' ),
 			'execute_callback'    => 'extrachill_community_ability_save_bbpress_draft',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_bbpress_draft_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -104,7 +104,7 @@ function extrachill_community_register_draft_abilities() {
 			),
 			'output_schema'       => array( 'type' => 'boolean' ),
 			'execute_callback'    => 'extrachill_community_ability_delete_bbpress_draft',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_bbpress_draft_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -115,6 +115,41 @@ function extrachill_community_register_draft_abilities() {
 			),
 		)
 	);
+}
+
+/**
+ * Permission callback for the bbPress draft abilities.
+ *
+ * Enforces identity at the ability boundary so the ability is self-defending
+ * regardless of which caller (REST, CLI, chat tool, MCP, another plugin)
+ * invokes it. Rules:
+ *
+ *  - Caller must be logged in.
+ *  - If $input['user_id'] is supplied and does not match the current user,
+ *    the caller must hold `edit_others_posts` (the same capability bbPress
+ *    uses to gate cross-author content edits).
+ *  - Otherwise (no user_id supplied, or it matches the current user), pass.
+ *
+ * @param array $input Ability input payload.
+ * @return bool True if the caller may execute the ability.
+ */
+function extrachill_community_ability_bbpress_draft_permission( $input = array() ) {
+	if ( ! is_user_logged_in() ) {
+		return false;
+	}
+
+	if ( ! is_array( $input ) || ! isset( $input['user_id'] ) ) {
+		return true;
+	}
+
+	$requested_user_id = (int) $input['user_id'];
+	$current_user_id   = (int) get_current_user_id();
+
+	if ( $requested_user_id <= 0 || $requested_user_id === $current_user_id ) {
+		return true;
+	}
+
+	return current_user_can( 'edit_others_posts' );
 }
 
 function extrachill_community_build_draft_context_from_input( $input ) {


### PR DESCRIPTION
## Summary

Closes **part 1** of #28: the bbPress draft abilities (`extrachill/get-bbpress-draft`, `extrachill/save-bbpress-draft`, `extrachill/delete-bbpress-draft`) registered with `permission_callback => '__return_true'`. The execute callbacks read `$input['user_id']` and fall through to `get_current_user_id()`, so any caller that forwards a user-supplied `user_id` could read/write/delete arbitrary users' drafts. The live REST handler in `extrachill-api` forces matching `user_id` before execute, so production is safe today — but per `RULES.md`, the ability is the trust boundary and must self-defend.

Parts 2 (user_meta lost-update race → custom table) and 3 (dead helpers, already merged) are intentionally **out of scope** for this PR.

## Pattern chosen: A (gate cross-user access behind `edit_others_posts`)

Grep results that informed the choice:

```
$ grep -rn "wp_get_ability.*extrachill/\(get\|save\|delete\)-bbpress-draft" --include='*.php'
extrachill-community/inc/content/editor/drafts.php:17:   wp_get_ability( 'extrachill/get-bbpress-draft' )    // gate
extrachill-community/inc/content/editor/drafts.php:21:   wp_get_ability( 'extrachill/get-bbpress-draft' )    // restore form content
extrachill-community/inc/content/editor/drafts.php:32:   wp_get_ability( 'extrachill/delete-bbpress-draft' ) // clear after bbp_new_topic / bbp_new_reply
extrachill-api/inc/routes/community/drafts.php:151:      wp_get_ability( 'extrachill/get-bbpress-draft' )
extrachill-api/inc/routes/community/drafts.php:175:      wp_get_ability( 'extrachill/save-bbpress-draft' )
extrachill-api/inc/routes/community/drafts.php:216:      wp_get_ability( 'extrachill/delete-bbpress-draft' )
```

```
$ grep -rn "extrachill.*draft" wp-content/plugins/extrachill-cli/
(no matches)
```

There are **two** non-test callers:

1. **`extrachill-api/inc/routes/community/drafts.php`** — REST handler. Always forces `user_id = get_current_user_id()` before execute. Safe under either pattern.
2. **`extrachill-community/inc/content/editor/drafts.php`** — intra-plugin caller. Specifically the `bbp_new_topic` / `bbp_new_reply` hooks call `extrachill/delete-bbpress-draft` with `user_id = bbp_get_topic_author_id($topic_id)` / `bbp_get_reply_author_id($reply_id)`. In the normal submit-form path, that author IS the current user (they just submitted). In the admin-posts-on-behalf path, the admin posting has `edit_others_posts`.

Pattern B (ignore caller-supplied `user_id` entirely) would break case 2's admin-on-behalf cleanup path. Pattern A preserves it.

## What changed

`inc/content/editor/draft-abilities.php` only.

- All three abilities now use `extrachill_community_ability_bbpress_draft_permission` instead of `__return_true`.
- New shared permission callback enforces:
  - **Anonymous → deny.** `is_user_logged_in()` is the floor.
  - **No `user_id` supplied, or `user_id <= 0`, or `user_id === current_user_id` → allow.** This preserves every existing caller (REST always matches; intra-plugin caller matches in the normal flow).
  - **`user_id` supplied and differs from current → require `edit_others_posts`.** This is the same capability bbPress uses to gate cross-author content edits, so the choice is consistent with bbPress conventions and doesn't invent a new cap.

No changes to the execute callbacks. No changes to the REST handler in `extrachill-api`. No new capability invented.

## Test plan (manual verification — no automated tests in this repo)

1. **Live REST behavior unchanged.**
   - `POST /wp-json/extrachill/v1/community/drafts` with a topic/reply payload → 200 + saved draft.
   - `GET /wp-json/extrachill/v1/community/drafts?type=topic&forum_id=…` → 200 + draft.
   - `DELETE /wp-json/extrachill/v1/community/drafts?type=…` → 200 + `deleted: true`.
   - Form-level draft restoration on the new-topic and reply forms still pre-fills content from the stored draft.
   - Submitting a new topic/reply still clears its draft (via `bbp_new_topic` / `bbp_new_reply`).
2. **Hostile-user_id rejection.** Call the ability directly with a forged `user_id`:
   ```php
   wp_get_ability( 'extrachill/save-bbpress-draft' )->execute( [
       'user_id'  => <other_user_id>,
       'type'     => 'topic',
       'forum_id' => 1,
       'content'  => 'hostile',
   ] );
   ```
   - As a subscriber (no `edit_others_posts`): expect a permission error from the ability runtime.
   - As an admin (has `edit_others_posts`): expect success — the draft is saved against `<other_user_id>`.
   - Same matrix for `extrachill/get-bbpress-draft` and `extrachill/delete-bbpress-draft`.
3. **Anonymous rejection.** Logged-out call to any of the three abilities → permission error.
4. **Same-user matching passes for non-REST callers.** From WP-CLI or a test plugin, call any of the three abilities with `user_id = get_current_user_id()` (or no `user_id` at all) → succeeds for the current user.

## Critical rules respected

- Conventional commit (`fix(drafts): …`) so homeboy can auto-bump.
- No changes to `CHANGELOG.md` or version strings.
- All work done in the `/var/lib/datamachine/workspace/extrachill-community@ability-permissions` worktree, not against `/var/www/extrachill.com/wp-content/plugins/extrachill-community/`.
- No deploy, no release — PR only.
- No new capability introduced; reuses bbPress's `edit_others_posts`.
- REST handler in `extrachill-api` untouched (different repo, read-only for this PR).

cc @chubes — ready for review.