### PR TITLE
feat(profiles): bridge My Shows concert history onto community profile

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -78,6 +78,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-mentions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
+	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/concert-history.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/custom-user-profile.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/verification.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/settings/settings-content.php';

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -370,3 +370,61 @@
     max-width: 100px;
     max-height: 100px;
 }
+
+/* ==================================================
+   Concert History card (My Shows bridge)
+================================================== */
+
+.ec-concert-history-card .ec-concert-stats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+	margin: 0 0 1rem;
+	padding: 0;
+	list-style: none;
+}
+
+.ec-concert-history-card .ec-concert-stats li {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	min-width: 70px;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm);
+	background: var(--card-background);
+}
+
+.ec-concert-history-card .ec-concert-stat-value {
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 1.1;
+}
+
+.ec-concert-history-card .ec-concert-stat-label {
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	opacity: 0.75;
+}
+
+.ec-concert-history-card .ec-concert-history-cta {
+	margin-top: 0.75rem;
+	font-weight: 600;
+}
+
+.ec-concert-history-empty .ec-concert-history-cta,
+.ec-concert-history-empty p {
+	margin-bottom: 0.75rem;
+}
+
+/* Legacy free-text music-fan notes: demoted, lighter weight. */
+.ec-music-fan-details-card .ec-music-fan-nudge {
+	margin-top: 0.75rem;
+	font-size: 0.9rem;
+	opacity: 0.85;
+}
+
+.ec-music-fan-details-card .ec-music-fan-nudge em {
+	opacity: 0.7;
+}

--- a/inc/user-profiles/concert-history.php
+++ b/inc/user-profiles/concert-history.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Concert History Profile Card
+ *
+ * Bridges the My Shows concert-tracking data (events site, blog 7) onto the
+ * bbPress community user profile. Renders real tracked concert history —
+ * total shows, top artists/venues/cities — replacing the dead free-text
+ * `top_concerts` usermeta field as the canonical concert record.
+ *
+ * Data source: the public `extrachill/get-user-concert-stats` ability,
+ * dispatched cross-site to the events site via in-process REST
+ * (ec_cross_site_rest_request). The tracking table is network-scoped, but the
+ * taxonomy enrichment (artist/venue/city names) requires events-site context,
+ * so we always route through the events site.
+ *
+ * Performance: stats are cached per-user in a short transient on the community
+ * site so repeated profile views don't re-dispatch a cross-site request each
+ * time. The cache is invalidated by TTL only (concert history changes rarely).
+ *
+ * @package ExtraChillCommunity
+ * @since 0.x
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Cache TTL for per-user concert stats on the profile (seconds).
+ */
+const EC_CONCERT_HISTORY_CACHE_TTL = 15 * MINUTE_IN_SECONDS;
+
+/**
+ * Fetch a user's aggregate concert stats from the events site.
+ *
+ * Calls the public get-user-concert-stats ability via in-process cross-site
+ * REST dispatch and caches the result in a per-user transient. Returns null
+ * on any failure (missing primitive, cross-site error, malformed payload) so
+ * the caller can silently skip the card without ever breaking the profile.
+ *
+ * @param int $user_id User ID.
+ * @return array|null Stats payload, or null on failure / unavailable.
+ */
+function ec_community_get_concert_stats( int $user_id ): ?array {
+	if ( $user_id <= 0 ) {
+		return null;
+	}
+
+	$cache_key = 'ec_concert_stats_' . $user_id;
+	$cached    = get_transient( $cache_key );
+	if ( false !== $cached ) {
+		// Empty-array sentinel means "fetched, but user has no shows".
+		return is_array( $cached ) ? $cached : null;
+	}
+
+	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
+		return null;
+	}
+
+	$response = ec_cross_site_rest_request(
+		'events',
+		'GET',
+		'/extrachill/v1/concert-tracking/user/' . $user_id . '/stats',
+		array( 'user_id' => $user_id )
+	);
+
+	if ( is_wp_error( $response ) || ! is_array( $response ) ) {
+		// Cache a brief negative result to avoid hammering on every view.
+		set_transient( $cache_key, 'none', MINUTE_IN_SECONDS );
+		return null;
+	}
+
+	set_transient( $cache_key, $response, EC_CONCERT_HISTORY_CACHE_TTL );
+
+	return $response;
+}
+
+/**
+ * Build the My Shows URL for a given user on the events site.
+ *
+ * @param int $user_id User ID.
+ * @return string Absolute URL to the user's concert history, or '' if events
+ *                site URL cannot be resolved.
+ */
+function ec_community_my_shows_url( int $user_id ): string {
+	if ( ! function_exists( 'ec_get_blog_id' ) ) {
+		return '';
+	}
+
+	$events_blog_id = ec_get_blog_id( 'events' );
+	if ( ! $events_blog_id ) {
+		return '';
+	}
+
+	$base = get_home_url( $events_blog_id, '/my-shows/' );
+
+	// Own profile links to the bare page; viewing someone else's appends the
+	// user_id so the My Shows block renders their history.
+	if ( (int) get_current_user_id() === $user_id ) {
+		return $base;
+	}
+
+	return add_query_arg( 'user_id', $user_id, $base );
+}
+
+/**
+ * Render a top-list (artists / venues / cities) as a comma-separated line.
+ *
+ * @param array  $items Each item: array{ name:string, slug:string, count:int }.
+ * @param int    $limit Max items to render.
+ * @return string Escaped HTML, or '' if the list is empty.
+ */
+function ec_community_render_top_list( array $items, int $limit = 5 ): string {
+	if ( empty( $items ) ) {
+		return '';
+	}
+
+	$names = array();
+	foreach ( array_slice( $items, 0, $limit ) as $item ) {
+		if ( empty( $item['name'] ) ) {
+			continue;
+		}
+		$names[] = esc_html( $item['name'] );
+	}
+
+	return implode( ', ', $names );
+}
+
+/**
+ * Display the Concert History card on the bbPress user profile.
+ *
+ * Pulls real tracked shows from the events site and renders an aggregate
+ * summary with a link to the full My Shows history. Skips silently when the
+ * data is unavailable. For a profile owner with zero tracked shows, renders a
+ * soft call-to-action to start their history.
+ */
+function ec_community_display_concert_history() {
+	$user_id = bbp_get_displayed_user_id();
+	if ( ! $user_id ) {
+		return;
+	}
+
+	$is_own = ( (int) get_current_user_id() === (int) $user_id );
+	$stats  = ec_community_get_concert_stats( (int) $user_id );
+
+	$total_shows = is_array( $stats ) && isset( $stats['total_shows'] ) ? (int) $stats['total_shows'] : 0;
+
+	// No tracked shows: show a CTA on the owner's profile, hide for visitors.
+	if ( $total_shows < 1 ) {
+		if ( ! $is_own ) {
+			return;
+		}
+
+		$my_shows_url = ec_community_my_shows_url( (int) $user_id );
+		if ( ! $my_shows_url ) {
+			return;
+		}
+		?>
+		<div class="card ec-concert-history-card ec-concert-history-empty">
+			<div class="card-header">
+				<h3><?php esc_html_e( 'Concert History', 'extra-chill-community' ); ?></h3>
+			</div>
+			<div class="card-body">
+				<p><?php esc_html_e( 'You haven\'t tracked any shows yet. Build your concert history — every show you\'ve been to, in one place.', 'extra-chill-community' ); ?></p>
+				<p><a class="button" href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Start your concert history →', 'extra-chill-community' ); ?></a></p>
+			</div>
+		</div>
+		<?php
+		return;
+	}
+
+	$my_shows_url   = ec_community_my_shows_url( (int) $user_id );
+	$unique_venues  = isset( $stats['unique_venues'] ) ? (int) $stats['unique_venues'] : 0;
+	$unique_artists = isset( $stats['unique_artists'] ) ? (int) $stats['unique_artists'] : 0;
+	$unique_cities  = isset( $stats['unique_cities'] ) ? (int) $stats['unique_cities'] : 0;
+
+	$top_artists = ec_community_render_top_list( $stats['top_artists'] ?? array() );
+	$top_venues  = ec_community_render_top_list( $stats['top_venues'] ?? array() );
+	$top_cities  = ec_community_render_top_list( $stats['top_cities'] ?? array() );
+
+	$heading = $is_own
+		? __( 'My Concert History', 'extra-chill-community' )
+		: __( 'Concert History', 'extra-chill-community' );
+	?>
+	<div class="card ec-concert-history-card">
+		<div class="card-header">
+			<h3><?php echo esc_html( $heading ); ?></h3>
+		</div>
+		<div class="card-body">
+			<ul class="ec-concert-stats">
+				<li>
+					<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $total_shows ) ); ?></span>
+					<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'show', 'shows', $total_shows, 'extra-chill-community' ) ); ?></span>
+				</li>
+				<?php if ( $unique_artists > 0 ) : ?>
+					<li>
+						<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_artists ) ); ?></span>
+						<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'artist', 'artists', $unique_artists, 'extra-chill-community' ) ); ?></span>
+					</li>
+				<?php endif; ?>
+				<?php if ( $unique_venues > 0 ) : ?>
+					<li>
+						<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_venues ) ); ?></span>
+						<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'venue', 'venues', $unique_venues, 'extra-chill-community' ) ); ?></span>
+					</li>
+				<?php endif; ?>
+				<?php if ( $unique_cities > 0 ) : ?>
+					<li>
+						<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_cities ) ); ?></span>
+						<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'city', 'cities', $unique_cities, 'extra-chill-community' ) ); ?></span>
+					</li>
+				<?php endif; ?>
+			</ul>
+
+			<?php if ( $top_artists ) : ?>
+				<p><strong><?php esc_html_e( 'Top Artists:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_artists ); ?></p>
+			<?php endif; ?>
+			<?php if ( $top_venues ) : ?>
+				<p><strong><?php esc_html_e( 'Top Venues:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_venues ); ?></p>
+			<?php endif; ?>
+			<?php if ( $top_cities ) : ?>
+				<p><strong><?php esc_html_e( 'Top Cities:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_cities ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $my_shows_url ) : ?>
+				<p class="ec-concert-history-cta">
+					<a href="<?php echo esc_url( $my_shows_url ); ?>">
+						<?php
+						echo esc_html(
+							$is_own
+								? __( 'View your full concert history →', 'extra-chill-community' )
+								: __( 'View full concert history →', 'extra-chill-community' )
+						);
+						?>
+					</a>
+				</p>
+			<?php endif; ?>
+		</div>
+	</div>
+	<?php
+}
+
+// Render the Concert History card inside the profile body, after the user
+// header card. Priority 5 places it above the legacy "Music Fan Details" card
+// (hooked at priority 20).
+add_action( 'bbp_template_after_user_details', 'ec_community_display_concert_history', 5 );

--- a/inc/user-profiles/custom-user-profile.php
+++ b/inc/user-profiles/custom-user-profile.php
@@ -40,40 +40,74 @@ function display_main_site_post_count_on_profile() {
 	}
 }
 
-// Function to display music fan details
+/**
+ * Display the legacy "Music Fan Details" card.
+ *
+ * Renders the free-text favorite_artists / top_concerts / top_venues usermeta.
+ * This is the pre-My-Shows manual record; it is now demoted below the real
+ * Concert History card (see inc/user-profiles/concert-history.php). When the
+ * profile owner has legacy top_concerts text, a nudge invites them to convert
+ * it into structured tracked shows via My Shows.
+ *
+ * Rendered on `bbp_template_after_user_details` (priority 20) so it appears in
+ * the profile body, below the Concert History card (priority 5). The previous
+ * `bbp_init` hook fired during init and the echoed markup was discarded, so
+ * this card never actually rendered — moving to the template hook fixes that.
+ */
 function display_music_fan_details() {
+	$user_id = bbp_get_displayed_user_id();
+
 	// Music Fan Section variables
-	$favorite_artists = get_user_meta(bbp_get_displayed_user_id(), 'favorite_artists', true);
-	$top_concerts     = get_user_meta(bbp_get_displayed_user_id(), 'top_concerts', true);
-	$top_venues       = get_user_meta(bbp_get_displayed_user_id(), 'top_venues', true);
+	$favorite_artists = get_user_meta( $user_id, 'favorite_artists', true );
+	$top_concerts     = get_user_meta( $user_id, 'top_concerts', true );
+	$top_venues       = get_user_meta( $user_id, 'top_venues', true );
 
-	// Wrap the existing conditional block in a card
-	if ( $favorite_artists || $top_concerts || $top_venues ) :
-		?>
-		<div class="card">
-			<div class="card-header">
-				<h3><?php esc_html_e('Music Fan Details', 'extra-chill-community'); ?></h3>
-			</div>
-			<div class="card-body">
-				<?php if ( $favorite_artists ) : ?>
-					<p><strong><?php esc_html_e('Favorite Artists:', 'extra-chill-community'); ?></strong> <?php echo nl2br(esc_html($favorite_artists)); ?></p>
-				<?php endif; ?>
+	if ( ! ( $favorite_artists || $top_concerts || $top_venues ) ) {
+		return;
+	}
 
-				<?php if ( $top_concerts ) : ?>
-					<p><strong><?php esc_html_e('Top Concerts:', 'extra-chill-community'); ?></strong> <?php echo nl2br(esc_html($top_concerts)); ?></p>
-				<?php endif; ?>
-
-				<?php if ( $top_venues ) : ?>
-					<p><strong><?php esc_html_e('Top Venues:', 'extra-chill-community'); ?></strong> <?php echo nl2br(esc_html($top_venues)); ?></p>
-				<?php endif; ?>
-			</div>
+	$is_own = ( (int) get_current_user_id() === (int) $user_id );
+	?>
+	<div class="card ec-music-fan-details-card">
+		<div class="card-header">
+			<h3><?php esc_html_e( 'Music Fan Details', 'extra-chill-community' ); ?></h3>
 		</div>
-		<?php
-	endif;
+		<div class="card-body">
+			<?php if ( $favorite_artists ) : ?>
+				<p><strong><?php esc_html_e( 'Favorite Artists:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $favorite_artists ) ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $top_concerts ) : ?>
+				<p><strong><?php esc_html_e( 'Top Concerts:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $top_concerts ) ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( $top_venues ) : ?>
+				<p><strong><?php esc_html_e( 'Top Venues:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $top_venues ) ); ?></p>
+			<?php endif; ?>
+
+			<?php
+			// Nudge the owner to convert their free-text concert memories into
+			// structured tracked shows on My Shows.
+			if ( $is_own && $top_concerts && function_exists( 'ec_community_my_shows_url' ) ) :
+				$my_shows_url = ec_community_my_shows_url( (int) $user_id );
+				if ( $my_shows_url ) :
+					?>
+					<p class="ec-music-fan-nudge">
+						<em><?php esc_html_e( 'These are your old free-text notes.', 'extra-chill-community' ); ?></em>
+						<a href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Turn them into your real concert history →', 'extra-chill-community' ); ?></a>
+					</p>
+					<?php
+				endif;
+			endif;
+			?>
+		</div>
+	</div>
+	<?php
 }
 
-// Hook the display functions to run after bbPress is loaded
-add_action('bbp_init', 'display_music_fan_details');
+// Render the legacy Music Fan Details card inside the profile body, below the
+// Concert History card (priority 5). Priority 20 keeps it last.
+add_action( 'bbp_template_after_user_details', 'display_music_fan_details', 20 );
 
 // Load the function after bbPress is fully loaded
 add_action( 'after_setup_theme', 'override_bbp_user_role_after_bbp_load' );

--- a/inc/user-profiles/custom-user-profile.php
+++ b/inc/user-profiles/custom-user-profile.php
@@ -86,15 +86,19 @@ function display_music_fan_details() {
 			<?php endif; ?>
 
 			<?php
-			// Nudge the owner to convert their free-text concert memories into
-			// structured tracked shows on My Shows.
-			if ( $is_own && $top_concerts && function_exists( 'ec_community_my_shows_url' ) ) :
+			// These are legacy free-text notes from before My Shows existed.
+			// We deliberately do NOT promise to "convert" them: the events
+			// catalog is a forward-looking calendar with almost no historic /
+			// out-of-market shows, so searching for these past memories mostly
+			// finds nothing. Instead, invite the owner to start tracking shows
+			// going forward via My Shows — the path that actually works today.
+			if ( $is_own && function_exists( 'ec_community_my_shows_url' ) ) :
 				$my_shows_url = ec_community_my_shows_url( (int) $user_id );
 				if ( $my_shows_url ) :
 					?>
 					<p class="ec-music-fan-nudge">
-						<em><?php esc_html_e( 'These are your old free-text notes.', 'extra-chill-community' ); ?></em>
-						<a href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Turn them into your real concert history →', 'extra-chill-community' ); ?></a>
+						<em><?php esc_html_e( 'These are your personal notes.', 'extra-chill-community' ); ?></em>
+						<a href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Start tracking shows you attend →', 'extra-chill-community' ); ?></a>
 					</p>
 					<?php
 				endif;


### PR DESCRIPTION
## Summary

Bridges the **My Shows** concert-tracking data (events site) onto the **bbPress community user profile**, turning a fully-built-but-disconnected feature into a network engagement surface. This is move #1 of the My Shows ↔ community synergy work.

### Why
- My Shows is a complete engine (tracking, calendar, map, stats, setlist.fm/phish.net import) but adoption is near-zero (**9 tracked shows, 4 users**).
- Meanwhile **27 users** wrote rich free-text concert memories in the legacy `top_concerts` usermeta field — proven demand for exactly this, sitting in the wrong format, read by nothing.
- The community profile and the real tracking data had **no connection**. This wires them together using primitives that already exist.

### What changed
- **New `Concert History` card** (`inc/user-profiles/concert-history.php`): pulls aggregate stats (total shows, unique artists/venues/cities, top lists) from the events site via in-process cross-site REST (`ec_cross_site_rest_request`), cached per-user in a transient. Links to the user's full `/my-shows/` history (own profile → bare page; visitor → `?user_id=`).
- **Empty/owner states**: owner with 0 shows gets a "start your concert history" CTA; visitors viewing an empty profile see nothing; cross-site failures skip the card silently so the profile never breaks.
- **Fixes a latent bug**: both the new card and the legacy `Music Fan Details` card now render on `bbp_template_after_user_details` (the correct profile-body hook). The legacy card was hooked to `bbp_init`, where its echoed markup was discarded — it **never actually rendered** in production. Verified via live profile fetch.
- **Demote + nudge**: the legacy free-text card now renders below Concert History, with an owner-only nudge to convert `top_concerts` notes into structured tracked shows. No data removed.
- Theme-variable-based CSS for the stats row + nudges, appended to the already-enqueued `user-profile.css` (filemtime cache-busted).

### No new infrastructure
Uses only existing primitives — public `get-user-concert-stats` ability, `ec_cross_site_rest_request`, `ec_get_blog_id`. No new data model, no new endpoints. Pure consuming-layer bridge.

## Validation
- `php -l` clean on all changed files.
- `homeboy lint` → `passed: true`, zero findings.
- End-to-end cross-site path tested from community site (blog 2): `ec_cross_site_rest_request('events', ...)` for user 38 returns 6 shows + correct top lists, and blog context restores to 2 afterward.

## Notes
- Conventional-commit message; no version/changelog hand-edits (homeboy owns those).
- Built in DMC worktree `extrachill-community@concert-profile-bridge`.