### PR TITLE
Fix i18n text-domain mismatches (issue #39)

### DIFF
--- a/inc/user-profiles/verification.php
+++ b/inc/user-profiles/verification.php
@@ -25,13 +25,13 @@ function extrachill_add_user_role_fields($user) {
 	<h3><?php esc_html_e('Extra User Information', 'extra-chill-community'); ?></h3>
 	<table class="form-table">
 		<tr>
-			<th><label for="user_is_artist"><?php esc_html_e('Artist Status'); ?></label></th>
+			<th><label for="user_is_artist"><?php esc_html_e('Artist Status', 'extra-chill-community'); ?></label></th>
 			<td>
 				<input type="checkbox" name="user_is_artist" id="user_is_artist" value="1" <?php checked($artist, true); ?>>
 			</td>
 		</tr>
 		<tr>
-			<th><label for="user_is_professional"><?php esc_html_e('Industry Professional Status'); ?></label></th>
+			<th><label for="user_is_professional"><?php esc_html_e('Industry Professional Status', 'extra-chill-community'); ?></label></th>
 			<td>
 				<input type="checkbox" name="user_is_professional" id="user_is_professional" value="1" <?php checked($professional, true); ?>>
 			</td>


### PR DESCRIPTION
## Summary

Resolves the i18n text-domain portion of #39.

**Key finding:** the **182 `WordPress.WP.I18n.TextDomainMismatch`** findings originally reported in #39 were **already cleared** by the merged phpcbf auto-fix PR (#41). Current lint reports **0** TextDomainMismatch. (The issue table marked this rule "auto-fix: no", but phpcbf's `TextDomainMismatch` sniff does rewrite wrong-domain literals to the header-declared domain, so the mechanical pass swept them up.)

This PR cleans up the two remaining **unambiguous missing-domain** i18n calls so the i18n-domain surface is fully clean.

## Before / after — i18n domain counts

| Rule | Before | After |
|------|-------:|------:|
| `WordPress.WP.I18n.TextDomainMismatch` | 0 (already cleared by #41; was 182 pre-#41) | 0 |
| `WordPress.WP.I18n.MissingArgDomain` | 2 | 0 |

## Changes

Added the canonical `'extra-chill-community'` text domain to two `esc_html_e()` calls in `inc/user-profiles/verification.php` (lines 28 & 34) that had **no domain literal at all**. Both sit in this plugin's own code immediately beside a correctly-domained call, so the fix is unambiguous.

## Diff is i18n-domain-only (no logic changes)

```diff
-<?php esc_html_e('Artist Status'); ?>
+<?php esc_html_e('Artist Status', 'extra-chill-community'); ?>
-<?php esc_html_e('Industry Professional Status'); ?>
+<?php esc_html_e('Industry Professional Status', 'extra-chill-community'); ?>
```

Only the domain argument is added. No control flow, escaping, or output changes.

## Deliberately skipped

- **`bbpress/form-reply.php:77`** — `esc_html_e( 'Your account has the ability to post unrestricted HTML content.', 'bbpress' )`. This is a **bbPress template override** re-exporting a string that bbPress ships under the `bbpress` domain. Keeping the `'bbpress'` domain is correct; PHPCS does not flag it as a mismatch. Changing it would break translation lookup against bbPress's catalog.

## Scope / out of scope

References #39 **without closing it** — the remaining #39 work is untouched:
- `WordPress.Security.EscapeOutput.OutputNotEscaped` (69) — separate security task
- `WordPress.WP.I18n.MissingTranslatorsComment` (30) — out of scope
- eslint findings in `webpack.config.js` — out of scope

Ref #39