### PR TITLE
refactor: drop ad-hoc --brand-blue token, use theme --link-color

### DIFF
--- a/inc/assets/css/bbpress.css
+++ b/inc/assets/css/bbpress.css
@@ -14,19 +14,6 @@
 ================================================== */
 
 /* ==================================================
-   bbPress-Specific CSS Variables
-================================================== */
-:root {
-    /* Error and Success States */
-
-
-    /* Brand Colors */
-    --brand-blue: #003466;
-    --brand-blue-rgb: 0, 52, 102;
-
-}
-
-/* ==================================================
    Base bbPress Container
 ================================================== */
 #bbpress-forums {
@@ -232,7 +219,7 @@ span.bbp-admin-links {
 ================================================== */
 blockquote {
     font-size: 0.9em;
-    border-left: 4px solid var(--brand-blue);
+    border-left: 4px solid var(--link-color);
     background-color: var(--background-color);
     font-style: normal;
 }
@@ -467,7 +454,7 @@ blockquote {
 
 /* Rank progress bar — subtle, frosty, on-brand */
 .rank-progress {
-    margin: var(--spacing-xs, 0.5rem) 0 var(--spacing-sm, 0.75rem);
+    margin: var(--spacing-xs) 0 var(--spacing-sm);
     max-width: 420px;
 }
 
@@ -478,13 +465,13 @@ blockquote {
     justify-content: space-between;
     gap: 4px 10px;
     margin-bottom: 5px;
-    font-size: var(--font-size-xs, 0.75rem);
+    font-size: var(--font-size-xs);
     color: var(--muted-text);
 }
 
 .rank-progress-percent {
     font-weight: 600;
-    color: var(--brand-blue, #003466);
+    color: var(--link-color);
 }
 
 .rank-progress-track {
@@ -492,7 +479,7 @@ blockquote {
     width: 100%;
     height: 8px;
     border-radius: 999px;
-    background: rgba(var(--brand-blue-rgb, 0, 52, 102), 0.12);
+    background: color-mix(in srgb, var(--link-color) 12%, transparent);
     overflow: hidden;
 }
 
@@ -501,8 +488,8 @@ blockquote {
     border-radius: 999px;
     background: linear-gradient(
         90deg,
-        var(--brand-blue, #003466),
-        var(--accent-3, #00c8e3)
+        var(--link-color),
+        var(--accent-3)
     );
     min-width: 2px;
 }
@@ -516,14 +503,14 @@ blockquote {
 .rank-progress-fill.is-max {
     background: linear-gradient(
         90deg,
-        var(--accent-3, #00c8e3),
-        var(--brand-blue, #003466)
+        var(--accent-3),
+        var(--link-color)
     );
 }
 
 .rank-progress-hint {
     margin-top: 5px;
-    font-size: var(--font-size-xs, 0.75rem);
+    font-size: var(--font-size-xs);
     color: var(--muted-text);
 }
 
@@ -632,7 +619,7 @@ label {
 
 #bbpress-forums ul.status-closed,
 #bbpress-forums ul.status-closed a {
-    color: var(--brand-blue);
+    color: var(--link-color);
 }
 
 /* Closed status hover handled by theme */


### PR DESCRIPTION
## Summary

The community bbPress CSS carried its own `:root` block defining **`--brand-blue: #003466`** (and `--brand-blue-rgb`) — ad-hoc brand tokens that duplicate and drift from the theme's design system. `#003466` isn't even a theme color; it was an off-palette guess at "blue." Community already consumes the theme — it should not carry its own brand tokens.

## Changes

- **Deleted** the ad-hoc `:root` block (`--brand-blue` + `--brand-blue-rgb`)
- Mapped every `--brand-blue` usage to the theme's canonical **`--link-color`** (`#0b5394`):
  - blockquote `border-left` (pre-existing usage)
  - `.status-closed` color (pre-existing usage)
  - the rank-progress bar (percent text + gradient fills)
- Translucent progress track now uses `color-mix(in srgb, var(--link-color) 12%, transparent)` — matching the `color-mix` pattern **already used in `leaderboard.css`** — instead of needing an rgb token
- Stripped dead/incorrect `var(…, fallback)` literals so theme tokens are referenced bare, consistent with the rest of the file

## Result

```
PROGRESS BAR — now 100% theme tokens, zero ad-hoc:
  --link-color   (theme)  fill base + percent + borders
  --accent-3     (theme)  frosty cyan gradient highlight
  --muted-text   (theme)  meta + hint text
  --font-size-xs (theme)  meta + hint sizing
  --spacing-xs/sm(theme)  margins
  color-mix()             translucent track (existing community pattern)
```

Net **-13 lines**. Community now consumes the theme design system with **no ad-hoc brand tokens**.

## Note

This supersedes the `--brand-blue-rgb` token I added earlier (#50) — that was treating the symptom (undefined token) rather than the disease (the ad-hoc token shouldn't exist at all). This removes both.

Conventional commit; homeboy owns versioning/changelog.