### PR TITLE
refactor: consume theme tokens + clear phpcs lint debt

### DIFF
--- a/bbpress/form-reply.php
+++ b/bbpress/form-reply.php
@@ -36,6 +36,7 @@ if ( bbp_is_reply_edit() ) : ?>
 						$reply_author    = get_userdata( $reply_author_id );
 						$username        = $reply_author ? $reply_author->user_nicename : '';
 						if ( $username ) {
+							/* translators: %s: username being replied to */
 							printf( esc_html__( 'Reply to @%s', 'extra-chill-community' ), esc_html( $username ) );
 						} else {
 							/* translators: %s: topic title */

--- a/bbpress/form-topic.php
+++ b/bbpress/form-topic.php
@@ -82,7 +82,12 @@ if ( ! bbp_is_single_forum() ) : ?>
 					<?php if ( ! ( bbp_use_wp_editor() || current_user_can( 'unfiltered_html' ) ) ) : ?>
 
 						<p class="form-allowed-tags">
-							<label><?php printf( esc_html__( 'You may use these %s tags and attributes:', 'extra-chill-community' ), '<abbr title="HyperText Markup Language">HTML</abbr>' ); ?></label>
+							<label>
+								<?php
+								/* translators: %s: HTML abbreviation markup */
+								printf( esc_html__( 'You may use these %s tags and attributes:', 'extra-chill-community' ), '<abbr title="HyperText Markup Language">HTML</abbr>' );
+								?>
+							</label>
 							<code><?php bbp_allowed_tags(); ?></code>
 						</p>
 

--- a/bbpress/loop-single-blog-comment-card.php
+++ b/bbpress/loop-single-blog-comment-card.php
@@ -46,7 +46,7 @@ $author_role = $user_info ? bbp_get_user_display_role( $author_id ) : '';
 
 				<div class="upvote-date">
 					<span class="bbp-reply-post-date">
-						<?php echo esc_html( date( 'F j, Y, g:i a', strtotime( $comment_date ) ) ); ?>
+						<?php echo esc_html( date( 'F j, Y, g:i a', strtotime( $comment_date ) ) ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Display in site-local time, preserving existing rendered output. ?>
 					</span>
 				</div>
 

--- a/bbpress/loop-single-reply-card.php
+++ b/bbpress/loop-single-reply-card.php
@@ -21,7 +21,7 @@ $reply_id_check = bbp_get_reply_id();
 $topic_id_check = ! empty( $bbp_instance->current_topic_id ) ? $bbp_instance->current_topic_id : bbp_get_topic_id();
 
 $current_post_type = get_post_type( $reply_id_check );
-$is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( $current_post_type === bbp_get_topic_post_type() );
+$is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_post_type() === $current_post_type );
 ?>
 
 <div id="post-<?php bbp_reply_id(); ?>" 
@@ -139,7 +139,7 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( $current_post_
 					$prefetch_forum_title = get_query_var('prefetch_forum_title');
 					?>
 					<span class="bbp-header">
-						<?php if ( $is_lead_topic || $current_post_type === bbp_get_topic_post_type() ) : ?>
+						<?php if ( $is_lead_topic || bbp_get_topic_post_type() === $current_post_type ) : ?>
 							<?php esc_html_e( 'in forum: ', 'extra-chill-community' ); ?>
 							<?php if ( $prefetch_forum_url && $prefetch_forum_title ) : ?>
 								<a class="bbp-forum-permalink" href="<?php echo esc_url( $prefetch_forum_url ); ?>">

--- a/bbpress/loop-single-topic-card.php
+++ b/bbpress/loop-single-topic-card.php
@@ -103,6 +103,7 @@ if ( ! $topic_id ) {
 				<span class="bbp-topic-started-in">
 				<?php
 					printf(
+					/* translators: %1$s: forum link */
 					esc_html__( 'in %1$s', 'extra-chill-community' ),
 					'<a href="' . esc_url( bbp_get_forum_permalink( $forum_id_for_topic ) ) . '">' . esc_html( bbp_get_forum_title( $forum_id_for_topic ) ) . '</a>'
 				);

--- a/bbpress/loop-topics.php
+++ b/bbpress/loop-topics.php
@@ -69,6 +69,7 @@ if ( 'upvotes' === $current_sort ) {
          INNER JOIN {$wpdb->posts} t ON p.post_parent = t.ID
          WHERE p.post_type = %s AND t.post_type = %s AND p.post_date >= %s
          GROUP BY p.post_parent ORDER BY COUNT(p.ID) DESC LIMIT 100",
+		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Compared against post_date (site-local), not post_date_gmt.
 		bbp_get_reply_post_type(), bbp_get_topic_post_type(), date('Y-m-d H:i:s', strtotime('-45 days'))
 	));
 	$loop_args['post__in'] = ! empty($popular_ids) ? $popular_ids : array( 0 );

--- a/bbpress/user-details.php
+++ b/bbpress/user-details.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 
 	// Check for user's bbPress posts (topics or replies)
 	$user_id          = bbp_get_displayed_user_id();
-	$current_user     = wp_get_current_user();
+	$display_user     = wp_get_current_user();
 	$args             = array(
 		'author'         => $user_id,
 		'post_type'      => array( 'reply', 'topic' ), // Prioritize replies in the query
@@ -31,9 +31,9 @@ defined( 'ABSPATH' ) || exit;
 	if ( $user_posts_query->have_posts() ) {
 		while ( $user_posts_query->have_posts() ) {
 			$user_posts_query->the_post();
-			$post_type = get_post_type();
+			$last_post_type = get_post_type();
 
-			if ( 'reply' === $post_type ) {
+			if ( 'reply' === $last_post_type ) {
 				// For replies, link to the parent topic with an anchor to the reply
 				$topic_id      = bbp_get_reply_topic_id(get_the_ID());
 				$topic_title   = get_the_title($topic_id);
@@ -41,14 +41,14 @@ defined( 'ABSPATH' ) || exit;
 				$last_post_url = get_permalink($topic_id) . $reply_anchor;
 				$post_date     = get_the_date(); // Get the date of the post
 				$post_time     = get_the_time(); // Get the time of the post
-				$message       = 'Welcome back, <b>' . esc_html($current_user->display_name) . "</b>! Your last post was in <a href='" . esc_url($last_post_url) . "'>" . esc_html($topic_title) . '</a> on ' . esc_html($post_date) . ' at ' . esc_html($post_time) . '.';
+				$message       = 'Welcome back, <b>' . esc_html($display_user->display_name) . "</b>! Your last post was in <a href='" . esc_url($last_post_url) . "'>" . esc_html($topic_title) . '</a> on ' . esc_html($post_date) . ' at ' . esc_html($post_time) . '.';
 			} else {
 				// For topics, just link to the topic itself
 				$last_post_title = get_the_title();
 				$last_post_url   = get_the_permalink();
 				$post_date       = get_the_date(); // Get the date of the post
 				$post_time       = get_the_time(); // Get the time of the post
-				$message         = 'Welcome back, <b>' . esc_html($current_user->display_name) . "</b>! Your last post was in <a href='" . esc_url($last_post_url) . "'>" . esc_html($last_post_title) . '</a> on ' . esc_html($post_date) . ' at ' . esc_html($post_time) . '.';
+				$message         = 'Welcome back, <b>' . esc_html($display_user->display_name) . "</b>! Your last post was in <a href='" . esc_url($last_post_url) . "'>" . esc_html($last_post_title) . '</a> on ' . esc_html($post_date) . ' at ' . esc_html($post_time) . '.';
 			}
 
 
@@ -56,7 +56,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 	} else {
 		// User hasn't posted yet
-		echo '<p>Welcome, <b>' . esc_html($current_user->display_name) . "</b>! You haven't posted yet. Start by introducing yourself in <a href='/t/introductions-thread'>The Back Bar!</a></p>";
+		echo '<p>Welcome, <b>' . esc_html($display_user->display_name) . "</b>! You haven't posted yet. Start by introducing yourself in <a href='/t/introductions-thread'>The Back Bar!</a></p>";
 	}
 	wp_reset_postdata(); // Reset the global post object
 
@@ -99,36 +99,41 @@ defined( 'ABSPATH' ) || exit;
 
 			$rp_current_label = isset( $rank_progress['current']['label'] ) ? (string) $rank_progress['current']['label'] : '';
 			$rp_is_max        = ! empty( $rank_progress['is_max'] );
-			?>
-			<div class="rank-progress" role="img" aria-label="<?php
-				echo esc_attr(
-					$rp_is_max
-						? sprintf(
-							/* translators: %s: current rank label */
-							__( 'Rank progress: %s, maximum rank reached', 'extra-chill-community' ),
-							$rp_current_label
-						)
-						: sprintf(
-							/* translators: 1: current rank label, 2: rounded percent toward next rank */
-							__( 'Rank progress: %1$s, %2$d%% toward next rank', 'extra-chill-community' ),
-							$rp_current_label,
-							(int) round( $rp_percent )
-						)
+
+			if ( $rp_is_max ) {
+				$rp_aria_label = sprintf(
+					/* translators: %s: current rank label */
+					__( 'Rank progress: %s, maximum rank reached', 'extra-chill-community' ),
+					$rp_current_label
 				);
-			?>">
+			} else {
+				$rp_aria_label = sprintf(
+					/* translators: 1: current rank label, 2: rounded percent toward next rank */
+					__( 'Rank progress: %1$s, %2$d%% toward next rank', 'extra-chill-community' ),
+					$rp_current_label,
+					(int) round( $rp_percent )
+				);
+			}
+
+			$rp_current_text = sprintf(
+				/* translators: %s: current rank label */
+				__( 'Current: %s', 'extra-chill-community' ),
+				$rp_current_label
+			);
+			?>
+			<div class="rank-progress" role="img" aria-label="<?php echo esc_attr( $rp_aria_label ); ?>">
 				<div class="rank-progress-meta">
-					<span class="rank-progress-current"><?php echo esc_html( sprintf(
-						/* translators: %s: current rank label */
-						__( 'Current: %s', 'extra-chill-community' ),
-						$rp_current_label
-					) ); ?></span>
+					<span class="rank-progress-current"><?php echo esc_html( $rp_current_text ); ?></span>
 					<span class="rank-progress-percent"><?php echo esc_html( (int) round( $rp_percent ) ); ?>%</span>
-					<?php if ( ! $rp_is_max && ! empty( $rank_progress['next']['label'] ) ) : ?>
-						<span class="rank-progress-next"><?php echo esc_html( sprintf(
+					<?php
+					if ( ! $rp_is_max && ! empty( $rank_progress['next']['label'] ) ) :
+						$rp_next_text = sprintf(
 							/* translators: %s: next rank label */
 							__( 'Next: %s', 'extra-chill-community' ),
 							(string) $rank_progress['next']['label']
-						) ); ?></span>
+						);
+						?>
+						<span class="rank-progress-next"><?php echo esc_html( $rp_next_text ); ?></span>
 					<?php elseif ( $rp_is_max ) : ?>
 						<span class="rank-progress-next"><?php esc_html_e( 'Max rank reached', 'extra-chill-community' ); ?></span>
 					<?php endif; ?>
@@ -136,13 +141,16 @@ defined( 'ABSPATH' ) || exit;
 				<div class="rank-progress-track">
 					<div class="rank-progress-fill<?php echo $rp_is_max ? ' is-max' : ''; ?>" style="width:<?php echo esc_attr( $rp_percent ); ?>%"></div>
 				</div>
-				<?php if ( ! $rp_is_max && ! empty( $rank_progress['next']['label'] ) && null !== $rank_progress['points_to_next'] ) : ?>
-					<div class="rank-progress-hint"><?php echo esc_html( sprintf(
+				<?php
+				if ( ! $rp_is_max && ! empty( $rank_progress['next']['label'] ) && null !== $rank_progress['points_to_next'] ) :
+					$rp_hint_text = sprintf(
 						/* translators: 1: points remaining, 2: next rank label */
 						__( '%1$s points to %2$s', 'extra-chill-community' ),
 						(int) ceil( (float) $rank_progress['points_to_next'] ),
 						(string) $rank_progress['next']['label']
-					) ); ?></div>
+					);
+					?>
+					<div class="rank-progress-hint"><?php echo esc_html( $rp_hint_text ); ?></div>
 				<?php endif; ?>
 			</div>
 			<?php
@@ -182,11 +190,11 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php if ( ! empty($dynamic_links) ) : ?>
 	<div class="bbp-user-links-inline">
-		<?php foreach ( $dynamic_links as $link ) : ?>
+		<?php foreach ( $dynamic_links as $dynamic_link ) : ?>
 			<?php
-			$type_key     = isset($link['type_key']) ? $link['type_key'] : 'other';
-			$url          = isset($link['url']) ? $link['url'] : '';
-			$custom_label = isset($link['custom_label']) ? $link['custom_label'] : '';
+			$type_key     = isset($dynamic_link['type_key']) ? $dynamic_link['type_key'] : 'other';
+			$url          = isset($dynamic_link['url']) ? $dynamic_link['url'] : '';
+			$custom_label = isset($dynamic_link['custom_label']) ? $dynamic_link['custom_label'] : '';
 			$icon_id      = isset($platform_icons[ $type_key ]) ? $platform_icons[ $type_key ] : 'link';
 
 			if ( empty($url) ) {

--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -91,6 +91,7 @@ if ( $is_artist || $is_professional ) :
 			$display_name = bbp_get_displayed_user_field('display_name');
 			// Adjust title based on whether they have bands or not
 			if ( ! empty($user_artist_ids) ) {
+				/* translators: %s: user display name */
 				printf( esc_html__( "%s's Artists", 'extra-chill-community' ), esc_html($display_name) );
 			} elseif ( bbp_get_displayed_user_id() === get_current_user_id() ) {
 				// Title for own profile with no bands

--- a/inc/abilities/community-drafts.php
+++ b/inc/abilities/community-drafts.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Ability: extrachill/community-drafts
  *
@@ -9,6 +8,8 @@ declare(strict_types=1);
  *
  * @package ExtraChillCommunity
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/community-taxonomy-counts.php
+++ b/inc/abilities/community-taxonomy-counts.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Ability: extrachill/community-taxonomy-counts
  *
@@ -10,6 +9,8 @@ declare(strict_types=1);
  *
  * @package ExtraChillCommunity
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/community-upvote.php
+++ b/inc/abilities/community-upvote.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Ability: extrachill/community-upvote
  *
@@ -9,6 +8,8 @@ declare(strict_types=1);
  *
  * @package ExtraChillCommunity
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/assets/css/bbpress.css
+++ b/inc/assets/css/bbpress.css
@@ -438,7 +438,7 @@ blockquote {
 }
 
 .upvote-icon .ec-icon:hover {
-    color: #083b6c;
+    color: var(--link-color-hover);
 }
 
 /* ==================================================

--- a/inc/assets/css/global.css
+++ b/inc/assets/css/global.css
@@ -14,7 +14,7 @@
    Notification Bell
 ================================================== */
 .notification-bell-svg {
-	color: #fff;
+	color: var(--button-text-color);
 	font-size: var(--font-size-lg);
 }
 
@@ -47,7 +47,7 @@
 	top: -5px;
 	right: -5px;
 	background-color: var(--error-color);
-	color: #fff;
+	color: var(--button-text-color);
 	border-radius: 50%;
 	padding: 0 5px;
 	font-size: var(--font-size-xs);

--- a/inc/assets/css/notifications.css
+++ b/inc/assets/css/notifications.css
@@ -1,11 +1,11 @@
 /* Notification Card Styles */
 .notification-card {
-    background-color: #f9fafb;
-    border: 1px solid #e0e0e0;
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
     border-radius: var(--border-radius-sm);
     padding: 20px;
     margin-bottom: 20px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    box-shadow: var(--card-shadow);
     box-sizing: border-box;
     width: 100%;
 }
@@ -16,16 +16,16 @@
     align-items: center;
     margin-bottom: 15px;
     padding-bottom: 10px;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .notification-type-icon {
-	color: #003466;
+	color: var(--link-color);
 }
 
 .notification-timestamp {
     font-size: var(--font-size-sm);
-    color: #777;
+    color: var(--muted-text);
 }
 
 .notification-card-body {
@@ -49,7 +49,7 @@
 .notification-card-footer {
     margin-top: 15px;
     padding-top: 10px;
-    border-top: 1px solid #eee;
+    border-top: 1px solid var(--border-color);
     display: flex;
     justify-content: flex-end;
 }
@@ -67,31 +67,8 @@
     }
 }
 
-/* Dark Mode Styles */
-@media (prefers-color-scheme: dark) {
-    .notification-card {
-        background-color: #2e2e2e; /* dark background */
-        border-color: #444; /* darker border */
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-    }
-
-    .notification-card-header {
-        border-bottom-color: #555;
-    }
-
-    .notification-type-icon {
-        color: #66b2ff; /* lighter blue for contrast */
-    }
-
-    .notification-timestamp {
-        color: #aaa;
-    }
-
-    .notification-message {
-        color: #ddd;
-    }
-
-    .notification-card-footer {
-        border-top-color: #555;
-    }
-}
+/*
+ * Dark mode is handled automatically by the theme's design tokens
+ * (--card-background, --border-color, --muted-text, --link-color, --card-shadow),
+ * which carry their own prefers-color-scheme: dark overrides in root.css.
+ */

--- a/inc/assets/css/replies-loop.css
+++ b/inc/assets/css/replies-loop.css
@@ -428,10 +428,10 @@ span.bbp-topic-post-date {
 
 span.bbp-admin-links {
     float: right;
-    color: #ddd;
+    color: var(--muted-text);
 }
 span.bbp-admin-links a {
-    color: #707070;
+    color: var(--muted-text);
     font-weight: 400;
     font-size: var(--font-size-xs);
     text-transform: uppercase;
@@ -441,7 +441,7 @@ span.bbp-author-ip {
     font-size: var(--font-size-xs);
     font-weight: 700;
     word-wrap: break-word;
-    color: #747474;
+    color: var(--muted-text);
 }
 
 /* Revision Log (Edit History Footer) */

--- a/inc/assets/css/tinymce-editor.css
+++ b/inc/assets/css/tinymce-editor.css
@@ -1,83 +1,8 @@
-/* --- Color Variables & Dark Mode Overrides --- */
-:root {
-    /* Base Colors (Light Mode) */
-    --background-color: #fff;
-    --text-color: #000;
-    
-    /* Main brand/link color: "blue version" of #53940b */
-    --link-color: #0b5394;
-    
-    /* Slightly lighter gray for borders so they're less prominent */
-    --border-color: #ddd;
-    
-
-
-    /* Component-Specific Variables */
-    --header-bg: #000;
-    --header-text: #fff;
-    
-    /* Accent & Secondary Accent */
-    /* Keep a green accent for special highlights, or unify if you want everything consistent */
-    --accent: #53940b;
-    --accent-2: #36454F;
-    
-    /* Notices */
-    --notice-bg: #f8f9fa;
-    --notice-border: #0b5394; /* Same as link-color for consistency */
-    
-    /* Card & Form Backgrounds */
-    --card-background: #f8fafc;
-    --muted-text: #6b7280;
-    
-    /* Shadows */
-    --card-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
-    --card-hover-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    
-    /* Focus/Outline States */
-    --focus-border-color: #53940b;
-    --focus-box-shadow: 0 0 0 3px rgba(83, 148, 11, 0.2);
-}
-
-/* --- Dark Mode Overrides --- */
-@media (prefers-color-scheme: dark) {
-    :root {
-        /* Base Colors (Dark Mode) */
-        --background-color: #1a1a1a;
-        --text-color: #e5e5e5;
-        
-        /* Green Link Color in Dark Mode for contrast */
-        --link-color: #53940b;
-        
-        /* Darker border for separation */
-        --border-color: #555;
-        
-
-
-        /* Component-Specific Variables */
-        --header-bg: #000;
-        --header-text: #fff;
-        
-        /* Accent & Secondary Accent */
-        --accent: #53940b; /* Keep the green accent in dark mode */
-        --accent-2: #a8c0d0; /* Softer bluish accent */
-        
-        /* Notices */
-        --notice-bg: #1e1e1e;
-        --notice-border: #444;
-        
-        /* Card & Form Backgrounds */
-        --card-background: #2a2a2a;
-        --muted-text: #b0b0b0;
-        
-        /* Softer Shadows for Dark Mode */
-        --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
-        --card-hover-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-        
-        /* Focus/Outline States */
-        --focus-border-color: #8aa6bf;
-        --focus-box-shadow: 0 0 0 3px rgba(138, 166, 191, 0.2);
-    }
-}
+/*
+ * Design tokens come from the theme's root.css, which is injected into this
+ * TinyMCE iframe via the mce_css filter (see inc/content/editor/tinymce-customization.php).
+ * Do not redefine theme tokens here — consume them.
+ */
 
 /* General content styling */
 body.mce-content-body {
@@ -94,7 +19,7 @@ body.mce-content-body h4,
 body.mce-content-body h5,
 body.mce-content-body h6 {
     font-family: "WilcoLoftSans", sans-serif;
-    color: var(--header-text);
+    color: var(--header-text-color);
     margin-bottom: 10px;
 }
 
@@ -143,8 +68,8 @@ body.mce-content-body button,
 body.mce-content-body input[type="button"],
 body.mce-content-body input[type="submit"],
 body.mce-content-body input[type="reset"] {
-    background-color: #0b5394;
-    color: #fff;
+    background-color: var(--link-color);
+    color: var(--button-text-color);
     padding: 10px 20px;
 	border: none;
 	border-radius: 4px;
@@ -155,7 +80,7 @@ body.mce-content-body button:hover,
 body.mce-content-body input[type="button"]:hover,
 body.mce-content-body input[type="submit"]:hover,
 body.mce-content-body input[type="reset"]:hover {
-    background-color: #083b6c;
+    background-color: var(--link-color-hover);
 }
 
 /* Style the formatselect dropdown menu */
@@ -179,7 +104,7 @@ body.mce-content-body input[type="reset"]:hover {
 .mce-listbox .mce-listbox-item.mce-active,
 .mce-listbox .mce-listbox-item:hover {
     background-color: var(--accent-2);
-    color: var(--header-text);
+    color: var(--header-text-color);
 }
 
 /* ==================================================
@@ -314,7 +239,7 @@ select {
 .mentions-item:hover,
 .mentions-item.selected {
     background-color: var(--accent-2);
-    color: var(--header-text);
+    color: var(--header-text-color);
 }
 
 .mentions-item.mentions-no-results,
@@ -376,7 +301,7 @@ select {
 
 .mentions-item:hover .mentions-username,
 .mentions-item.selected .mentions-username {
-    color: var(--header-text);
+    color: var(--header-text-color);
 }
 
 .mentions-item:hover .mentions-login,

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -193,7 +193,7 @@
 }
 
 .social-link:hover {
-    color: #083b6c;
+    color: var(--link-color-hover);
 }
 
 .social-link.website:hover {

--- a/inc/content/content-filters.php
+++ b/inc/content/content-filters.php
@@ -132,7 +132,8 @@ function extrachill_truncate_html_content($content, $length = 500, $ellipsis = '
 }
 
 function ec_display_forum_description() {
-	if ( $description = bbp_get_forum_content() ) {
+	$description = bbp_get_forum_content();
+	if ( $description ) {
 		echo '<div class="bbp-forum-description">' . wp_kses_post( $description ) . '</div>';
 	}
 }

--- a/inc/content/editor/draft-storage.php
+++ b/inc/content/editor/draft-storage.php
@@ -182,7 +182,7 @@ function extrachill_community_bbpress_drafts_fetch( $user_id, array $context ) {
 
 	$table = extrachill_community_bbpress_drafts_table_name();
 	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-	$row   = $wpdb->get_row(
+	$row = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT * FROM {$table}
 	// phpcs:enable WordPress.DB.PreparedSQL

--- a/inc/content/editor/tinymce-customization.php
+++ b/inc/content/editor/tinymce-customization.php
@@ -23,6 +23,14 @@ function bbp_enable_visual_editor($args = array()) {
 add_filter('bbp_after_get_the_content_parse_args', 'bbp_enable_visual_editor', 999);
 
 function bbp_add_tinymce_stylesheet($mce_css) {
+	// Inject the theme's canonical design tokens (root.css) into the editor iframe so
+	// tinymce-editor.css can consume theme tokens instead of redefining a parallel palette.
+	$theme_root_path = get_template_directory() . '/assets/css/root.css';
+	if ( file_exists( $theme_root_path ) ) {
+		$theme_root_version = filemtime( $theme_root_path );
+		$mce_css           .= ', ' . get_template_directory_uri() . '/assets/css/root.css?ver=' . $theme_root_version;
+	}
+
 	$version  = filemtime(EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/css/tinymce-editor.css');
 	$mce_css .= ', ' . EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/css/tinymce-editor.css?ver=' . $version;
 	return $mce_css;

--- a/inc/content/recent-feed.php
+++ b/inc/content/recent-feed.php
@@ -69,6 +69,7 @@ if ( ! class_exists('ExtraChill_Community_Feed_Query') ) {
  * @param int $size Avatar size
  * @return string Avatar URL
  */
+// phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Feed query functions and their lightweight WP_Query-shaped helper class are a single cohesive unit; splitting would fragment includes without behavior benefit.
 function extrachill_get_avatar_url_with_custom_support($user_id, $size = 80) {
 	$avatar_html = get_avatar($user_id, $size);
 	if ( preg_match('/src=["\']([^"\']+)["\']/', $avatar_html, $matches) ) {

--- a/inc/content/topic-reply-abilities.php
+++ b/inc/content/topic-reply-abilities.php
@@ -625,11 +625,11 @@ function extrachill_community_ability_get_topic( $input ) {
 	}
 
 	$post = get_post( $topic_id );
-	if ( ! $post || $post->post_type !== bbp_get_topic_post_type() ) {
+	if ( ! $post || bbp_get_topic_post_type() !== $post->post_type ) {
 		return new WP_Error( 'not_a_topic', 'Post ID is not a valid topic.' );
 	}
 
-	if ( $post->post_status !== bbp_get_public_status_id() ) {
+	if ( bbp_get_public_status_id() !== $post->post_status ) {
 		return new WP_Error( 'topic_not_published', 'Topic is not published.' );
 	}
 
@@ -700,7 +700,7 @@ function extrachill_community_ability_create_topic( $input ) {
 
 	// Validate forum exists.
 	$forum = get_post( $forum_id );
-	if ( ! $forum || $forum->post_type !== bbp_get_forum_post_type() ) {
+	if ( ! $forum || bbp_get_forum_post_type() !== $forum->post_type ) {
 		return new WP_Error( 'invalid_forum', 'Forum ID does not point to a valid forum.' );
 	}
 
@@ -765,7 +765,7 @@ function extrachill_community_ability_create_reply( $input ) {
 
 	// Validate topic exists.
 	$topic = get_post( $topic_id );
-	if ( ! $topic || $topic->post_type !== bbp_get_topic_post_type() ) {
+	if ( ! $topic || bbp_get_topic_post_type() !== $topic->post_type ) {
 		return new WP_Error( 'invalid_topic', 'Topic ID does not point to a valid topic.' );
 	}
 
@@ -1020,7 +1020,7 @@ function extrachill_community_ability_get_topic_for_editor( $input ) {
 	}
 
 	$post = get_post( $topic_id );
-	if ( ! $post || $post->post_type !== bbp_get_topic_post_type() ) {
+	if ( ! $post || bbp_get_topic_post_type() !== $post->post_type ) {
 		return new WP_Error( 'not_a_topic', 'Post ID is not a valid topic.' );
 	}
 
@@ -1075,7 +1075,7 @@ function extrachill_community_ability_get_reply_for_editor( $input ) {
 	}
 
 	$post = get_post( $reply_id );
-	if ( ! $post || $post->post_type !== bbp_get_reply_post_type() ) {
+	if ( ! $post || bbp_get_reply_post_type() !== $post->post_type ) {
 		return new WP_Error( 'not_a_reply', 'Post ID is not a valid reply.' );
 	}
 
@@ -1140,7 +1140,7 @@ function extrachill_community_ability_update_topic( $input ) {
 	}
 
 	$post = get_post( $topic_id );
-	if ( ! $post || $post->post_type !== bbp_get_topic_post_type() ) {
+	if ( ! $post || bbp_get_topic_post_type() !== $post->post_type ) {
 		return new WP_Error( 'not_a_topic', 'Post ID is not a valid topic.' );
 	}
 
@@ -1222,7 +1222,7 @@ function extrachill_community_ability_update_reply( $input ) {
 	}
 
 	$post = get_post( $reply_id );
-	if ( ! $post || $post->post_type !== bbp_get_reply_post_type() ) {
+	if ( ! $post || bbp_get_reply_post_type() !== $post->post_type ) {
 		return new WP_Error( 'not_a_reply', 'Post ID is not a valid reply.' );
 	}
 

--- a/inc/core/cache-invalidation.php
+++ b/inc/core/cache-invalidation.php
@@ -50,12 +50,12 @@ function extrachill_handle_forum_cache_invalidation($post_id) {
 
 	$post_type = get_post_type($post_id);
 
-	if ( $post_type !== bbp_get_topic_post_type() && $post_type !== bbp_get_reply_post_type() ) {
+	if ( bbp_get_topic_post_type() !== $post_type && bbp_get_reply_post_type() !== $post_type ) {
 		return;
 	}
 
-	$topic_id = ( $post_type === bbp_get_topic_post_type() ) ? $post_id : bbp_get_reply_topic_id($post_id);
-	$reply_id = ( $post_type === bbp_get_reply_post_type() ) ? $post_id : 0;
+	$topic_id = ( bbp_get_topic_post_type() === $post_type ) ? $post_id : bbp_get_reply_topic_id($post_id);
+	$reply_id = ( bbp_get_reply_post_type() === $post_type ) ? $post_id : 0;
 	$forum_id = $topic_id ? bbp_get_topic_forum_id($topic_id) : 0;
 
 	extrachill_delete_leaderboard_cache();

--- a/inc/core/infrastructure-abilities.php
+++ b/inc/core/infrastructure-abilities.php
@@ -256,7 +256,7 @@ function extrachill_community_ability_toggle_forum_homepage( $input ) {
 	}
 
 	$post = get_post( $forum_id );
-	if ( ! $post || $post->post_type !== bbp_get_forum_post_type() ) {
+	if ( ! $post || bbp_get_forum_post_type() !== $post->post_type ) {
 		return new WP_Error( 'not_a_forum', 'Post ID is not a valid forum.' );
 	}
 

--- a/inc/home/latest-post.php
+++ b/inc/home/latest-post.php
@@ -80,14 +80,14 @@ function extrachill_construct_activity_output($current_post_id) {
 	$author_profile_url = bbp_get_user_profile_url($author_id);
 
 	$post_type   = get_post_type($current_post_id);
-	$topic_id    = $post_type === bbp_get_reply_post_type() ? bbp_get_reply_topic_id($current_post_id) : $current_post_id;
+	$topic_id    = bbp_get_reply_post_type() === $post_type ? bbp_get_reply_topic_id($current_post_id) : $current_post_id;
 	$forum_id    = bbp_get_topic_forum_id($topic_id);
 	$forum_title = get_the_title($forum_id);
 	// Use human_time_diff for verbose output
 	$time_diff = human_time_diff( get_post_time('U', true, $current_post_id), time() ) . ' ago';
 
-	$reply_url  = $post_type === bbp_get_reply_post_type() ? bbp_get_reply_url($current_post_id) : get_permalink($topic_id);
-	$type_label = $post_type === bbp_get_reply_post_type() ? 'replied to' : 'posted';
+	$reply_url  = bbp_get_reply_post_type() === $post_type ? bbp_get_reply_url($current_post_id) : get_permalink($topic_id);
+	$type_label = bbp_get_reply_post_type() === $post_type ? 'replied to' : 'posted';
 	$title      = get_the_title($topic_id);
 
 	// Construct output

--- a/inc/social/notifications/capture-mentions.php
+++ b/inc/social/notifications/capture-mentions.php
@@ -56,7 +56,7 @@ function extrachill_capture_mention_notifications($post_id, $topic_id, $forum_id
 
 			// Priority deduplication: If mentioned user is topic author, remove reply notification
 			// Mention notifications are more specific than reply notifications
-			if ( $user->ID === get_post_field('post_author', $actual_topic_id_for_context) ) {
+			if ( get_post_field('post_author', $actual_topic_id_for_context) === $user->ID ) {
 				// Switch to community site for deduplication
 				$current_blog_id = get_current_blog_id();
 				$switched        = false;

--- a/inc/social/notifications/capture-replies.php
+++ b/inc/social/notifications/capture-replies.php
@@ -26,7 +26,7 @@ if ( ! defined('ABSPATH') ) {
  */
 function extrachill_capture_reply_notifications($reply_id, $topic_id, $forum_id, $anonymous_data, $reply_author) {
 	// Prevent self-notification (author replying to own topic)
-	if ( $reply_author === get_post_field('post_author', $topic_id) ) {
+	if ( get_post_field('post_author', $topic_id) === $reply_author ) {
 		return;
 	}
 

--- a/inc/social/notifications/notification-card.php
+++ b/inc/social/notifications/notification-card.php
@@ -40,6 +40,7 @@ function extrachill_render_notification_card($notification) {
 	$time               = $notification['time'] ?? '';
 
 	// Format timestamp
+	// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Display in site-local time, preserving existing rendered output.
 	$time_formatted = $time ? esc_html(date('n/j/y \\a\\t g:ia', strtotime($time))) : '';
 
 	// Get actor avatar

--- a/inc/social/rank-system/rank-abilities.php
+++ b/inc/social/rank-system/rank-abilities.php
@@ -89,7 +89,6 @@ function extrachill_community_register_rank_abilities() {
 			),
 		)
 	);
-
 }
 
 // ─── Execute callbacks ─────────────────────────────────────────────────────────

--- a/inc/user-profiles/verification.php
+++ b/inc/user-profiles/verification.php
@@ -53,6 +53,11 @@ function extrachill_save_user_meta($user_id) {
 		return false;
 	}
 
+	// Verify the core user-edit nonce (WordPress also enforces this before firing these hooks).
+	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['_wpnonce'] ) ), 'update-user_' . $user_id ) ) {
+		return false;
+	}
+
 	// Direct save for Artist status
 	update_user_meta($user_id, 'user_is_artist', isset($_POST['user_is_artist']) ? '1' : '0');
 

--- a/page-templates/leaderboard-template.php
+++ b/page-templates/leaderboard-template.php
@@ -43,6 +43,7 @@ echo '<tbody>';
 
 foreach ( $users as $user ) {
 	$user_profile_url = bbp_get_user_profile_url($user->ID);
+	// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Display in site-local time, preserving existing rendered output.
 	$join_date        = date('Y-m-d', strtotime($user->user_registered));
 	$points           = extrachill_display_user_points($user->ID);
 	$rank             = extrachill_display_user_rank($user->ID);

--- a/page-templates/main-blog-comments-feed.php
+++ b/page-templates/main-blog-comments-feed.php
@@ -17,8 +17,8 @@ get_header();
 $isUserProfile = bbp_is_single_user();
 
 if ( $isUserProfile ) {
-	$title = '@' . bbp_get_displayed_user_field('user_nicename');
-	echo '<div class="community-section-header"><h1 class="profile-title-inline">' . esc_html( $title ) . '</h1></div>';
+	$feed_title = '@' . bbp_get_displayed_user_field('user_nicename');
+	echo '<div class="community-section-header"><h1 class="profile-title-inline">' . esc_html( $feed_title ) . '</h1></div>';
 
 } else {
 	// Display the title for non-profile pages

--- a/page-templates/recent-feed-template.php
+++ b/page-templates/recent-feed-template.php
@@ -14,8 +14,8 @@ get_header();
 $isUserProfile = bbp_is_single_user();
 
 if ( $isUserProfile ) {
-	$title = '@' . bbp_get_displayed_user_field('user_nicename');
-	echo '<div class="community-section-header"><h1 class="profile-title-inline">' . esc_html( $title ) . '</h1></div>';
+	$feed_title = '@' . bbp_get_displayed_user_field('user_nicename');
+	echo '<div class="community-section-header"><h1 class="profile-title-inline">' . esc_html( $feed_title ) . '</h1></div>';
 } else {
 	echo '<div class="community-section-header"><h1>Recent Activity</h1></div>';
 }
@@ -43,7 +43,9 @@ if ( $recent_feed && ! empty($recent_feed['items']) ) {
 		<ul class="forums bbp-replies">
 			<li class="bbp-body">
 				<?php
+				global $post;
 				foreach ( $feed_items as $feed_item ) {
+					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentionally sets the global $post for setup_postdata() and the bbPress template part below.
 					$post = $feed_item['post'];
 
 					if ( ! $post || ! is_object($post) ) {
@@ -67,7 +69,7 @@ if ( $recent_feed && ! empty($recent_feed['items']) ) {
 
 					$bbp->current_reply_id = $post->ID;
 
-					if ( $post->post_type === bbp_get_topic_post_type() ) {
+					if ( bbp_get_topic_post_type() === $post->post_type ) {
 						$topic_id = $post->ID;
 					} else {
 						$topic_id = (int) get_post_field( 'post_parent', $post->ID );

--- a/src/blocks/leaderboard/render.php
+++ b/src/blocks/leaderboard/render.php
@@ -7,8 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$per_page = isset( $attributes['perPage'] ) ? (int) $attributes['perPage'] : 25;
-$per_page = max( 1, min( 100, $per_page ) );
+$leaderboard_per_page = isset( $attributes['perPage'] ) ? (int) $attributes['perPage'] : 25;
+$leaderboard_per_page = max( 1, min( 100, $leaderboard_per_page ) );
 
 $sprite_url = get_template_directory_uri() . '/assets/fonts/extrachill.svg';
 
@@ -21,6 +21,6 @@ $class = 'wp-block-extrachill-leaderboard extrachill-leaderboard';
 printf(
 	'<div class="%1$s" data-per-page="%2$d" data-sprite-url="%3$s"></div>',
 	esc_attr( $class ),
-	(int) $per_page,
+	(int) $leaderboard_per_page,
 	esc_url( $sprite_url )
 );


### PR DESCRIPTION
Two cleanups in extrachill-community: (1) remove ad-hoc/duplicate design tokens and convert callers to theme tokens, (2) clear phpcs lint debt blocking the release preflight. No behavior changes beyond the intended token + formatting cleanup.

## Task A — token cleanup

### TinyMCE iframe investigation (the key question)
**Finding: the theme's `root.css` is NOT injected into the bbPress front-end TinyMCE editor iframe.** That iframe is a separate document whose stylesheets come exclusively from `content_css` / the `mce_css` filter (see `inc/content/editor/tinymce-customization.php`). It loaded only `tinymce-editor.css`, which is why that file carried an ad-hoc `:root` block redefining ~32 theme tokens — it was the only place the palette existed inside the iframe. (The theme's `blocks_everywhere_enqueue_iframe_assets` path is for the *Gutenberg/Blocks Everywhere* iframe, and this whole TinyMCE file `return`s early when Blocks Everywhere is active, so the two paths never coexist.)

**Decision: make the theme tokens available in the iframe, then consume them** (the cleanest option per the brief, rather than maintaining a hand-copied parallel palette or a var()-with-fallback half-measure):
- `bbp_add_tinymce_stylesheet()` now injects the theme's `root.css` (`get_template_directory_uri() . '/assets/css/root.css'`, `filemtime`-versioned) into the editor iframe via the existing `mce_css` filter, ahead of `tinymce-editor.css`.
- Removed the entire ad-hoc `:root` + dark-mode `:root` blocks from `tinymce-editor.css`; it now consumes theme tokens directly.
- Fixed consumers that referenced non-theme token names: `--header-text` → `--header-text-color`; editor button colors `#0b5394`/`#fff`/`#083b6c` → `--link-color`/`--button-text-color`/`--link-color-hover`.
- One genuine one-off left intact: white text on the semi-transparent drag-overlay (`color: #fff` on `rgba(0,0,0,0.5)`).

### Hardcoded brand colors → theme tokens (across community CSS)
- `notifications.css`: card → `--card-background`/`--border-color`/`--muted-text`/`--link-color`/`--card-shadow`; **dropped the manual `prefers-color-scheme: dark` block** since the theme tokens already carry their own dark-mode overrides in `root.css`.
- `global.css`: notification bell + count badge white → `--button-text-color`.
- `bbpress.css` (upvote hover) + `user-profile.css` (social-link hover): `#083b6c` → `--link-color-hover`.
- `replies-loop.css`: bbp admin-link / author-IP grays (`#ddd`/`#707070`/`#747474`) → `--muted-text`.
- No `--brand-blue` reintroduced (verified by grep); the recent `bbpress.css` cleanup is untouched.

## Task B — clear phpcs lint debt

**Tooling:** repo has no composer.json; linted via `homeboy lint extrachill-community --path <worktree>` (runs PHPCS WordPress standard + phpstan). Auto-fixable errors fixed with the built-in `--fix` (phpcbf), the rest by hand.

**Before:** 58 phpcs errors (14 auto-fixable). **After:** **0 phpcs errors.** (40 warnings remain — warnings, not errors, out of scope. The ESLint summary in the lint output is JS and pre-existing, out of scope for this phpcs pass.)

Breakdown of fixes:
- **Yoda conditions (21):** swapped operands so constants/function calls sit left of strict comparisons.
- **GlobalVariablesOverride (8):** renamed reserved WP globals to locals (`$current_user`→`$display_user`, `$post_type`→`$last_post_type`, `$link`→`$dynamic_link`, `$title`→`$feed_title`, `$per_page`→`$leaderboard_per_page`); in `recent-feed-template.php` the global `$post` is intentionally driven for `setup_postdata()` + the bbPress template part, so it gets `global $post;` + a justified targeted `phpcs:ignore`.
- **MissingTranslatorsComment (4):** added `translators:` comments above placeholder i18n calls.
- **date_date (4):** targeted `phpcs:ignore` documenting intentional site-local display / `post_date` (non-GMT) comparison — preserves existing rendered output rather than shifting timezones.
- **EmbeddedPhp / ScopeIndent / FunctionClosingBrace / multiple-assignment-in-control-structure / FileHeader order:** phpcbf auto-fixes, plus a clean manual rewrite of the rank-progress bar markup in `user-details.php` (the auto-fix had leaked whitespace into the `aria-label` attribute and mangled indentation — refactored to build label strings into variables first, keeping output identical and the rank bar intact).
- **NonceVerification (2):** `verification.php` now explicitly verifies the core `update-user_{id}` nonce (which core already enforces before firing these hooks).
- **SeparateFunctionsFromOO (1):** targeted `phpcs:ignore` for the cohesive feed-query helper class + functions unit in `recent-feed.php` (splitting would fragment includes with no behavior benefit).

## Verify
- `homeboy lint extrachill-community` (against this worktree): **0 errors**.
- `php -l` clean on all changed PHP.
- grep confirms no `--brand-blue` reintroduced.
- Rank-progress bar PHP (`user-details.php`) preserved; `bbpress.css` `--brand-blue` cleanup preserved.