### PR TITLE
refactor: retire duplicate community-get-leaderboard ability

### DIFF
--- a/inc/social/rank-system/rank-abilities.php
+++ b/inc/social/rank-system/rank-abilities.php
@@ -90,44 +90,6 @@ function extrachill_community_register_rank_abilities() {
 		)
 	);
 
-	wp_register_ability(
-		'extrachill/community-get-leaderboard',
-		array(
-			'label'               => __( 'Get Leaderboard', 'extra-chill-community' ),
-			'description'         => __( 'Get community leaderboard with pagination.', 'extra-chill-community' ),
-			'category'            => 'extrachill-community',
-			'input_schema'        => array(
-				'type'       => 'object',
-				'properties' => array(
-					'limit'  => array(
-						'type'        => 'integer',
-						'description' => 'Number of users to return (default 25)',
-					),
-					'offset' => array(
-						'type'        => 'integer',
-						'description' => 'Pagination offset (default 0)',
-					),
-				),
-			),
-			'output_schema'       => array(
-				'type'       => 'object',
-				'properties' => array(
-					'total' => array( 'type' => 'integer' ),
-					'users' => array( 'type' => 'array' ),
-				),
-			),
-			'execute_callback'    => 'extrachill_community_ability_get_leaderboard',
-			'permission_callback' => '__return_true',
-			'meta'                => array(
-				'show_in_rest' => false,
-				'annotations'  => array(
-					'readonly'    => true,
-					'idempotent'  => true,
-					'destructive' => false,
-				),
-			),
-		)
-	);
 }
 
 // ─── Execute callbacks ─────────────────────────────────────────────────────────
@@ -216,45 +178,4 @@ function extrachill_community_ability_recalculate_points( $input ) {
 	}
 
 	return array( 'recalculated' => $count );
-}
-
-/**
- * Get leaderboard with pagination.
- *
- * @param array $input Ability input.
- * @return array|WP_Error
- */
-function extrachill_community_ability_get_leaderboard( $input ) {
-	$limit  = isset( $input['limit'] ) ? (int) $input['limit'] : 25;
-	$offset = isset( $input['offset'] ) ? (int) $input['offset'] : 0;
-
-	if ( ! function_exists( 'extrachill_get_leaderboard_users' ) ) {
-		return new WP_Error( 'leaderboard_unavailable', 'Leaderboard system is not loaded.' );
-	}
-
-	$users = extrachill_get_leaderboard_users( $limit, $offset );
-	$total = extrachill_get_leaderboard_total_users();
-
-	$result = array();
-	$rank   = $offset + 1;
-
-	foreach ( $users as $user ) {
-		$points   = (float) get_user_meta( $user->ID, 'extrachill_total_points', true );
-		$result[] = array(
-			'rank'         => $rank,
-			'user_id'      => (int) $user->ID,
-			'user_login'   => $user->user_login,
-			'display_name' => $user->display_name,
-			'total_points' => $points,
-			'rank_name'    => function_exists( 'extrachill_determine_rank_by_points' )
-				? extrachill_determine_rank_by_points( $points )
-				: 'Unknown',
-		);
-		++$rank;
-	}
-
-	return array(
-		'total' => $total,
-		'users' => $result,
-	);
 }


### PR DESCRIPTION
## Summary
Removes the duplicate `extrachill/community-get-leaderboard` ability and its execute callback. The canonical leaderboard lives in `extrachill/users-leaderboard` (extrachill-users); the REST route and CLI command are migrated to it in the cross-linked PRs. Part of Extra-Chill/extrachill-api#63.

## The duplication finding
Two abilities ran nearly the same `WP_User_Query` over user meta `extrachill_total_points`:
- **CANONICAL** `extrachill/users-leaderboard` (extrachill-users) — modern shape `{ items[...], pagination{...} }`, input `{ page, per_page }`. This is what the SDK (`@extrachill/api-client`) and the leaderboard block already expect.
- **DUPLICATE (removed here)** `extrachill/community-get-leaderboard` — legacy shape `{ total, users[...] }`, input `{ limit, offset }`.

## What was removed
- The `wp_register_ability('extrachill/community-get-leaderboard', ...)` registration block in `inc/social/rank-system/rank-abilities.php`.
- Its execute callback `extrachill_community_ability_get_leaderboard()`.

## What was intentionally KEPT
- The other two abilities `extrachill/community-get-user-points` and `extrachill/community-recalculate-points` — untouched.
- Helper functions `extrachill_get_leaderboard_users()` and `extrachill_get_leaderboard_total_users()` (in `inc/social/rank-system/point-calculation.php`) — **still used** by `page-templates/leaderboard-template.php`, so they remain. (Grep confirmed this caller before deciding.)
- All point CALCULATION (`extrachill_get_user_total_points`, `extrachill_increment_user_points`, the recalc queue) — out of scope and untouched.

## Leaderboard block — no change needed
`src/blocks/leaderboard/view.tsx` already consumes the canonical `{ items, pagination }` shape (`data.items`, `data.pagination.total_pages`, `item.position`, `item.id`, `item.points`, `item.rank`, `item.registered`). Verified against the canonical ability output — no `.tsx` change required, so no rebuild needed for this PR.

## Grep proof of no remaining callers
Before removal, `community-get-leaderboard` had exactly three references in the live tree: the API route, the CLI command, and this registration. The first two are repointed at the canonical ability in the cross-linked PRs; this PR removes the third. Across all three feature branches there are now **zero** remaining references.

## Point calculation stays in community (deliberate non-consolidation)
Per #63, points are earned from bbPress activity and the calculation/recalc machinery stays here in extrachill-community. Only the duplicate leaderboard READ surface is retired.

## Coordinated PRs — ORDERING MATTERS
- API route repoint: Extra-Chill/extrachill-api#64
- CLI command migration: Extra-Chill/extrachill-cli#25

**This PR must merge LAST (or simultaneously).** It deletes the `community-get-leaderboard` ability that the API route and CLI command currently call. If this merges before those two, the route and CLI command break until they catch up. Merge #64 and extrachill-cli#25 first (or all three together).