### PR TITLE
fix(mentions): port @mentions completer from blocks-everywhere (production regression)

### DIFF
--- a/inc/assets/js/bbpress-blocks-mentions.js
+++ b/inc/assets/js/bbpress-blocks-mentions.js
@@ -1,0 +1,144 @@
+/**
+ * @mentions autocompleter for the Blocks Everywhere (Gutenberg) bbPress editor.
+ *
+ * Registers a custom completer via the `editor.Autocomplete.completers` filter
+ * that hits the canonical `extrachill/users-search` REST endpoint and inserts
+ * a link to the user's community profile when selected.
+ *
+ * Runs inside the BE iframe (where wp.* globals are available because BE
+ * loads the editor scripts into the iframe document) and on non-iframe BE
+ * renders. Vanilla ES5-compatible — no build step.
+ *
+ * The legacy TinyMCE @mentions plugin in bbpress-tinymce.js still handles
+ * the fallback path when Blocks Everywhere is inactive.
+ *
+ * @package ExtraChillCommunity
+ */
+
+( function () {
+	'use strict';
+
+	if ( ! window.wp || ! wp.hooks || ! wp.apiFetch || ! wp.element ) {
+		return;
+	}
+
+	if ( window.extrachillBbpressMentionsRegistered ) {
+		return;
+	}
+	window.extrachillBbpressMentionsRegistered = true;
+
+	var apiFetch = wp.apiFetch;
+	var element = wp.element;
+	var createElement = element.createElement;
+	var concatChildren = element.concatChildren;
+
+	var SEARCH_PATH = '/extrachill/v1/users/search';
+
+	function buildPath( term ) {
+		return SEARCH_PATH + '?context=mentions&term=' + encodeURIComponent( term );
+	}
+
+	function normalizeUsers( users ) {
+		if ( ! Array.isArray( users ) ) {
+			return [];
+		}
+		return users
+			.filter( function ( user ) {
+				return user && user.slug;
+			} )
+			.map( function ( user ) {
+				return {
+					id: user.id,
+					slug: user.slug,
+					username: user.username,
+					avatarUrl: user.avatar_url,
+					profileUrl: user.profile_url,
+				};
+			} );
+	}
+
+	function getOptionLabel( user ) {
+		var avatar = user.avatarUrl
+			? createElement( 'img', {
+					className: 'editor-autocompleters__user-avatar',
+					alt: '',
+					src: user.avatarUrl,
+			  } )
+			: createElement( 'span', {
+					className: 'editor-autocompleters__no-avatar',
+			  } );
+
+		return concatChildren(
+			[
+				avatar,
+				createElement(
+					'span',
+					{ className: 'editor-autocompleters__user-name' },
+					'@' + user.slug
+				),
+				createElement(
+					'span',
+					{ className: 'editor-autocompleters__user-slug' },
+					user.username
+				),
+			]
+		);
+	}
+
+	function getMentionLink( user ) {
+		var href = user.profileUrl || '/u/' + user.slug;
+		return createElement(
+			'a',
+			{ href: href, className: 'ec-mention' },
+			'@' + user.slug
+		);
+	}
+
+	var mentionsCompleter = {
+		name: 'extrachill-mentions',
+		className: 'editor-autocompleters__user',
+		triggerPrefix: '@',
+		isDebounced: true,
+		options: function ( filterValue ) {
+			if ( ! filterValue || filterValue.length < 2 ) {
+				return [];
+			}
+
+			return apiFetch( { path: buildPath( filterValue ) } )
+				.then( normalizeUsers )
+				.catch( function () {
+					return [];
+				} );
+		},
+		getOptionKeywords: function ( user ) {
+			var values = [ user.slug, user.username ].filter( Boolean );
+			return values.reduce( function ( acc, value ) {
+				return acc.concat( String( value ).split( /\s+/ ) );
+			}, [] );
+		},
+		getOptionLabel: getOptionLabel,
+		getOptionCompletion: function ( user ) {
+			return {
+				action: 'insert-at-caret',
+				value: concatChildren( [ getMentionLink( user ), ' ' ] ),
+			};
+		},
+	};
+
+	wp.hooks.addFilter(
+		'editor.Autocomplete.completers',
+		'extrachill-community/mentions',
+		function ( completers ) {
+			completers = completers || [];
+			// Avoid double-registration if the filter fires again with our
+			// completer already present.
+			var hasOurs = completers.some( function ( c ) {
+				return c && c.name === 'extrachill-mentions';
+			} );
+			if ( hasOurs ) {
+				return completers;
+			}
+			return completers.concat( [ mentionsCompleter ] );
+		}
+	);
+} )();

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -79,6 +79,20 @@ function extrachill_community_enqueue_blocks_everywhere_iframe_assets() {
     }
 
     wp_enqueue_style( 'extrachill-bbpress' );
+
+    // The @mentions completer registers itself via the standard Gutenberg
+    // `editor.Autocomplete.completers` filter and must run inside the BE
+    // iframe document where `wp.hooks` / `wp.apiFetch` / `wp.element` live.
+    $mentions_path = EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/js/bbpress-blocks-mentions.js';
+    if ( file_exists( $mentions_path ) ) {
+        wp_enqueue_script(
+            'extrachill-community-bbpress-mentions',
+            EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/js/bbpress-blocks-mentions.js',
+            array( 'wp-hooks', 'wp-api-fetch', 'wp-element' ),
+            filemtime( $mentions_path ),
+            true
+        );
+    }
 }
 add_action( 'blocks_everywhere_enqueue_iframe_assets', 'extrachill_community_enqueue_blocks_everywhere_iframe_assets' );
 
@@ -257,7 +271,6 @@ function extrachill_community_configure_blocks_everywhere_bbpress_endpoints( $se
 
 	$settings['bbpress']['draftEndpoint'] = rest_url( 'extrachill/v1/community/drafts' );
 	$settings['bbpress']['mediaEndpoint'] = rest_url( 'extrachill/v1/media' );
-	$settings['bbpress']['mentionsEndpoint'] = rest_url( 'extrachill/v1/users/search' );
 
 	return $settings;
 }


### PR DESCRIPTION
## Why

\`@mentions\` autocomplete in the bbPress Blocks Everywhere editor has been silently broken in production. Typing \`@chubes\` produces zero suggestions, regardless of whether the user exists.

**Root cause:** the completer lived in \`blocks-everywhere/src/completer/mentions.js\` and was a layer-purity violation (vendor-specific name, className, query, URL shape, user-data contract) that also contained a regression — \`apiFetch({ path })\` was being called with the full \`rest_url()\` URL instead of a relative REST path. The api-fetch root-URL middleware prepended the API root, producing a 404'd double-URL. The \`try/catch\` swallowed the error, returning \`[]\`.

**Coordinated change:** Extra-Chill/blocks-everywhere#7 deletes the EC-specific completer from BE entirely. This PR re-homes it in extrachill-community where the EC contract belongs.

## What changes

### New: \`inc/assets/js/bbpress-blocks-mentions.js\`

Plain ES5 + \`wp.*\` globals — no build step. Registers a Gutenberg completer named \`extrachill-mentions\` via the standard \`editor.Autocomplete.completers\` filter. Key correctness change vs. the deleted BE completer:

\`\`\`js
// Before (BE, broken):
const base = wpBlocksEverywhere?.bbpress?.mentionsEndpoint; // full URL
apiFetch( { path: \`\${base}?...\` } ); // 404: double-concatenated

// After (community, working):
var SEARCH_PATH = '/extrachill/v1/users/search';
apiFetch( { path: SEARCH_PATH + '?context=mentions&term=' + ... } );
\`\`\`

### Enqueue

Hooks into \`blocks_everywhere_enqueue_iframe_assets\` (already used by this plugin for stylesheet injection). Declares \`wp-hooks\`, \`wp-api-fetch\`, \`wp-element\` as dependencies. Loads only when \`extrachill_community_bbpress_editor_is_active()\` is true.

### Drop \`mentionsEndpoint\` injection

BE no longer reads \`bbpress.mentionsEndpoint\` (it's gone in the BE PR). Removing the injection so the settings payload doesn't carry dead config.

## What stays

- TinyMCE \`@mentions\` plugin in \`bbpress-tinymce.js\` is unchanged — that's the fallback path when Blocks Everywhere is inactive.
- Server-side mention-notification capture (\`inc/social/notifications/capture-mentions.php\`) is unchanged — it parses \`@username\` patterns from saved post content and creates notifications. Independent of the autocomplete UI.

## Layering note

The \`/extrachill/v1/users/search\` endpoint is still served by extrachill-api today (it's a duplicate of the canonical \`extrachill/users-search\` ability in extrachill-users). Extra-Chill/extrachill-api#TBD thins that route down to a \`wp_get_ability()->execute()\` wrapper per RULES.md. Independent of this PR.

## Coordination

Ship with Extra-Chill/blocks-everywhere#7 in the same deploy window. Either order produces a working state, but shipping BE first means \`@mentions\` shows zero results for the gap window; shipping community first means the completer is registered twice (BE's broken one returns \`[]\` from a 404, ours works — Gutenberg shows both, ours wins).

## Verification

- \`node -c bbpress-blocks-mentions.js\` — syntax OK
- \`php -l inc/core/assets.php\` — syntax OK
- Endpoint already returns 200 with correct data when authenticated (verified against live extrachill/users-search ability)