### PR TITLE
fix: schedule points-recalc cron in activation, unschedule in deactivation (closes #49)

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -99,3 +99,4 @@ function extrachill_community_register_blocks() {
 }
 
 register_activation_hook( __FILE__, 'extrachill_community_activate' );
+register_deactivation_hook( __FILE__, 'extrachill_community_deactivate' );

--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -34,6 +34,36 @@ function extrachill_community_run_activation_setup() {
 
 	extrachill_create_community_pages();
 	extrachill_create_community_forums();
+	extrachill_community_schedule_points_recalculation();
+}
+
+/**
+ * Schedule the hourly points recalculation cron event.
+ *
+ * Runs on activation (and as a self-healing safety net during deferred
+ * activation setup) instead of at file-include time, so the event is only
+ * scheduled for active installs and can be reliably cleared on deactivation.
+ *
+ * The recurrence interval is filterable via
+ * `extrachill_points_recalculation_interval` (defaults to 'hourly').
+ */
+function extrachill_community_schedule_points_recalculation() {
+	if ( wp_next_scheduled('extrachill_hourly_points_recalculation') ) {
+		return;
+	}
+
+	$interval = apply_filters('extrachill_points_recalculation_interval', 'hourly');
+	wp_schedule_event(time(), $interval, 'extrachill_hourly_points_recalculation');
+}
+
+/**
+ * Deactivation handler.
+ *
+ * Clears scheduled cron events so deactivating the plugin does not leave an
+ * orphaned recurring event firing against a missing callback.
+ */
+function extrachill_community_deactivate() {
+	wp_clear_scheduled_hook('extrachill_hourly_points_recalculation');
 }
 
 add_action(

--- a/inc/social/rank-system/point-calculation.php
+++ b/inc/social/rank-system/point-calculation.php
@@ -170,11 +170,10 @@ function extrachill_get_leaderboard_total_users() {
 	return (int) $total;
 }
 
-// Schedule hourly points recalculation processing
-if ( ! wp_next_scheduled('extrachill_hourly_points_recalculation') ) {
-	wp_schedule_event(time(), 'hourly', 'extrachill_hourly_points_recalculation');
-}
-
+// The 'extrachill_hourly_points_recalculation' cron event is scheduled on plugin
+// activation and cleared on deactivation (see inc/core/activation.php). Scheduling
+// no longer happens at include time, which previously left an orphaned recurring
+// cron firing against a missing callback after the plugin was deactivated.
 add_action('extrachill_hourly_points_recalculation', 'extrachill_process_points_recalculation_queue');
 
 /**


### PR DESCRIPTION
## Summary

Fixes #49 — the `extrachill_hourly_points_recalculation` WP-Cron event was scheduled at **file-include time** with no unschedule path, leaving an **orphaned hourly cron** firing against a missing callback after the plugin was deactivated.

## The orphan-cron risk

`inc/social/rank-system/point-calculation.php` (old L173–176) called `wp_schedule_event()` at the top level on every request, guarded only by `wp_next_scheduled()`. Because nothing ever cleared it:

- Deactivating the plugin left the recurring event in `cron` option.
- WP-Cron kept firing `extrachill_hourly_points_recalculation` with no registered callback (the `add_action` lived in the now-unloaded plugin) — wasted cron ticks / noise.
- Scheduling was also re-evaluated on **every request**, not just once.

## The fix (activation/deactivation wiring)

Matches the clean pattern in `extrachill-users/inc/core/activation.php` (schedule in activation, unschedule in deactivation):

- **Schedule** moved into `extrachill_community_run_activation_setup()` via new `extrachill_community_schedule_points_recalculation()`. This runs on `register_activation_hook` **and** the existing deferred-activation safety net (`plugins_loaded` priority 20), so installs that activated before bbPress was ready still get the schedule.
- **Unschedule** added: new `extrachill_community_deactivate()` calls `wp_clear_scheduled_hook('extrachill_hourly_points_recalculation')`, wired via `register_deactivation_hook( __FILE__, ... )` in `extrachill-community.php`.
- The cron **callback** (`extrachill_process_points_recalculation_queue`) and its `add_action` stay in `point-calculation.php` — only the scheduling moved.
- Interval is now filterable via `extrachill_points_recalculation_interval` (defaults to `'hourly'`).

## Verify

- Schedule happens on activation (or deferred activation setup), not on every request at include time.
- Deactivation clears the cron — no orphan.
- The hourly recalc still runs on an active install (callback + `add_action` unchanged).
- `php -l` clean on all three changed files.

## Acceptance criteria (from #49)

- [x] Cron scheduled in activation, unscheduled in deactivation
- [x] Not re-evaluated on every request at include-time