### PR TITLE
refactor: dedupe rank-tier ladder, depend on extrachill-users

### DIFF
--- a/inc/social/rank-system/chill-forums-rank.php
+++ b/inc/social/rank-system/chill-forums-rank.php
@@ -9,83 +9,8 @@ function extrachill_determine_rank_by_points( $points ) {
 		return ec_get_rank_for_points( $points );
 	}
 
-	$points = (float) $points;
-
-	if ( $points >= 516246 ) {
-		return 'Frozen Deep Space';
-	}
-	if ( $points >= 344164 ) {
-		return 'Upper Atmosphere';
-	}
-	if ( $points >= 229442 ) {
-		return 'Ice Age';
-	}
-	if ( $points >= 152961 ) {
-		return 'Antarctica';
-	}
-	if ( $points >= 101974 ) {
-		return 'Glacier';
-	}
-	if ( $points >= 67983 ) {
-		return 'Blizzard';
-	}
-	if ( $points >= 45322 ) {
-		return 'Ski Resort';
-	}
-	if ( $points >= 30214 ) {
-		return 'Snowstorm';
-	}
-	if ( $points >= 20143 ) {
-		return 'Flurry';
-	}
-	if ( $points >= 13428 ) {
-		return 'Ice Rink';
-	}
-	if ( $points >= 8952 ) {
-		return 'Frozen Foods Isle';
-	}
-	if ( $points >= 5968 ) {
-		return 'Walk-In Freezer';
-	}
-	if ( $points >= 3978 ) {
-		return 'Ice Machine';
-	}
-	if ( $points >= 2652 ) {
-		return 'Freezer';
-	}
-	if ( $points >= 1768 ) {
-		return 'Fridge';
-	}
-	if ( $points >= 1178 ) {
-		return 'Cooler';
-	}
-	if ( $points >= 785 ) {
-		return 'Ice Maker';
-	}
-	if ( $points >= 523 ) {
-		return 'Bag of Ice';
-	}
-	if ( $points >= 349 ) {
-		return 'Ice Tray';
-	}
-	if ( $points >= 232 ) {
-		return 'Ice Cube';
-	}
-	if ( $points >= 155 ) {
-		return 'Overnight Freeze';
-	}
-	if ( $points >= 103 ) {
-		return 'First Frost';
-	}
-	if ( $points >= 69 ) {
-		return 'Crisp Air';
-	}
-	if ( $points >= 35 ) {
-		return 'Puddle';
-	}
-	if ( $points >= 15 ) {
-		return 'Droplet';
-	}
+	// extrachill-users is network-activated, so the canonical
+	// ec_get_rank_for_points() is always loaded and this is never reached.
 	return 'Dew';
 }
 


### PR DESCRIPTION
## Summary

Fixes #40. The 25-tier rank ladder was duplicated literal-for-literal in `extrachill-community`. The canonical version lives in `extrachill-users` (`ec_get_rank_for_points()` in `inc/rank-system/rank-tiers.php`), which is **`Network: true`** — always loaded across the multisite. The inline copy in `inc/social/rank-system/chill-forums-rank.php` was a dead fallback and a drift hazard.

## Change

`extrachill_determine_rank_by_points()` is now a thin delegate to the canonical function. The 77-line inline ladder (lines 12–89) is removed; the fallback now returns the floor rank `'Dew'` with a comment noting it should never execute since `extrachill-users` is network-activated.

```php
function extrachill_determine_rank_by_points( $points ) {
    if ( function_exists( 'ec_get_rank_for_points' ) ) {
        return ec_get_rank_for_points( $points );
    }
    // extrachill-users is network-activated, so the canonical
    // ec_get_rank_for_points() is always loaded and this is never reached.
    return 'Dew';
}
```

## Why it's safe

The canonical ladder in `extrachill-users` is **identical** to the removed copy (same `516246` top threshold → `Frozen Deep Space`, same `Dew` floor, all 25 tiers). Same input → same output.

## Callers verified (grep) — all unaffected

The public wrapper functions are unchanged, so every call site keeps working:

- `extrachill_display_user_rank()` — kept; still calls `extrachill_determine_rank_by_points()`
- `page-templates/leaderboard-template.php:48` → `extrachill_display_user_rank()`
- `bbpress/user-details.php:87` (profile page rank) → `extrachill_display_user_rank()`
- `inc/social/rank-system/chill-forums-rank.php:110` (reply author block) → `extrachill_display_user_rank()`
- `inc/social/rank-system/rank-abilities.php:156-157, 249-250` → `extrachill_determine_rank_by_points()`

Profile pages and reply author blocks render the same output for the same point totals.

`php -l` passes.