### PR TITLE
feat(abilities): add markdown format support to community-create-reply/topic (closes #30)

### DIFF
--- a/inc/content/topic-reply-abilities.php
+++ b/inc/content/topic-reply-abilities.php
@@ -105,14 +105,19 @@ function extrachill_community_register_topic_reply_abilities() {
 		'extrachill/community-create-topic',
 		array(
 			'label'               => __( 'Create Topic', 'extrachill-community' ),
-			'description'         => __( 'Create a new forum topic. Fires bbp_new_topic for notifications and cache.', 'extrachill-community' ),
+			'description'         => __( 'Create a new forum topic. Accepts HTML (default) or markdown via the format parameter. Fires bbp_new_topic for notifications and cache.', 'extrachill-community' ),
 			'category'            => 'extrachill-community',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'forum_id' => array( 'type' => 'integer', 'description' => 'Forum to post in' ),
 					'title'    => array( 'type' => 'string', 'description' => 'Topic title' ),
-					'content'  => array( 'type' => 'string', 'description' => 'Topic content (HTML allowed)' ),
+					'content'  => array( 'type' => 'string', 'description' => 'Topic content (HTML or markdown depending on format)' ),
+					'format'   => array(
+						'type'        => 'string',
+						'enum'        => array( 'html', 'markdown' ),
+						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
+					),
 					'user_id'  => array( 'type' => 'integer', 'description' => 'Author user ID (defaults to current user)' ),
 				),
 				'required'   => array( 'forum_id', 'title', 'content' ),
@@ -146,13 +151,18 @@ function extrachill_community_register_topic_reply_abilities() {
 		'extrachill/community-create-reply',
 		array(
 			'label'               => __( 'Create Reply', 'extrachill-community' ),
-			'description'         => __( 'Post a reply to a topic. Fires bbp_new_reply for notifications and cache.', 'extrachill-community' ),
+			'description'         => __( 'Post a reply to a topic. Accepts HTML (default) or markdown via the format parameter. Fires bbp_new_reply for notifications and cache.', 'extrachill-community' ),
 			'category'            => 'extrachill-community',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
 					'topic_id' => array( 'type' => 'integer', 'description' => 'Topic to reply to' ),
-					'content'  => array( 'type' => 'string', 'description' => 'Reply content (HTML allowed)' ),
+					'content'  => array( 'type' => 'string', 'description' => 'Reply content (HTML or markdown depending on format)' ),
+					'format'   => array(
+						'type'        => 'string',
+						'enum'        => array( 'html', 'markdown' ),
+						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
+					),
 					'reply_to' => array( 'type' => 'integer', 'description' => 'Parent reply ID for threaded replies (optional)' ),
 					'user_id'  => array( 'type' => 'integer', 'description' => 'Author user ID (defaults to current user)' ),
 				),
@@ -341,10 +351,12 @@ function extrachill_community_ability_create_topic( $input ) {
 		return new WP_Error( 'bbpress_unavailable', 'bbPress is not active.' );
 	}
 
-	$forum_id = isset( $input['forum_id'] ) ? (int) $input['forum_id'] : 0;
-	$title    = isset( $input['title'] ) ? sanitize_text_field( $input['title'] ) : '';
-	$content  = isset( $input['content'] ) ? wp_kses_post( $input['content'] ) : '';
-	$user_id  = extrachill_community_resolve_user_id( $input );
+	$forum_id    = isset( $input['forum_id'] ) ? (int) $input['forum_id'] : 0;
+	$title       = isset( $input['title'] ) ? sanitize_text_field( $input['title'] ) : '';
+	$raw_content = isset( $input['content'] ) ? (string) $input['content'] : '';
+	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
+	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
+	$user_id     = extrachill_community_resolve_user_id( $input );
 
 	if ( ! $forum_id ) {
 		return new WP_Error( 'missing_forum_id', 'A forum_id is required.' );
@@ -407,10 +419,12 @@ function extrachill_community_ability_create_reply( $input ) {
 		return new WP_Error( 'bbpress_unavailable', 'bbPress is not active.' );
 	}
 
-	$topic_id = isset( $input['topic_id'] ) ? (int) $input['topic_id'] : 0;
-	$content  = isset( $input['content'] ) ? wp_kses_post( $input['content'] ) : '';
-	$reply_to = isset( $input['reply_to'] ) ? (int) $input['reply_to'] : 0;
-	$user_id  = extrachill_community_resolve_user_id( $input );
+	$topic_id    = isset( $input['topic_id'] ) ? (int) $input['topic_id'] : 0;
+	$raw_content = isset( $input['content'] ) ? (string) $input['content'] : '';
+	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
+	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
+	$reply_to    = isset( $input['reply_to'] ) ? (int) $input['reply_to'] : 0;
+	$user_id     = extrachill_community_resolve_user_id( $input );
 
 	if ( ! $topic_id ) {
 		return new WP_Error( 'missing_topic_id', 'A topic_id is required.' );
@@ -505,6 +519,43 @@ function extrachill_community_ability_list_replies( $input ) {
 		'page'     => $page,
 		'per_page' => $per_page,
 	);
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Convert markdown content to Gutenberg block markup when format === 'markdown'.
+ *
+ * Relies on Block Format Bridge's public helper bfb_convert(), which is bundled
+ * with Data Machine (network-activated). When BFB is unavailable, or when format
+ * is anything other than 'markdown', the original content is returned untouched
+ * so the caller's existing HTML path continues to work.
+ *
+ * On conversion failure (BFB returns an empty string), the original markdown is
+ * returned so the write isn't blocked — wp_kses_post() downstream will still
+ * sanitise it as raw HTML.
+ *
+ * @param string $content Raw content from the caller.
+ * @param string $format  Either 'html' or 'markdown'.
+ * @return string Possibly converted content, ready for wp_kses_post().
+ */
+function extrachill_community_maybe_convert_markdown( $content, $format ) {
+	if ( 'markdown' !== $format ) {
+		return $content;
+	}
+
+	if ( ! function_exists( 'bfb_convert' ) ) {
+		error_log( '[Extrachill Community] Markdown format requested but bfb_convert() is unavailable — falling back to raw HTML handling.' );
+		return $content;
+	}
+
+	$converted = bfb_convert( $content, 'markdown', 'blocks' );
+	if ( '' === $converted ) {
+		error_log( '[Extrachill Community] bfb_convert() returned an empty string for markdown input — falling back to raw content.' );
+		return $content;
+	}
+
+	return $converted;
 }
 
 // ─── Formatters ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #30.

## Summary

Adds an optional `format` parameter to both `extrachill/community-create-reply` and `extrachill/community-create-topic` abilities. Accepted values: `html` (default — current behaviour) and `markdown`.

When `format === 'markdown'` and `bfb_convert()` is available, the content is converted to Gutenberg block markup before `wp_kses_post()` sanitises it and persists it as `post_content`. When BFB isn't available, or the conversion returns an empty string, we log via `error_log()` with an `[Extrachill Community]` prefix and fall through to raw HTML handling — the write is never blocked.

## Before / After

**Before** — caller has to hand-author block markup:

```php
wp_get_ability( 'extrachill/community-create-reply' )->execute( array(
    'topic_id' => 456,
    'content'  => '<!-- wp:paragraph --><p><strong>Hello</strong> world</p><!-- /wp:paragraph -->',
    'user_id'  => 1,
) );
```

**After** — caller speaks markdown:

```php
wp_get_ability( 'extrachill/community-create-reply' )->execute( array(
    'topic_id' => 456,
    'content'  => '**Hello** world',
    'format'   => 'markdown',
    'user_id'  => 1,
) );
```

Result on the page renders as a real bold paragraph block, not literal asterisks.

## Implementation notes

- Schema additions on both abilities: `format` is a string with `enum: ['html', 'markdown']`. Descriptions updated to mention markdown support.
- Shared helper `extrachill_community_maybe_convert_markdown( \$content, \$format )` keeps the conversion logic DRY across both callbacks and centralises the BFB-unavailable / empty-conversion fallback paths.
- `wp_kses_post()` still runs at the end regardless of format — it's safe for both raw HTML and serialised block markup (verified on the live VPS).
- Per the issue, no new conversion infrastructure was built. `bfb_convert()` is the existing public helper shipped by Block Format Bridge, which is bundled with Data Machine (network-activated on the EC multisite), so it's available globally. No composer dep added; `function_exists()` guard is enough on this network.

## Verification

On the live VPS:

\`\`\`
\$ wp eval 'echo function_exists("bfb_convert") ? "yes" : "no";'
yes

\$ wp eval 'echo bfb_convert("**bold** and a list:\n- one\n- two", "markdown", "blocks");'
<!-- wp:paragraph --><p><strong>bold</strong> and a list:</p><!-- /wp:paragraph --><!-- wp:list {"ordered":false} --><ul class="wp-block-list"><!-- wp:list-item --><li>one</li><!-- /wp:list-item --><!-- wp:list-item --><li>two</li><!-- /wp:list-item --></ul><!-- /wp:list -->
\`\`\`

The serialised output survives `wp_kses_post()` unchanged. Helper logic also exercised in isolation against all three paths (`html` passthrough, `markdown` conversion, empty-format fallback) — all PASS.

End-to-end smoke test via `wp extrachill community create-reply --format=markdown ...` is gated on the matching CLI PR (filed separately in extrachill-cli) plus a deploy. Backward compatibility is preserved: calls without `format` behave exactly as before.

## Pairs with

Companion PR in `extrachill-cli` adds the `--format` flag to the `create-reply` / `create-topic` subcommands so the new ability surface is reachable from WP-CLI.

## Out of scope

Per the issue: no changes to `block-format-bridge` itself, no reach into Data Machine's vendor directory — public `bfb_convert()` only, behind a `function_exists()` guard.