### PR TITLE
refactor: replace hardcoded extrachill.com domain with ec_get_site_url

### DIFF
--- a/src/blocks/edit-profile/render.php
+++ b/src/blocks/edit-profile/render.php
@@ -18,9 +18,7 @@ if ( ! is_user_logged_in() ) {
 
 $class = 'wp-block-extrachill-edit-profile';
 
-$artist_site_url = function_exists( 'ec_get_site_url' )
-	? ec_get_site_url( 'artist' )
-	: 'https://artist.extrachill.com';
+$artist_site_url = ec_get_site_url( 'artist' );
 
 $current_user_id = get_current_user_id();
 

--- a/src/blocks/user-settings/render.php
+++ b/src/blocks/user-settings/render.php
@@ -18,9 +18,7 @@ if ( ! is_user_logged_in() ) {
 
 $class = 'wp-block-extrachill-user-settings';
 
-$artist_site_url = function_exists( 'ec_get_site_url' )
-	? ec_get_site_url( 'artist' )
-	: 'https://artist.extrachill.com';
+$artist_site_url = ec_get_site_url( 'artist' );
 
 $current_user_id = get_current_user_id();
 


### PR DESCRIPTION
## Summary
Replaces the hardcoded `https://artist.extrachill.com` fallback in the edit-profile and user-settings block render templates with a direct `ec_get_site_url( 'artist' )` call.

These were the ternary FALSE branch of an `ec_get_site_url` check; on staging/dev clones the `ec_site_url_override` filter rewrites domains, but the hardcoded fallback leaked the production domain.

## Changes
- `src/blocks/edit-profile/render.php:21-23` — use `ec_get_site_url( 'artist' )` directly
- `src/blocks/user-settings/render.php:21-23` — use `ec_get_site_url( 'artist' )` directly

## Verification
- Site key `artist` → blog ID 4 → `artist.extrachill.com` (matches the replaced literal); no behavior change on production, clones now resolve correctly.

refs Extra-Chill/extrachill-multisite#36