### PR TITLE
Fix excessive margin on community latest post component

### DIFF
--- a/inc/home/latest-post.php
+++ b/inc/home/latest-post.php
@@ -71,7 +71,7 @@ function extrachill_fetch_all_artist_forum_ids() {
  */
 function extrachill_construct_activity_output($current_post_id) {
     if (!$current_post_id) {
-        return '<div class="community-latest-post"><p>No recent activity found in this section.</p></div>';
+        return '<div class="community-latest-post">No recent activity found in this section.</div>';
     }
 
     // Fetch post information
@@ -92,7 +92,7 @@ function extrachill_construct_activity_output($current_post_id) {
 
     // Construct output
     $output = sprintf(
-        '<div class="community-latest-post"><p><strong>Latest:</strong> <a href="%s">%s</a> %s <a href="%s">%s</a> in <a href="%s">%s</a> - %s</p></div>',
+        '<div class="community-latest-post"><strong>Latest:</strong> <a href="%s">%s</a> %s <a href="%s">%s</a> in <a href="%s">%s</a> - %s</div>',
         esc_url($author_profile_url),
         esc_html($author_name),
         $type_label,
@@ -121,7 +121,7 @@ function fetch_latest_post_info_for_homepage() {
     $all_forum_ids = array_unique(array_filter($all_forum_ids));
 
     if (empty($all_forum_ids)) {
-        return '<div class="community-latest-post"><p>No forums found for homepage.</p></div>';
+        return '<div class="community-latest-post">No forums found for homepage.</div>';
     }
 
     // Query for the single latest post across all these forums


### PR DESCRIPTION
## Summary
- The `.community-latest-post` component wrapped its content in a `<p>` tag, which inherited the theme's paragraph margins and produced ridiculous spacing.
- Removed the `<p>` tag from all three output paths in `inc/home/latest-post.php` (activity output, no-activity fallback, no-forums fallback). Content now sits directly inside the `.community-latest-post` div, which already provides its own padding.

## Why
The div already supplies padding/border/background; the inner `<p>` was redundant and only served to leak theme paragraph margins into the box.