### PR TITLE
fix(drafts): replace user_meta blob with custom table to eliminate lost-update race

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -47,6 +47,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/tinymce-image-uploads.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/blocks-everywhere.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-abilities-category.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-storage.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/drafts.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/ability-helpers.php';

--- a/inc/content/editor/draft-abilities.php
+++ b/inc/content/editor/draft-abilities.php
@@ -167,48 +167,17 @@ function extrachill_community_resolve_draft_user_id( $input ) {
 	return $user_id > 0 ? $user_id : 0;
 }
 
-function extrachill_community_bbpress_drafts_meta_key() {
-	return 'ec_bbpress_drafts';
-}
-
-function extrachill_community_bbpress_draft_key( array $context ) {
-	$type    = isset( $context['type'] ) ? (string) $context['type'] : '';
-	$blog_id = isset( $context['blog_id'] ) ? (int) $context['blog_id'] : (int) get_current_blog_id();
-
-	if ( 'topic' === $type ) {
-		$forum_id = isset( $context['forum_id'] ) ? (int) $context['forum_id'] : 0;
-		return sprintf( 'topic:%d:%d', $blog_id, $forum_id );
-	}
-
-	if ( 'reply' === $type ) {
-		$topic_id = isset( $context['topic_id'] ) ? (int) $context['topic_id'] : 0;
-		$reply_to = isset( $context['reply_to'] ) ? (int) $context['reply_to'] : 0;
-		return sprintf( 'reply:%d:%d:%d', $blog_id, $topic_id, $reply_to );
-	}
-
-	return sprintf( 'unknown:%d', $blog_id );
-}
-
-function extrachill_community_bbpress_drafts_get_all( $user_id ) {
-	$user_id = (int) $user_id;
-	if ( $user_id <= 0 ) {
-		return array();
-	}
-
-	$drafts = get_user_meta( $user_id, extrachill_community_bbpress_drafts_meta_key(), true );
-
-	return is_array( $drafts ) ? $drafts : array();
-}
-
-function extrachill_community_bbpress_drafts_set_all( $user_id, array $drafts ) {
-	$user_id = (int) $user_id;
-	if ( $user_id <= 0 ) {
-		return false;
-	}
-
-	return (bool) update_user_meta( $user_id, extrachill_community_bbpress_drafts_meta_key(), $drafts );
-}
-
+/**
+ * Get-ability execute callback.
+ *
+ * Reads a single draft row from the storage repository. Falls back to the
+ * unassigned-forum draft (forum_id=0) when `prefer_unassigned` is set and the
+ * specific-forum lookup returned no row — preserves the "I started typing
+ * before picking a forum" UX.
+ *
+ * @param array $input Ability input.
+ * @return array|null
+ */
 function extrachill_community_ability_get_bbpress_draft( $input ) {
 	$user_id = extrachill_community_resolve_draft_user_id( $input );
 	if ( $user_id <= 0 ) {
@@ -216,19 +185,26 @@ function extrachill_community_ability_get_bbpress_draft( $input ) {
 	}
 
 	$context = extrachill_community_build_draft_context_from_input( $input );
-	$drafts  = extrachill_community_bbpress_drafts_get_all( $user_id );
-	$key     = extrachill_community_bbpress_draft_key( $context );
-	$draft   = isset( $drafts[ $key ] ) && is_array( $drafts[ $key ] ) ? $drafts[ $key ] : null;
+	$draft   = extrachill_community_bbpress_drafts_fetch( $user_id, $context );
 
 	if ( null === $draft && 'topic' === $context['type'] && ! empty( $input['prefer_unassigned'] ) && $context['forum_id'] > 0 ) {
 		$context['forum_id'] = 0;
-		$key   = extrachill_community_bbpress_draft_key( $context );
-		$draft = isset( $drafts[ $key ] ) && is_array( $drafts[ $key ] ) ? $drafts[ $key ] : null;
+		$draft               = extrachill_community_bbpress_drafts_fetch( $user_id, $context );
 	}
 
 	return $draft;
 }
 
+/**
+ * Save-ability execute callback.
+ *
+ * Upserts a single draft row. The storage layer's UNIQUE KEY guarantees
+ * atomic, race-free updates even when two browser tabs save the same draft
+ * context simultaneously.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error Stored draft row, or WP_Error on invalid input.
+ */
 function extrachill_community_ability_save_bbpress_draft( $input ) {
 	$user_id = extrachill_community_resolve_draft_user_id( $input );
 	if ( $user_id <= 0 ) {
@@ -239,30 +215,29 @@ function extrachill_community_ability_save_bbpress_draft( $input ) {
 	$draft   = array_merge(
 		$context,
 		array(
-			'title'   => isset( $input['title'] ) ? (string) $input['title'] : '',
-			'content' => isset( $input['content'] ) ? (string) $input['content'] : '',
+			'title'      => isset( $input['title'] ) ? (string) $input['title'] : '',
+			'content'    => isset( $input['content'] ) ? (string) $input['content'] : '',
+			'updated_at' => time(),
 		)
 	);
 
-	$drafts = extrachill_community_bbpress_drafts_get_all( $user_id );
-	$key    = extrachill_community_bbpress_draft_key( $draft );
+	$stored = extrachill_community_bbpress_drafts_upsert( $user_id, $draft );
 
-	$drafts[ $key ] = array(
-		'type'       => $draft['type'],
-		'blog_id'    => $draft['blog_id'],
-		'forum_id'   => isset( $draft['forum_id'] ) ? (int) $draft['forum_id'] : 0,
-		'topic_id'   => isset( $draft['topic_id'] ) ? (int) $draft['topic_id'] : 0,
-		'reply_to'   => isset( $draft['reply_to'] ) ? (int) $draft['reply_to'] : 0,
-		'title'      => isset( $draft['title'] ) ? (string) $draft['title'] : '',
-		'content'    => isset( $draft['content'] ) ? (string) $draft['content'] : '',
-		'updated_at' => time(),
-	);
+	if ( false === $stored ) {
+		return new WP_Error( 'draft_save_failed', 'Failed to save draft.' );
+	}
 
-	extrachill_community_bbpress_drafts_set_all( $user_id, $drafts );
-
-	return $drafts[ $key ];
+	return $stored;
 }
 
+/**
+ * Delete-ability execute callback.
+ *
+ * Deletes a single draft row. Returns true on no-op (row didn't exist).
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
 function extrachill_community_ability_delete_bbpress_draft( $input ) {
 	$user_id = extrachill_community_resolve_draft_user_id( $input );
 	if ( $user_id <= 0 ) {
@@ -270,14 +245,6 @@ function extrachill_community_ability_delete_bbpress_draft( $input ) {
 	}
 
 	$context = extrachill_community_build_draft_context_from_input( $input );
-	$drafts  = extrachill_community_bbpress_drafts_get_all( $user_id );
-	$key     = extrachill_community_bbpress_draft_key( $context );
 
-	if ( ! isset( $drafts[ $key ] ) ) {
-		return true;
-	}
-
-	unset( $drafts[ $key ] );
-
-	return extrachill_community_bbpress_drafts_set_all( $user_id, $drafts );
+	return extrachill_community_bbpress_drafts_delete( $user_id, $context );
 }

--- a/inc/content/editor/draft-storage.php
+++ b/inc/content/editor/draft-storage.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * bbPress Draft Storage (custom table)
+ *
+ * Single source of truth for the bbPress draft storage backend. Replaces the
+ * previous read/modify/write loop over a single `ec_bbpress_drafts` user_meta
+ * blob, which dropped concurrent writes silently.
+ *
+ * Storage shape: one row per draft, keyed on
+ * (user_id, blog_id, type, forum_id, topic_id, reply_to). Writes use
+ * INSERT ... ON DUPLICATE KEY UPDATE so concurrent saves from multiple tabs
+ * upsert atomically without a read/modify/write window.
+ *
+ * Lazy migration: the first read for a user with legacy user_meta backfills
+ * any rows into the table and deletes the user_meta blob. No site-wide
+ * migration script needed; the data heals as users return to compose.
+ *
+ * @package ExtraChillCommunity
+ * @subpackage ForumFeatures\Content\Editor
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Returns the unprefixed table name for the bbPress drafts table.
+ *
+ * The table is created per-blog (uses $wpdb->prefix) because draft context
+ * already includes blog_id — but on multisite each subsite's storage is
+ * isolated, matching how the rest of the plugin treats forum content.
+ *
+ * @return string
+ */
+function extrachill_community_bbpress_drafts_table_name() {
+	global $wpdb;
+	return $wpdb->prefix . 'ec_bbpress_drafts';
+}
+
+/**
+ * The schema version. Bump when the CREATE TABLE statement changes.
+ */
+function extrachill_community_bbpress_drafts_schema_version() {
+	return '1';
+}
+
+/**
+ * Option key tracking the installed schema version for this blog.
+ */
+function extrachill_community_bbpress_drafts_schema_option() {
+	return 'extrachill_community_bbpress_drafts_schema_version';
+}
+
+/**
+ * Install or upgrade the drafts table for the current blog.
+ *
+ * Idempotent. Safe to call on every plugin load — guarded by an option so
+ * dbDelta only runs when the schema version changes.
+ */
+function extrachill_community_bbpress_drafts_install_table() {
+	$installed = get_option( extrachill_community_bbpress_drafts_schema_option(), '0' );
+	$target    = extrachill_community_bbpress_drafts_schema_version();
+
+	if ( (string) $installed === (string) $target ) {
+		return;
+	}
+
+	global $wpdb;
+	$table           = extrachill_community_bbpress_drafts_table_name();
+	$charset_collate = $wpdb->get_charset_collate();
+
+	$sql = "CREATE TABLE $table (
+		draft_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+		user_id BIGINT(20) UNSIGNED NOT NULL,
+		blog_id BIGINT(20) UNSIGNED NOT NULL,
+		type VARCHAR(16) NOT NULL,
+		forum_id BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		topic_id BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		reply_to BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		title TEXT NULL,
+		content LONGTEXT NULL,
+		updated_at BIGINT(20) UNSIGNED NOT NULL,
+		PRIMARY KEY  (draft_id),
+		UNIQUE KEY uniq_draft (user_id, blog_id, type, forum_id, topic_id, reply_to),
+		KEY idx_user_updated (user_id, updated_at)
+	) $charset_collate;";
+
+	if ( ! function_exists( 'dbDelta' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	}
+
+	dbDelta( $sql );
+
+	update_option( extrachill_community_bbpress_drafts_schema_option(), $target, false );
+}
+add_action( 'plugins_loaded', 'extrachill_community_bbpress_drafts_install_table', 15 );
+
+/**
+ * Upsert a single draft row.
+ *
+ * Atomic — INSERT ... ON DUPLICATE KEY UPDATE relies on the UNIQUE KEY
+ * uniq_draft so concurrent writes from two browser tabs collapse to a single
+ * row without a read/modify/write window.
+ *
+ * @param int   $user_id Draft owner.
+ * @param array $draft   Draft fields. Must include `type`.
+ * @return array|false Stored row on success, false on failure.
+ */
+function extrachill_community_bbpress_drafts_upsert( $user_id, array $draft ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	$row = array(
+		'user_id'    => $user_id,
+		'blog_id'    => isset( $draft['blog_id'] ) ? (int) $draft['blog_id'] : (int) get_current_blog_id(),
+		'type'       => isset( $draft['type'] ) ? (string) $draft['type'] : '',
+		'forum_id'   => isset( $draft['forum_id'] ) ? (int) $draft['forum_id'] : 0,
+		'topic_id'   => isset( $draft['topic_id'] ) ? (int) $draft['topic_id'] : 0,
+		'reply_to'   => isset( $draft['reply_to'] ) ? (int) $draft['reply_to'] : 0,
+		'title'      => isset( $draft['title'] ) ? (string) $draft['title'] : '',
+		'content'    => isset( $draft['content'] ) ? (string) $draft['content'] : '',
+		'updated_at' => isset( $draft['updated_at'] ) ? (int) $draft['updated_at'] : time(),
+	);
+
+	if ( '' === $row['type'] ) {
+		return false;
+	}
+
+	$table = extrachill_community_bbpress_drafts_table_name();
+
+	// Manual INSERT ... ON DUPLICATE KEY UPDATE — $wpdb->replace would delete
+	// the row first (losing draft_id continuity), so we do this explicitly.
+	$sql = $wpdb->prepare(
+		"INSERT INTO {$table}
+			(user_id, blog_id, type, forum_id, topic_id, reply_to, title, content, updated_at)
+		VALUES (%d, %d, %s, %d, %d, %d, %s, %s, %d)
+		ON DUPLICATE KEY UPDATE
+			title = VALUES(title),
+			content = VALUES(content),
+			updated_at = VALUES(updated_at)",
+		$row['user_id'],
+		$row['blog_id'],
+		$row['type'],
+		$row['forum_id'],
+		$row['topic_id'],
+		$row['reply_to'],
+		$row['title'],
+		$row['content'],
+		$row['updated_at']
+	);
+
+	$result = $wpdb->query( $sql );
+	if ( false === $result ) {
+		return false;
+	}
+
+	return $row;
+}
+
+/**
+ * Fetch a single draft row matching the supplied context.
+ *
+ * @param int   $user_id Draft owner.
+ * @param array $context Draft context (type, blog_id, forum_id, topic_id, reply_to).
+ * @return array|null Stored row or null if none.
+ */
+function extrachill_community_bbpress_drafts_fetch( $user_id, array $context ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return null;
+	}
+
+	extrachill_community_bbpress_drafts_migrate_user_meta_if_needed( $user_id );
+
+	$table = extrachill_community_bbpress_drafts_table_name();
+	$row   = $wpdb->get_row(
+		$wpdb->prepare(
+			"SELECT * FROM {$table}
+			WHERE user_id = %d
+				AND blog_id = %d
+				AND type = %s
+				AND forum_id = %d
+				AND topic_id = %d
+				AND reply_to = %d
+			LIMIT 1",
+			$user_id,
+			isset( $context['blog_id'] ) ? (int) $context['blog_id'] : (int) get_current_blog_id(),
+			isset( $context['type'] ) ? (string) $context['type'] : '',
+			isset( $context['forum_id'] ) ? (int) $context['forum_id'] : 0,
+			isset( $context['topic_id'] ) ? (int) $context['topic_id'] : 0,
+			isset( $context['reply_to'] ) ? (int) $context['reply_to'] : 0
+		),
+		ARRAY_A
+	);
+
+	return $row ? extrachill_community_bbpress_drafts_normalize_row( $row ) : null;
+}
+
+/**
+ * Delete a single draft row matching the supplied context.
+ *
+ * @param int   $user_id Draft owner.
+ * @param array $context Draft context (type, blog_id, forum_id, topic_id, reply_to).
+ * @return bool True on success (including no-op when row didn't exist).
+ */
+function extrachill_community_bbpress_drafts_delete( $user_id, array $context ) {
+	global $wpdb;
+
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return false;
+	}
+
+	extrachill_community_bbpress_drafts_migrate_user_meta_if_needed( $user_id );
+
+	$table  = extrachill_community_bbpress_drafts_table_name();
+	$result = $wpdb->delete(
+		$table,
+		array(
+			'user_id'  => $user_id,
+			'blog_id'  => isset( $context['blog_id'] ) ? (int) $context['blog_id'] : (int) get_current_blog_id(),
+			'type'     => isset( $context['type'] ) ? (string) $context['type'] : '',
+			'forum_id' => isset( $context['forum_id'] ) ? (int) $context['forum_id'] : 0,
+			'topic_id' => isset( $context['topic_id'] ) ? (int) $context['topic_id'] : 0,
+			'reply_to' => isset( $context['reply_to'] ) ? (int) $context['reply_to'] : 0,
+		),
+		array( '%d', '%d', '%s', '%d', '%d', '%d' )
+	);
+
+	return false !== $result;
+}
+
+/**
+ * Normalize a DB row into the public draft shape (matches pre-refactor output).
+ *
+ * @param array $row Raw DB row.
+ * @return array
+ */
+function extrachill_community_bbpress_drafts_normalize_row( array $row ) {
+	return array(
+		'type'       => isset( $row['type'] ) ? (string) $row['type'] : '',
+		'blog_id'    => isset( $row['blog_id'] ) ? (int) $row['blog_id'] : 0,
+		'forum_id'   => isset( $row['forum_id'] ) ? (int) $row['forum_id'] : 0,
+		'topic_id'   => isset( $row['topic_id'] ) ? (int) $row['topic_id'] : 0,
+		'reply_to'   => isset( $row['reply_to'] ) ? (int) $row['reply_to'] : 0,
+		'title'      => isset( $row['title'] ) ? (string) $row['title'] : '',
+		'content'    => isset( $row['content'] ) ? (string) $row['content'] : '',
+		'updated_at' => isset( $row['updated_at'] ) ? (int) $row['updated_at'] : 0,
+	);
+}
+
+/**
+ * Lazy migration: on first table read for a user with legacy user_meta,
+ * backfill all rows into the table and delete the user_meta blob.
+ *
+ * Self-healing — no network-wide migration script needed. Users with no
+ * legacy data pay only one user_meta lookup which is cached.
+ *
+ * @param int $user_id Draft owner.
+ * @return void
+ */
+function extrachill_community_bbpress_drafts_migrate_user_meta_if_needed( $user_id ) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return;
+	}
+
+	$meta_key = 'ec_bbpress_drafts';
+	$legacy   = get_user_meta( $user_id, $meta_key, true );
+
+	if ( empty( $legacy ) || ! is_array( $legacy ) ) {
+		return;
+	}
+
+	foreach ( $legacy as $entry ) {
+		if ( ! is_array( $entry ) || empty( $entry['type'] ) ) {
+			continue;
+		}
+		extrachill_community_bbpress_drafts_upsert( $user_id, $entry );
+	}
+
+	delete_user_meta( $user_id, $meta_key );
+}

--- a/inc/content/topic-reply-abilities.php
+++ b/inc/content/topic-reply-abilities.php
@@ -888,20 +888,17 @@ function extrachill_community_build_editor_permissions( $post_id, $type ) {
  * @return array|null
  */
 function extrachill_community_get_draft_overlay( $user_id, $type, array $context ) {
-	if ( ! function_exists( 'extrachill_community_bbpress_drafts_get_all' ) ) {
+	if ( ! function_exists( 'extrachill_community_bbpress_drafts_fetch' ) ) {
 		return null;
 	}
 	$user_id = (int) $user_id;
 	if ( $user_id <= 0 ) {
 		return null;
 	}
-	$context['type'] = $type;
+	$context['type']    = $type;
 	$context['blog_id'] = isset( $context['blog_id'] ) ? (int) $context['blog_id'] : (int) get_current_blog_id();
 
-	$drafts = extrachill_community_bbpress_drafts_get_all( $user_id );
-	$key    = extrachill_community_bbpress_draft_key( $context );
-
-	return isset( $drafts[ $key ] ) && is_array( $drafts[ $key ] ) ? $drafts[ $key ] : null;
+	return extrachill_community_bbpress_drafts_fetch( $user_id, $context );
 }
 
 /**


### PR DESCRIPTION
Closes #28 (point 2 — the only remaining open work in that issue).

## What changed

Replaces the bbPress draft storage backend. The public ability surface (`extrachill/get-bbpress-draft`, `extrachill/save-bbpress-draft`, `extrachill/delete-bbpress-draft`) is unchanged — input/output schemas are identical. Only the storage layer was swapped.

### Before

Each user's drafts lived in a single `ec_bbpress_drafts` user_meta blob. Every save/delete was:

```
1. SELECT meta_value FROM usermeta WHERE user_id = X    (read whole blob)
2. PHP: $drafts[$key] = {...}                          (mutate)
3. UPDATE usermeta SET meta_value = ... WHERE user_id = X  (write whole blob)
```

Two concurrent writes from different tabs (or save+delete from `bbp_new_topic` overlapping with the BE autosave debounce) silently overwrote each other. No mutex, no CAS, no per-row primary key.

### After

One row per draft in a new custom table:

```sql
CREATE TABLE c8c_N_ec_bbpress_drafts (
  draft_id   BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
  user_id    BIGINT UNSIGNED NOT NULL,
  blog_id    BIGINT UNSIGNED NOT NULL,
  type       VARCHAR(16) NOT NULL,
  forum_id   BIGINT UNSIGNED NOT NULL DEFAULT 0,
  topic_id   BIGINT UNSIGNED NOT NULL DEFAULT 0,
  reply_to   BIGINT UNSIGNED NOT NULL DEFAULT 0,
  title      TEXT,
  content    LONGTEXT,
  updated_at BIGINT UNSIGNED NOT NULL,
  UNIQUE KEY uniq_draft (user_id, blog_id, type, forum_id, topic_id, reply_to),
  KEY idx_user_updated (user_id, updated_at)
) ENGINE=InnoDB;
```

Writes use `INSERT ... ON DUPLICATE KEY UPDATE` against `uniq_draft`. The UNIQUE KEY collapses concurrent writes to one atomic row mutation. No read/modify/write window.

## Lazy migration

The first read or write for a user with legacy `ec_bbpress_drafts` user_meta:

1. Reads the blob via `get_user_meta`
2. Upserts each entry into the new table
3. `delete_user_meta` on the blob

Self-healing — no site-wide migration script needed. Users with no legacy data pay only a cached `get_user_meta` lookup (already loaded in WP user object cache).

## Backwards compatibility

- **Public ability API:** unchanged.
- **REST routes:** `/extrachill/v1/community/drafts` GET/POST/DELETE unchanged (they delegate to abilities).
- **Removed helpers:** `extrachill_community_bbpress_drafts_get_all/set_all/meta_key/draft_key`. Verified zero external consumers across the production plugin tree. One internal caller in `topic-reply-abilities.php::extrachill_community_get_draft_overlay()` updated to use the new `extrachill_community_bbpress_drafts_fetch()` repository function.

## Verification

- `php -l` clean on all 4 changed files.
- No remaining references to removed helper names anywhere in the repo.
- Lazy migration logic tested by reasoning: `migrate_user_meta_if_needed()` runs on first fetch/delete, upserts each legacy entry, then deletes the blob. Subsequent reads find no blob → no-op.

## Issue #28 status after this PR

- ✅ Point 1 — `__return_true` permission callbacks — already shipped (was fixed prior to issue review)
- ✅ Point 2 — lost-update race on `ec_bbpress_drafts` user_meta — **this PR**
- ✅ Point 3 — duplicate storage helpers across plugins — already shipped (file was already deleted)

Issue #28 can close when this lands.

## Release notes

Conventional commit: `fix:` → patch bump. No changelog/version edits in this PR — homeboy owns those at release time.