### PR TITLE
refactor: migrate bbPress iframe styles to canonical enqueue_block_assets

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -55,7 +55,23 @@ function enqueue_bbpress_global_styles() {
 }
 add_action('wp_enqueue_scripts', 'enqueue_bbpress_global_styles');
 
-function extrachill_community_enqueue_blocks_everywhere_iframe_assets() {
+/**
+ * Enqueue bbPress styles + @mentions completer into the block-editor iframe.
+ *
+ * Uses the canonical Gutenberg `enqueue_block_assets` action, which fires for
+ * BOTH the host page and the editor iframe in any Gutenberg-driven editor
+ * context (Blocks Everywhere included). This replaces the previous
+ * BE-specific `blocks_everywhere_enqueue_iframe_assets` handler so the plugin
+ * aligns with the canonical iframe-styles API introduced in Gutenberg 22.8+,
+ * silencing the "added to the iframe incorrectly" warning.
+ *
+ * Guard is tight: only runs when the bbPress front-end editor is active,
+ * which means a bbPress topic/reply/edit page (or the homepage's New Topic
+ * modal) is being rendered. wp-admin post-editing requests fail this guard
+ * (no `is_bbpress()`, no `is_front_page()`), so `extrachill-bbpress-css` does
+ * not leak into wp-admin chrome.
+ */
+function extrachill_community_enqueue_block_editor_iframe_assets() {
     if ( ! function_exists( 'extrachill_community_bbpress_editor_is_active' ) ) {
         return;
     }
@@ -94,7 +110,7 @@ function extrachill_community_enqueue_blocks_everywhere_iframe_assets() {
         );
     }
 }
-add_action( 'blocks_everywhere_enqueue_iframe_assets', 'extrachill_community_enqueue_blocks_everywhere_iframe_assets' );
+add_action( 'enqueue_block_assets', 'extrachill_community_enqueue_block_editor_iframe_assets' );
 
 function modular_bbpress_styles() {
     if (bbp_is_forum_archive() || is_front_page() || is_home() || bbp_is_single_forum()) {


### PR DESCRIPTION
## Why this matters

Production console has been emitting a Gutenberg iframe-compat warning:
`extrachill-bbpress-css was added to the iframe incorrectly`. The style still reaches the iframe via Gutenberg's
compat-clone fallback, so visually nothing is broken — but the canonical iframe-styles API introduced in Gutenberg
**22.8+** is `enqueue_block_assets`, and the plugin should align with it instead of leaning on BE's plugin-specific
`blocks_everywhere_enqueue_iframe_assets` hook.

`enqueue_block_assets` is the documented, framework-level action that Gutenberg fires for **both** the host page and the
editor iframe in any Gutenberg-driven editor context (BE included). Migrating removes the warning at the source and
makes the plugin portable to any future iframe-rendering editor that registers via the canonical API.

## What changed

`inc/core/assets.php` — single handler migrated:

- **Renamed** `extrachill_community_enqueue_blocks_everywhere_iframe_assets()` → `extrachill_community_enqueue_block_editor_iframe_assets()`.
- **Hook changed** from `blocks_everywhere_enqueue_iframe_assets` → `enqueue_block_assets`.
- Body of the function is unchanged: same registration, same handle (`extrachill-bbpress`), same `@mentions` script
  enqueue, same `file_exists()` / `wp_style_is()` safety checks.
- Added a docblock explaining the rationale and the guard semantics so future readers don't reintroduce the BE-specific
  hook.

The BE-specific hook handler becomes redundant and is removed. BE itself still defines the hook for any other consumers
— this plugin just doesn't need it anymore.

The front-end enqueue path (`enqueue_bbpress_global_styles` on `wp_enqueue_scripts`) is **untouched**.

## Context guard — why this doesn't leak into wp-admin

`enqueue_block_assets` fires on every admin page if unguarded, which would leak `extrachill-bbpress-css` onto wp-admin
chrome (post editor, settings pages, etc.). The migrated handler reuses the existing
`extrachill_community_bbpress_editor_is_active()` helper as its only gate:

```php
if ( ! extrachill_community_bbpress_editor_is_active() ) {
    return;
}
```

That helper returns `true` only when:
- The current request is the front page (homepage New Topic modal needs the editor), OR
- The current request is a bbPress single topic / single reply / topic edit / reply edit / single forum page.

All of those are **frontend** requests being rendered to authenticated forum users. wp-admin post-editing requests fail
this guard because `is_bbpress()` is false and `is_front_page()` is false in admin context. Net result: no regression on
wp-admin chrome, same iframe coverage as before.

## Smoke-test path

1. **Iframe warning gone (primary fix):** load `community.extrachill.com` on a topic page with BE active. Open DevTools
   console. The previous `extrachill-bbpress-css ... added to the iframe incorrectly` warning should be gone.
2. **bbPress styling still correct in the editor:** open the reply form on the same topic. The BE iframe content should
   render with the same bbPress typography/colors as before (visual parity — the style still reaches the iframe, just
   via the canonical channel).
3. **No wp-admin leak (regression check):** log into wp-admin, open the post editor on a non-bbPress post (`/wp-admin/post.php?post=...&action=edit`).
   View source / Network tab. `bbpress.css` should NOT appear in the admin page's stylesheets.
4. **Front-end bbPress pages unchanged:** load a topic without BE involvement (e.g. anonymous view). The front-end
   `extrachill-bbpress` enqueue from `enqueue_bbpress_global_styles` is untouched, so styling parity holds.

## Hard constraints honored

- No `CHANGELOG.md` edits — homeboy owns release notes.
- No version string bumps — homeboy auto-detects from conventional commits.
- Conventional commit: `refactor:` prefix.
- PR only, no deploy, no release.

cc @chubes — ready for review.