### PR TITLE
Phase 1A: wire community topics into the canonical location-badge architecture

### DIFF
--- a/bbpress/content-single-topic-lead.php
+++ b/bbpress/content-single-topic-lead.php
@@ -36,6 +36,15 @@ do_action( 'bbp_template_before_lead_topic' ); ?>
 
 				<a href="<?php bbp_topic_permalink(); ?>" class="bbp-topic-permalink">#<?php bbp_topic_id(); ?></a>
 
+				<?php
+				// Render canonical taxonomy badges (location, etc.) via the
+				// theme's single-source-of-truth engine. Guarded so the lead
+				// still works if the theme helper is unavailable.
+				if ( function_exists( 'extrachill_display_taxonomy_badges' ) ) {
+					extrachill_display_taxonomy_badges( bbp_get_topic_id() );
+				}
+				?>
+
 				<?php do_action( 'bbp_theme_before_topic_admin_links' ); ?>
 
 				<?php bbp_topic_admin_links(); ?>

--- a/bbpress/form-topic.php
+++ b/bbpress/form-topic.php
@@ -94,6 +94,45 @@ if ( ! bbp_is_single_forum() ) : ?>
 					<?php endif; ?>
 
 					<?php
+					// Minimal location picker: assign an EXISTING hierarchical
+					// location term so the topic renders the canonical location
+					// badge. Pick-from-existing only (no freeform creation) to
+					// keep the network's curated location tree from drifting.
+					// The full composer term-picker UX is issue #59.
+					if ( taxonomy_exists( 'location' ) ) :
+						$selected_location = 0;
+						if ( bbp_is_topic_edit() ) {
+							$location_terms = get_the_terms( bbp_get_topic_id(), 'location' );
+							if ( ! empty( $location_terms ) && ! is_wp_error( $location_terms ) ) {
+								$selected_location = (int) $location_terms[0]->term_id;
+							}
+						}
+						?>
+
+						<?php do_action( 'bbp_theme_before_topic_form_location' ); ?>
+
+						<p>
+							<label for="bbp_topic_location"><?php esc_html_e( 'Location:', 'extra-chill-community' ); ?></label>
+							<?php
+							wp_dropdown_categories( array(
+								'taxonomy'          => 'location',
+								'name'              => 'bbp_topic_location',
+								'id'                => 'bbp_topic_location',
+								'selected'          => $selected_location,
+								'hierarchical'      => true,
+								'orderby'           => 'name',
+								'hide_empty'        => false,
+								'show_option_none'  => esc_html__( '&mdash; No location &mdash;', 'extra-chill-community' ),
+								'option_none_value' => 0,
+							) );
+							?>
+						</p>
+
+						<?php do_action( 'bbp_theme_after_topic_form_location' ); ?>
+
+					<?php endif; ?>
+
+					<?php
 					// Only show forum dropdown if NOT on a single forum AND NOT on a single artist profile page
 					if ( ! bbp_is_single_forum() && ! is_singular('artist_profile') ) :
 						?>

--- a/bbpress/loop-single-topic-card.php
+++ b/bbpress/loop-single-topic-card.php
@@ -52,7 +52,12 @@ if ( ! $topic_id ) {
 				</div><!-- .bbp-meta-upvote -->
 				<a class="bbp-topic-title" href="<?php echo esc_url( bbp_get_topic_permalink( $topic_id ) ); ?>"><?php echo esc_html( bbp_get_topic_title( $topic_id ) ); ?></a>
 				<?php
-				// Forum name display REMOVED from here
+				// Render canonical taxonomy badges (location, etc.) via the
+				// theme's single-source-of-truth engine. Guarded so the card
+				// still works if the theme helper is unavailable.
+				if ( function_exists( 'extrachill_display_taxonomy_badges' ) ) {
+					extrachill_display_taxonomy_badges( $topic_id );
+				}
 				?>
 			</div><!-- bbp-topic-header-inner -->
 		</div><!-- topic-card-header-area -->

--- a/inc/core/taxonomy-location.php
+++ b/inc/core/taxonomy-location.php
@@ -14,16 +14,67 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Register location taxonomy for forums
+ * Register location taxonomy for forums and topics
  *
  * Hooks at priority 20 to run after theme registers the taxonomy.
+ *
+ * Forums already act as location hubs. Topics gain the network-registered
+ * hierarchical `location` taxonomy so they can carry a location term and
+ * render the canonical location badge via extrachill_display_taxonomy_badges(),
+ * exactly like posts on every other site in the network.
  */
 function extrachill_community_register_location_for_forums() {
 	if ( taxonomy_exists( 'location' ) ) {
 		register_taxonomy_for_object_type( 'location', 'forum' );
+		register_taxonomy_for_object_type( 'location', 'topic' );
 	}
 }
 add_action( 'init', 'extrachill_community_register_location_for_forums', 20 );
+
+/**
+ * Persist a topic's location term on create/edit.
+ *
+ * Reads the optional `bbp_topic_location` field from the submitted topic form
+ * and assigns the matching EXISTING hierarchical location term. Pick-from-
+ * existing only — no freeform term creation, so the network's curated location
+ * tree never drifts. An empty/zero value clears the topic's location.
+ *
+ * bbPress verifies its own form nonce in bbp_new_topic_handler() /
+ * bbp_edit_topic_handler() before firing these actions, so the POST payload is
+ * already authenticated when we read it here.
+ *
+ * @param int $topic_id The topic ID.
+ */
+function extrachill_community_save_topic_location( $topic_id ) {
+	if ( ! taxonomy_exists( 'location' ) ) {
+		return;
+	}
+
+	// Field is optional and absent on programmatic (ability/REST) topic creation.
+	// Nonce is verified upstream by bbp_new_topic_handler() / bbp_edit_topic_handler()
+	// before these actions fire, so re-checking here would be redundant.
+	if ( ! isset( $_POST['bbp_topic_location'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
+		return;
+	}
+
+	$term_id = absint( wp_unslash( $_POST['bbp_topic_location'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
+
+	// Empty selection clears the location.
+	if ( 0 === $term_id ) {
+		wp_set_object_terms( $topic_id, array(), 'location' );
+		return;
+	}
+
+	// Pick-from-existing only: the submitted ID must be a real location term.
+	$term = get_term( $term_id, 'location' );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return;
+	}
+
+	wp_set_object_terms( $topic_id, array( $term->term_id ), 'location' );
+}
+add_action( 'bbp_new_topic', 'extrachill_community_save_topic_location', 20 );
+add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_location', 20 );
 
 /**
  * Redirect location archives to the corresponding forum


### PR DESCRIPTION
Closes #57. Child of #53 (Phase 1, part A). **Additive, low-risk — no data moves, no redirects, no forum consolidation.**

## What this does
Brings the community forum into the **same taxonomy-badge architecture every other site in the network already uses**, so topics can carry the hierarchical `location` term and render the canonical badge — exactly like posts on blog/events/wire/etc.

## What was registered
- `location` (the network-registered, hierarchical taxonomy) is now registered for the **`topic`** post type, mirroring the existing **`forum`** registration in `inc/core/taxonomy-location.php` (same `init` priority-20 hook, same `taxonomy_exists()` guard). `get_object_taxonomies('topic')` now includes `location`.

## Where badges now render
Both insertion points call the theme's single-source-of-truth engine `extrachill_display_taxonomy_badges()`, guarded with `function_exists()`:
- `bbpress/loop-single-topic-card.php` — topic cards in lists/feeds (next to the title).
- `bbpress/content-single-topic-lead.php` — single-topic header meta row.

## Reuses the canonical engine — no new engine, no forked CSS
- Badge rendering goes entirely through the theme's `extrachill_display_taxonomy_badges( $topic_id )` — the documented "single source of truth for ALL taxonomy badges." No badge HTML/markup is reinvented here.
- **No CSS changes.** The theme already enqueues `extrachill-taxonomy-badges` **unconditionally on every front-end page** (`wp_enqueue_scripts`, `inc/core/assets.php`), so the badge colors are already loaded in all bbPress/community contexts. Nothing to add.

## How assignment was kept minimal
- A single **pick-from-existing** `location` select was added to the topic create/edit form (`bbpress/form-topic.php`) via `wp_dropdown_categories()` (hierarchical, `show_option_none`). **No freeform term creation** — you can only pick an existing network location term, so the curated location tree never drifts. Location is optional.
- A save handler (`extrachill_community_save_topic_location()`) hooks `bbp_new_topic` / `bbp_edit_topic`, validates the submitted ID against an existing `location` term, and sets/clears it. bbPress verifies its own form nonce before firing those actions, so the handler reads the field safely (documented with a scoped `phpcs:ignore`).

This is intentionally just enough to test and demonstrate badges. The full user-facing composer term-picker UX is **#59** and is not built here.

## Explicitly deferred (non-goals)
- **#58** — killing/merging geographic forums, moving existing topics into a Scenes room, permalink redirects, backfilling location terms onto existing topics.
- **#59** — the full composer tagging UX.

## Verification
- `php -l` clean on all four touched files.
- `homeboy lint --changed-since HEAD`: all findings introduced by this change resolved. The 2 remaining findings (`WordPress.WP.Capabilities.Unknown` for the `moderate` cap) are **pre-existing bbPress patterns** on lines this PR only shifted — confirmed present in `HEAD`.
- No JS/CSS touched, so no `npm run build` needed.
- Manual reasoning: a topic with a `location` term renders the location badge in both the card and single view via the same engine/colors as other sites, and the badge links to the `location` archive (cross-site-aware through the engine).