### PR TITLE
fix: route topic/reply edit autosaves through WP core /autosaves

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -50,6 +50,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-storage.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/drafts.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/edit-autosave.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/ability-helpers.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/infrastructure-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-abilities.php';

--- a/inc/content/editor/edit-autosave.php
+++ b/inc/content/editor/edit-autosave.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * bbPress Edit-Flow Autosave via WP Core /autosaves
+ *
+ * Issue #37: route topic/reply EDIT autosaves through WordPress core's native
+ * `/wp/v2/<cpt>/<id>/autosaves` REST endpoint (per-user isolation, dedupe and
+ * snapshot semantics built in) instead of the custom drafts table.
+ *
+ * The custom drafts table (draft-storage.php / draft-abilities.php) still owns
+ * the new-topic / new-reply COMPOSE case, where no parent post exists yet and
+ * bbPress validation runs at insert-time. This file only handles the narrow
+ * remaining case core can serve cleanly: a logged-in user editing an existing
+ * topic or reply they can edit. Scope = ONLY the gap (RULES.md: do not build a
+ * unified abstraction that swallows the working compose path).
+ *
+ * How it works:
+ *  1. bbPress `topic` / `reply` CPTs ship with `show_in_rest = false`, so core's
+ *     autosaves controller is never registered for them. We flip `show_in_rest`
+ *     to true *conditionally* — only for the autosave REST request itself and
+ *     for the front-end edit page render — so the collection endpoint is not
+ *     broadly exposed network-wide on every page load.
+ *  2. On an edit page, we inject `postEntity = { type, id }` into the Blocks
+ *     Everywhere editor settings. BE's PostEntityShell then wraps the editor in
+ *     core's <EditorProvider> + <AutosaveMonitor>, which fire the standard
+ *     `/wp/v2/<cpt>/<id>/autosaves` path with no custom client code.
+ *
+ * Core's autosaves controller already enforces per-user isolation and the
+ * `edit_post` capability (WP_REST_Autosaves_Controller::create_item_permissions_check
+ * → parent update_item_permissions_check), so reads/writes stay owner-gated.
+ *
+ * @package ExtraChillCommunity
+ * @subpackage ForumFeatures\Content\Editor
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Detect whether the current request is a core autosaves REST request for a
+ * bbPress topic or reply.
+ *
+ * CPT args (including `show_in_rest`) are decided at registration time on the
+ * `init` hook, which runs before REST route matching — and before the
+ * `REST_REQUEST` constant is defined (that happens on `parse_request`). So we
+ * cannot rely on `REST_REQUEST` here; we inspect the raw request URI instead to
+ * know whether to expose the autosaves route for this request.
+ *
+ * Matches both the pretty form `/wp-json/wp/v2/<cpt>/<id>/autosaves[...]` and
+ * the `?rest_route=/wp/v2/<cpt>/<id>/autosaves` fallback form.
+ *
+ * @param string $cpt The bbPress CPT slug (topic or reply post type name).
+ * @return bool
+ */
+function extrachill_community_is_autosaves_rest_request( $cpt ) {
+	if ( empty( $cpt ) || ! isset( $_SERVER['REQUEST_URI'] ) ) {
+		return false;
+	}
+
+	$uri = rawurldecode( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+
+	// rest_base defaults to the post type name for bbPress CPTs (no custom rest_base set).
+	$pattern = '#/wp/v2/' . preg_quote( $cpt, '#' ) . '/\d+/autosaves#';
+
+	return (bool) preg_match( $pattern, $uri );
+}
+
+/**
+ * Detect whether the current front-end request is a logged-in user editing an
+ * existing topic.
+ *
+ * @return bool
+ */
+function extrachill_community_is_frontend_topic_edit() {
+	return is_user_logged_in()
+		&& function_exists( 'bbp_is_topic_edit' )
+		&& bbp_is_topic_edit();
+}
+
+/**
+ * Detect whether the current front-end request is a logged-in user editing an
+ * existing reply.
+ *
+ * @return bool
+ */
+function extrachill_community_is_frontend_reply_edit() {
+	return is_user_logged_in()
+		&& function_exists( 'bbp_is_reply_edit' )
+		&& bbp_is_reply_edit();
+}
+
+/**
+ * Conditionally enable `show_in_rest` for the topic CPT.
+ *
+ * Only flips on for (a) the autosaves REST request itself, or (b) a front-end
+ * topic-edit page render — keeping the collection endpoint off for normal page
+ * loads so the blast radius stays minimal.
+ *
+ * @param array $args register_post_type args for the topic CPT.
+ * @return array
+ */
+function extrachill_community_enable_topic_rest_for_autosave( $args ) {
+	if ( ! function_exists( 'bbp_get_topic_post_type' ) ) {
+		return $args;
+	}
+
+	$cpt = bbp_get_topic_post_type();
+
+	if ( extrachill_community_is_autosaves_rest_request( $cpt )
+		|| extrachill_community_is_frontend_topic_edit() ) {
+		$args['show_in_rest'] = true;
+	}
+
+	return $args;
+}
+add_filter( 'bbp_register_topic_post_type', 'extrachill_community_enable_topic_rest_for_autosave', 20 );
+
+/**
+ * Conditionally enable `show_in_rest` for the reply CPT.
+ *
+ * @param array $args register_post_type args for the reply CPT.
+ * @return array
+ */
+function extrachill_community_enable_reply_rest_for_autosave( $args ) {
+	if ( ! function_exists( 'bbp_get_reply_post_type' ) ) {
+		return $args;
+	}
+
+	$cpt = bbp_get_reply_post_type();
+
+	if ( extrachill_community_is_autosaves_rest_request( $cpt )
+		|| extrachill_community_is_frontend_reply_edit() ) {
+		$args['show_in_rest'] = true;
+	}
+
+	return $args;
+}
+add_filter( 'bbp_register_reply_post_type', 'extrachill_community_enable_reply_rest_for_autosave', 20 );
+
+/**
+ * Inject `postEntity` into the Blocks Everywhere editor settings on edit pages.
+ *
+ * When present, BE's PostEntityShell wraps the editor in core's
+ * <EditorProvider> + <AutosaveMonitor>, activating the native
+ * `/wp/v2/<cpt>/<id>/autosaves` path for the post being edited. Absent on
+ * compose pages, so the custom drafts table continues to own new-topic /
+ * new-reply autosave untouched.
+ *
+ * Runs at priority 30, after the endpoint configuration filter (priority 20)
+ * in inc/core/assets.php, so it composes cleanly with the existing bbpress
+ * settings sub-object.
+ *
+ * @param array $settings Blocks Everywhere editor settings.
+ * @return array
+ */
+function extrachill_community_configure_edit_post_entity( $settings ) {
+	if ( extrachill_community_is_frontend_topic_edit()
+		&& function_exists( 'bbp_get_topic_id' )
+		&& function_exists( 'bbp_get_topic_post_type' ) ) {
+		$topic_id = (int) bbp_get_topic_id();
+		if ( $topic_id > 0 && current_user_can( 'edit_post', $topic_id ) ) {
+			$settings['postEntity'] = array(
+				'type' => bbp_get_topic_post_type(),
+				'id'   => $topic_id,
+			);
+		}
+		return $settings;
+	}
+
+	if ( extrachill_community_is_frontend_reply_edit()
+		&& function_exists( 'bbp_get_reply_id' )
+		&& function_exists( 'bbp_get_reply_post_type' ) ) {
+		$reply_id = (int) bbp_get_reply_id();
+		if ( $reply_id > 0 && current_user_can( 'edit_post', $reply_id ) ) {
+			$settings['postEntity'] = array(
+				'type' => bbp_get_reply_post_type(),
+				'id'   => $reply_id,
+			);
+		}
+	}
+
+	return $settings;
+}
+add_filter( 'blocks_everywhere_editor_settings', 'extrachill_community_configure_edit_post_entity', 30 );


### PR DESCRIPTION
## Summary

Fixes the Gutenberg forum editor autosave gap for **editing existing topics/replies**, the remaining piece of #27/#37. Editing a published topic or reply previously ran **no autosave at all** — users lost work when navigating away mid-edit.

## Root cause

Two layers were investigated:

- **#27 (BE bundle does not consume `draftEndpoint`)** — **already resolved.** The deployed Blocks Everywhere bundle (`blocks-everywhere/build/index.min.js`) and its source (`src/editor/index.tsx`) now both consume `bbpress.draftEndpoint` and run debounced autosave/restore for **new-topic / new-reply compose** via the custom drafts table (shipped in #36). Verified by grepping the production bundle: `draftEndpoint` and the "bbPress draft autosave" path are present.
- **#37 (edit flows have no autosave)** — **the real remaining gap.** BE's bbPress draft client *deliberately excludes* edit flows: `isTopicDraft()` / `isReplyDraft()` short-circuit when `isTopicEdit` / `isReplyEdit` are set. So editing an existing post had zero autosave. WP core's `/wp/v2/<cpt>/<id>/autosaves` is the clean fit for the edit case (parent exists, validation already ran, per-user isolation + `edit_post` cap built into `WP_REST_Autosaves_Controller`). BE **already ships** the full `postEntity` → `EditorProvider` + `AutosaveMonitor` + `LocalAutosaveMonitor` stack (verified present in the production bundle). It only needed the community plugin to expose the CPTs to REST and declare the post entity on edit pages.

## What changed

New file `inc/content/editor/edit-autosave.php` (+ one `require_once` in the loader):

1. **Conditionally enable `show_in_rest`** on the bbPress `topic` / `reply` CPTs via the `bbp_register_topic_post_type` / `bbp_register_reply_post_type` filters — but **only** for (a) the `/wp/v2/<cpt>/<id>/autosaves` REST request itself, or (b) a front-end edit-page render. Normal page loads keep `show_in_rest = false`, so the collection endpoint is **not** broadly exposed network-wide. This mirrors BE's own `bbpress_support_gutenberg` admin flip (`show_in_rest = true`), an established pattern in the same stack.
2. **Inject `postEntity = { type, id }`** into the BE editor settings on owner edit pages (gated by `current_user_can('edit_post', $id)`). BE's `PostEntityShell` then wraps the editor in core's `<EditorProvider>` + `<AutosaveMonitor>`, firing the native `/autosaves` write path with no custom client code.

Compose autosave (new topic / new reply) is **untouched** and still owned by the custom drafts table from #36 — scope is ONLY the edit gap, no unified abstraction (per RULES.md "scope the new work to ONLY the gap").

## Does it use core `/autosaves` or fix config consumption?

Both, in the right places:
- **Edit flow (this PR):** uses WP core `/wp/v2/<cpt>/<id>/autosaves` — the #37 clean fix.
- **Compose flow:** config consumption (`draftEndpoint`) was already fixed upstream in BE; this PR leaves it alone.

## Blast radius audit (`show_in_rest`)

- WP core registers the autosaves subroute **only** inside the `show_in_rest => true` loop in `create_initial_rest_routes()`, so the parent collection route and the autosaves subroute register together — there is no way to get one without the other. We scope the flip to edit/autosave requests to keep the exposure minimal.
- Reads of published forum content are already public on the frontend; writes via `/autosaves` are gated by `edit_post` (core, `create_item_permissions_check` → parent `update_item_permissions_check`). Per-user isolation is built in.
- bbPress `topic` / `reply` CPTs already declare `editor` + `revisions` support, so they are fully compatible with core's autosave controller.

## Verification

- `php -l` clean on both touched files; `homeboy lint --changed-since main` reports **zero findings** for the new file and the loader change (all 25 repo findings are pre-existing debt in untouched files).
- Confirmed the production BE bundle already contains the `postEntity` → `EditorProvider` / `AutosaveMonitor` / `LocalAutosaveMonitor` stack, so this PR activates the edit-autosave **write path in production with no BE rebuild required**.
- Hook timing verified: the loader runs on `plugins_loaded` (before `init`), so the `bbp_register_*_post_type` filters are in place before bbPress registers the CPTs; the `blocks_everywhere_editor_settings` filter (priority 30) composes after the existing endpoint config (priority 20).

## Deferred (separate, scoped follow-up against `blocks-everywhere`)

The **autosave WRITE path** (POST `/autosaves`) works with this config-only change. The **restore-on-mount** behavior — GET `/wp/v2/<cpt>/<id>/autosaves?context=edit`, prefer the user's autosave over the parent body when newer (mirrors `extrachill-studio`'s `switchToDraft` pattern) — is **not** in BE's `PostEntityShell` today (`getEntityRecord` loads the parent body, and the minimal BE shell does not surface core's "restore autosave" notice). That restore logic belongs in BE's generic `PostEntityShell` so every consumer benefits, and is out of scope for this community-plugin worktree. Acceptance criterion "closing/reopening restores the latest autosave" should be completed in that BE PR.

Refs #27, #37.