### PR TITLE
fix: define --brand-blue-rgb token for rank-progress track

### DIFF
--- a/inc/assets/css/bbpress.css
+++ b/inc/assets/css/bbpress.css
@@ -22,6 +22,7 @@
 
     /* Brand Colors */
     --brand-blue: #003466;
+    --brand-blue-rgb: 0, 52, 102;
 
 }
 


### PR DESCRIPTION
## Summary

Design-system audit of the new rank-progress bar (shipped in #46) found that its translucent track used `rgba(var(--brand-blue-rgb, 0, 52, 102), 0.12)` but **`--brand-blue-rgb` was never defined anywhere** — so it silently fell back to the hardcoded `0, 52, 102` instead of resolving through a token.

This defines `--brand-blue-rgb: 0, 52, 102;` in the same community-local `:root` block that already defines `--brand-blue: #003466;`, so the track color is now fully token-driven.

## Audit result (all 7 progress-bar tokens now resolve)

| Token | Source |
|---|---|
| `--accent-3` | theme `root.css` |
| `--font-size-xs` | theme `root.css` |
| `--muted-text` | theme `root.css` |
| `--spacing-sm` | theme `root.css` |
| `--spacing-xs` | theme `root.css` |
| `--brand-blue` | community-local `:root` (already defined) |
| `--brand-blue-rgb` | community-local `:root` (**this PR**) |

All hex values in the block remain only as `var(... , fallback)` safety nets, which no longer fire. No Data Machine token misuse (Extra Chill plugin correctly uses theme + community-local tokens per the layering rule).

## Why it matters

Keeps the progress bar consistent with the design system so the track tint stays in sync if the brand color ever changes, rather than drifting from a hardcoded literal.

One-line change. Conventional commit; homeboy owns versioning/changelog.