### PR TITLE
feat: rank-progress bar on user profile

### DIFF
--- a/bbpress/user-details.php
+++ b/bbpress/user-details.php
@@ -87,6 +87,67 @@ defined( 'ABSPATH' ) || exit;
 			<b>Rank:</b> <?php echo esc_html(extrachill_display_user_rank(bbp_get_displayed_user_id())); ?>
 			| <b>Points:</b> <?php echo esc_html(extrachill_display_user_points(bbp_get_displayed_user_id())); ?>
 		</p>
+		<?php
+		// Rank-progress bar. Depends on ec_get_rank_progress() from extrachill-users
+		// (Network: true). Guard so the profile renders cleanly if it is absent
+		// (e.g. before that plugin's rank-registry change is deployed).
+		if ( function_exists( 'ec_get_rank_progress' ) ) {
+			$rank_progress = ec_get_rank_progress( (float) extrachill_display_user_points( bbp_get_displayed_user_id() ) );
+
+			$rp_percent = isset( $rank_progress['percent'] ) ? (float) $rank_progress['percent'] : 0.0;
+			$rp_percent = max( 0.0, min( 100.0, $rp_percent ) );
+
+			$rp_current_label = isset( $rank_progress['current']['label'] ) ? (string) $rank_progress['current']['label'] : '';
+			$rp_is_max        = ! empty( $rank_progress['is_max'] );
+			?>
+			<div class="rank-progress" role="img" aria-label="<?php
+				echo esc_attr(
+					$rp_is_max
+						? sprintf(
+							/* translators: %s: current rank label */
+							__( 'Rank progress: %s, maximum rank reached', 'extra-chill-community' ),
+							$rp_current_label
+						)
+						: sprintf(
+							/* translators: 1: current rank label, 2: rounded percent toward next rank */
+							__( 'Rank progress: %1$s, %2$d%% toward next rank', 'extra-chill-community' ),
+							$rp_current_label,
+							(int) round( $rp_percent )
+						)
+				);
+			?>">
+				<div class="rank-progress-meta">
+					<span class="rank-progress-current"><?php echo esc_html( sprintf(
+						/* translators: %s: current rank label */
+						__( 'Current: %s', 'extra-chill-community' ),
+						$rp_current_label
+					) ); ?></span>
+					<span class="rank-progress-percent"><?php echo esc_html( (int) round( $rp_percent ) ); ?>%</span>
+					<?php if ( ! $rp_is_max && ! empty( $rank_progress['next']['label'] ) ) : ?>
+						<span class="rank-progress-next"><?php echo esc_html( sprintf(
+							/* translators: %s: next rank label */
+							__( 'Next: %s', 'extra-chill-community' ),
+							(string) $rank_progress['next']['label']
+						) ); ?></span>
+					<?php elseif ( $rp_is_max ) : ?>
+						<span class="rank-progress-next"><?php esc_html_e( 'Max rank reached', 'extra-chill-community' ); ?></span>
+					<?php endif; ?>
+				</div>
+				<div class="rank-progress-track">
+					<div class="rank-progress-fill<?php echo $rp_is_max ? ' is-max' : ''; ?>" style="width:<?php echo esc_attr( $rp_percent ); ?>%"></div>
+				</div>
+				<?php if ( ! $rp_is_max && ! empty( $rank_progress['next']['label'] ) && null !== $rank_progress['points_to_next'] ) : ?>
+					<div class="rank-progress-hint"><?php echo esc_html( sprintf(
+						/* translators: 1: points remaining, 2: next rank label */
+						__( '%1$s points to %2$s', 'extra-chill-community' ),
+						(int) ceil( (float) $rank_progress['points_to_next'] ),
+						(string) $rank_progress['next']['label']
+					) ); ?></div>
+				<?php endif; ?>
+			</div>
+			<?php
+		}
+		?>
 		<div class="bbp-user-actions-area">
 				<?php if ( bbp_get_displayed_user_id() === get_current_user_id() ) : ?>
 					<a href="/settings" class="button-1 button-small"><?php esc_html_e('Settings', 'extra-chill-community'); ?></a>

--- a/inc/assets/css/bbpress.css
+++ b/inc/assets/css/bbpress.css
@@ -464,6 +464,79 @@ blockquote {
     font-size: var(--font-size-sm);
 }
 
+/* Rank progress bar — subtle, frosty, on-brand */
+.rank-progress {
+    margin: var(--spacing-xs, 0.5rem) 0 var(--spacing-sm, 0.75rem);
+    max-width: 420px;
+}
+
+.rank-progress-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 4px 10px;
+    margin-bottom: 5px;
+    font-size: var(--font-size-xs, 0.75rem);
+    color: var(--muted-text);
+}
+
+.rank-progress-percent {
+    font-weight: 600;
+    color: var(--brand-blue, #003466);
+}
+
+.rank-progress-track {
+    position: relative;
+    width: 100%;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(var(--brand-blue-rgb, 0, 52, 102), 0.12);
+    overflow: hidden;
+}
+
+.rank-progress-fill {
+    height: 100%;
+    border-radius: 999px;
+    background: linear-gradient(
+        90deg,
+        var(--brand-blue, #003466),
+        var(--accent-3, #00c8e3)
+    );
+    min-width: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .rank-progress-fill {
+        transition: width 0.6s ease;
+    }
+}
+
+.rank-progress-fill.is-max {
+    background: linear-gradient(
+        90deg,
+        var(--accent-3, #00c8e3),
+        var(--brand-blue, #003466)
+    );
+}
+
+.rank-progress-hint {
+    margin-top: 5px;
+    font-size: var(--font-size-xs, 0.75rem);
+    color: var(--muted-text);
+}
+
+@media (max-width: 480px) {
+    .rank-progress {
+        max-width: 100%;
+    }
+
+    .rank-progress-meta {
+        flex-direction: column;
+        gap: 2px;
+    }
+}
+
 /* ==================================================
    Buttons - Use .button-1, .button-2, .button-3 classes in HTML
 ================================================== */


### PR DESCRIPTION
## Summary

Adds a subtle, frosty, on-brand horizontal **rank-progress bar** to the bbPress user profile, rendered directly below the existing `Rank | Points` line. Server-rendered PHP + CSS only — no JS, no AJAX.

## Files changed

- **`bbpress/user-details.php`** — adds the progress-bar markup block immediately after the `.bbp-user-title-rank` paragraph (~line 85-89). The existing rank/points line is **untouched**.
- **`inc/assets/css/bbpress.css`** — adds `.rank-progress*` rules right after the existing "Rank and Points" block (after `.rankpoints`) for cohesion.

## Dependency + graceful degradation

This consumes the new **`ec_get_rank_progress( $points )`** helper added in **extrachill-users PR #64** (https://github.com/Extra-Chill/extrachill-users/pull/64). That plugin is `Network: true` (always loaded).

The call is wrapped in `function_exists( 'ec_get_rank_progress' )`, so:
- Before #64 merges/deploys, the function is absent → the bar renders **nothing** and the profile is unaffected.
- After #64 lands, the bar appears automatically.

Points are read via the file's existing helper `extrachill_display_user_points( bbp_get_displayed_user_id() )` (returns a numeric float, backed by `extrachill_total_points` user meta), cast to `(float)` and passed straight into `ec_get_rank_progress()`.

## `is_max` handling

When `is_max` is true (top tier, e.g. Frozen Deep Space):
- The bar renders **full** (percent clamps to 100).
- The meta row shows a **"Max rank reached"** label instead of a "Next:" rank.
- The **"points to next" hint line is omitted entirely** — it never prints `0 points to ...`. (The hint is also guarded on `points_to_next !== null` and a present `next.label`.)

## Escaping

- All dynamic text escaped with `esc_html()` (labels, percent, hint) and the `aria-label` with `esc_attr()`.
- The fill width uses a **numeric percent clamped to 0-100** (`max(0, min(100, ...))`) emitted via `esc_attr()` in the `style` attribute.
- Percent is shown as a rounded integer; `points_to_next` is shown as `ceil()` so it never under-reports remaining points.
- Container has `role="img"` + a descriptive `aria-label` for screen readers.

## CSS approach (tokens used)

Uses existing theme/plugin CSS custom properties with safe literal fallbacks (so it still looks right even if a token is missing):

- Track background: `rgba(var(--brand-blue-rgb, 0, 52, 102), 0.12)` — muted frosty blue. (`--brand-blue` is defined locally in `bbpress.css`; the `-rgb` variant falls back to the literal.)
- Fill gradient: `linear-gradient(90deg, var(--brand-blue, #003466), var(--accent-3, #00c8e3))` — cool blue → frosty cyan (`--accent-3` is the theme's icy/cyan token).
- Text: `var(--muted-text)`, percent emphasised in `var(--brand-blue)`.
- Sizing/spacing: `var(--font-size-xs)`, `var(--spacing-xs/-sm)`, all with fallbacks.

Styling is deliberately **subtle**: thin **8px** rounded track, muted translucent background, no loud gamified colors.

- Honors `prefers-reduced-motion`: the `width` transition is only applied inside `@media (prefers-reduced-motion: no-preference)`.
- Mobile-friendly: the meta row (`Current / % / Next`) wraps and **stacks vertically** under 480px.

## Before / after

**Before:**
```
Title: Participant | Rank: Dew | Points: 1240
```

**After (mid-tier):**
```
Title: Participant | Rank: Dew | Points: 1240

Current: Dew                 62%                 Next: Frost
[██████████████░░░░░░░░░]
260 points to Frost
```

**After (max tier):**
```
Title: ... | Rank: Frozen Deep Space | Points: 99999

Current: Frozen Deep Space   100%        Max rank reached
[████████████████████████]
(no "points to" line)
```

## Verification

- `php -l bbpress/user-details.php` → no syntax errors.
- Existing `.bbp-user-title-rank` rank/points line confirmed intact (unchanged).
- `function_exists` guard verified against current production where `ec_get_rank_progress` is not yet present.