### PR TITLE
chore: bump @extrachill/components to ^0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@extrachill/api-client": "^0.3.0",
-    "@extrachill/components": "^0.4.50",
+    "@extrachill/components": "^0.5.2",
     "@extrachill/tokens": "^0.3.1",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^14.0.0",


### PR DESCRIPTION
## Summary

Bumps the `@extrachill/components` dependency range from `^0.4.x` (was pinned `^0.4.50`) to `^0.5.2` and rebuilds the plugin's webpack assets against the new package.

## What changed

- **`package.json`**: `@extrachill/components` `^0.4.50` → `^0.5.2`
- Assets rebuilt (`npm run build`). Note: `build/` and `package-lock.json` are gitignored in this repo, so the only tracked change in this PR is the `package.json` range. Build assets are produced at zip/deploy time, not committed.

## Behavior changes riding along (smoke-test these surfaces)

`@extrachill/components@0.5.2` carries three behavioral changes the reviewer should smoke-test:

1. **BlockShellInner narrow/wide centering** — adds `margin-inline:auto`. Check block layouts render centered correctly.
2. **SearchBox canonical button classes** — verify the community search box button styling/markup.
3. **InlineStatus / Badge dark-mode token parity** — check InlineStatus and Badge components in dark mode.

## Build

- `npm install` resolves `@extrachill/components@0.5.2` ✅
- `npm run build` → **webpack 5.107.2 compiled successfully**, no warnings or errors ✅
- The new `@extrachill/components/styles/components.scss` (14 KiB) is pulled into the build output.

## Lint

- `homeboy lint extrachill-community` reports 243 pre-existing findings in PHP/TSX/JS source and `webpack.config.js`.
- **Zero findings reference `package.json`** — this one-line dependency bump introduces no new lint findings. Pre-existing debt left untouched per scope.

## Install note

This repo has a pre-existing peer-dependency conflict (`@wordpress/blocks@15.x` pulls React 19 peers that clash with `@wordpress/block-editor@^14`). Installed with `npm install` resolving peers; this conflict predates and is unrelated to this bump.