### PR TITLE
Composer term-picker: curated network taxonomy tagging (location-first)

### DIFF
--- a/bbpress/form-topic.php
+++ b/bbpress/form-topic.php
@@ -94,43 +94,19 @@ if ( ! bbp_is_single_forum() ) : ?>
 					<?php endif; ?>
 
 					<?php
-					// Minimal location picker: assign an EXISTING hierarchical
-					// location term so the topic renders the canonical location
-					// badge. Pick-from-existing only (no freeform creation) to
-					// keep the network's curated location tree from drifting.
-					// The full composer term-picker UX is issue #59.
-					if ( taxonomy_exists( 'location' ) ) :
-						$selected_location = 0;
-						if ( bbp_is_topic_edit() ) {
-							$location_terms = get_the_terms( bbp_get_topic_id(), 'location' );
-							if ( ! empty( $location_terms ) && ! is_wp_error( $location_terms ) ) {
-								$selected_location = (int) $location_terms[0]->term_id;
-							}
-						}
-						?>
+					// Composer term-picker (issue #59): curated, pick-from-
+					// existing taxonomy tagging. The React picker mounts via the
+					// bbp_theme_before_topic_form_location action
+					// (extrachill_community_render_term_picker_mounts) and submits
+					// the chosen EXISTING term IDs as bbp_topic_location[]. No
+					// freeform creation, so the network's curated taxonomy tree
+					// never drifts. Hooks preserved so plugins can still target
+					// this slot; the minimal #57 <select> it supersedes is gone.
+					?>
 
-						<?php do_action( 'bbp_theme_before_topic_form_location' ); ?>
+					<?php do_action( 'bbp_theme_before_topic_form_location' ); ?>
 
-						<p>
-							<label for="bbp_topic_location"><?php esc_html_e( 'Location:', 'extra-chill-community' ); ?></label>
-							<?php
-							wp_dropdown_categories( array(
-								'taxonomy'          => 'location',
-								'name'              => 'bbp_topic_location',
-								'id'                => 'bbp_topic_location',
-								'selected'          => $selected_location,
-								'hierarchical'      => true,
-								'orderby'           => 'name',
-								'hide_empty'        => false,
-								'show_option_none'  => esc_html__( '&mdash; No location &mdash;', 'extra-chill-community' ),
-								'option_none_value' => 0,
-							) );
-							?>
-						</p>
-
-						<?php do_action( 'bbp_theme_after_topic_form_location' ); ?>
-
-					<?php endif; ?>
+					<?php do_action( 'bbp_theme_after_topic_form_location' ); ?>
 
 					<?php
 					// Only show forum dropdown if NOT on a single forum AND NOT on a single artist profile page

--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -51,6 +51,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/drafts.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/edit-autosave.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/composer-term-picker.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/ability-helpers.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/infrastructure-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-abilities.php';

--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Composer Term-Picker
+ *
+ * Curated, pick-from-existing taxonomy tagging for the bbPress topic composer.
+ *
+ * Users tag their post with EXISTING curated network taxonomy terms (location
+ * today; artist/festival/venue later) via an autocomplete React picker. The
+ * picker searches terms through the WP REST API (NO AJAX, per the system-wide
+ * rule) and submits the chosen term IDs as a hidden `${field}[]` array that the
+ * server-side save handler assigns on bbp_new_topic / bbp_edit_topic.
+ *
+ * Curated only: the picker NEVER creates terms. Typing a non-matching string
+ * mints nothing, so the network's shared taxonomy tree never drifts.
+ *
+ * Taxonomy-parameterized: the picker is driven by a config array (one entry per
+ * taxonomy). Enabling artist/festival/venue later is a config addition here, not
+ * a new component — build location only now, leave the seam.
+ *
+ * @package ExtraChillCommunity
+ * @since 1.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Taxonomies the composer term-picker offers, in render order.
+ *
+ * Location-only today. To add artist/festival/venue later, append entries here
+ * (and ensure each taxonomy is registered for `topic` and REST-enabled). No
+ * React change required.
+ *
+ * Each entry:
+ * - taxonomy     Taxonomy slug.
+ * - rest_base    REST base for /wp/v2/<rest_base> term search.
+ * - label        Visible field label.
+ * - placeholder  Search input placeholder.
+ * - field        POST field name; values submit as `${field}[]`.
+ *
+ * @return array<int,array<string,string>> Taxonomy picker config.
+ */
+function extrachill_community_term_picker_taxonomies() {
+	$taxonomies = array(
+		array(
+			'taxonomy'    => 'location',
+			'rest_base'   => 'location',
+			'label'       => __( 'Location', 'extra-chill-community' ),
+			'placeholder' => __( 'Search locations (e.g. Charleston)…', 'extra-chill-community' ),
+			'field'       => 'bbp_topic_location',
+		),
+	);
+
+	/**
+	 * Filter the taxonomies offered by the composer term-picker.
+	 *
+	 * This is the generalization seam: artist/festival/venue can be enabled
+	 * later purely by extending this config (each must be registered for the
+	 * `topic` post type and REST-enabled).
+	 *
+	 * @param array $taxonomies Taxonomy picker config.
+	 */
+	return apply_filters( 'extrachill_community_term_picker_taxonomies', $taxonomies );
+}
+
+/**
+ * Build the localized config the React picker consumes.
+ *
+ * Filters out taxonomies that are not actually registered/REST-enabled, and
+ * seeds each taxonomy's `selected` terms when editing an existing topic.
+ *
+ * @param int $topic_id Topic ID (0 on the create flow).
+ * @return array<string,mixed> Localizable config.
+ */
+function extrachill_community_term_picker_config( $topic_id = 0 ) {
+	$taxonomies = array();
+
+	foreach ( extrachill_community_term_picker_taxonomies() as $entry ) {
+		$taxonomy = $entry['taxonomy'];
+
+		$tax_object = get_taxonomy( $taxonomy );
+		if ( ! $tax_object || empty( $tax_object->show_in_rest ) ) {
+			continue;
+		}
+
+		$selected = array();
+		if ( $topic_id > 0 ) {
+			$terms = get_the_terms( $topic_id, $taxonomy );
+			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $term ) {
+					$selected[] = array(
+						'id'     => (int) $term->term_id,
+						'name'   => $term->name,
+						'parent' => (int) $term->parent,
+					);
+				}
+			}
+		}
+
+		$rest_base = ! empty( $tax_object->rest_base ) ? $tax_object->rest_base : $taxonomy;
+
+		$taxonomies[] = array(
+			'taxonomy'     => $taxonomy,
+			'restBase'     => $rest_base,
+			'label'        => $entry['label'],
+			'placeholder'  => $entry['placeholder'],
+			'hierarchical' => (bool) $tax_object->hierarchical,
+			'field'        => $entry['field'],
+			'selected'     => $selected,
+		);
+	}
+
+	return array(
+		'restUrl'    => esc_url_raw( rest_url() ),
+		'restNonce'  => wp_create_nonce( 'wp_rest' ),
+		'taxonomies' => $taxonomies,
+	);
+}
+
+/**
+ * Enqueue the term-picker script + style on the bbPress topic composer.
+ *
+ * Guarded to bbPress contexts where the topic form renders (single forum,
+ * topic edit, or the homepage New Topic modal). Uses the wp-scripts build
+ * artifact and its generated dependency manifest.
+ */
+function extrachill_community_enqueue_term_picker() {
+	if ( ! function_exists( 'is_bbpress' ) ) {
+		return;
+	}
+
+	// Only where the create/edit topic form can appear.
+	$is_topic_form_context = is_bbpress() || is_front_page();
+	if ( ! $is_topic_form_context ) {
+		return;
+	}
+
+	$config = extrachill_community_term_picker_config(
+		( function_exists( 'bbp_is_topic_edit' ) && bbp_is_topic_edit() ) ? bbp_get_topic_id() : 0
+	);
+
+	// Nothing to render if no taxonomy resolved.
+	if ( empty( $config['taxonomies'] ) ) {
+		return;
+	}
+
+	$script_rel = 'build/term-picker.js';
+	// wp-scripts emits JS-imported styles with a `style-` prefix.
+	$style_rel = 'build/style-term-picker.css';
+	$asset_rel = 'build/term-picker.asset.php';
+
+	$script_path = EXTRACHILL_COMMUNITY_PLUGIN_DIR . $script_rel;
+	$asset_path  = EXTRACHILL_COMMUNITY_PLUGIN_DIR . $asset_rel;
+
+	if ( ! file_exists( $script_path ) ) {
+		return;
+	}
+
+	$asset = file_exists( $asset_path )
+		? require $asset_path
+		: array(
+			'dependencies' => array(),
+			'version'      => EXTRACHILL_COMMUNITY_VERSION,
+		);
+
+	wp_enqueue_script(
+		'extrachill-community-term-picker',
+		EXTRACHILL_COMMUNITY_PLUGIN_URL . $script_rel,
+		$asset['dependencies'],
+		$asset['version'],
+		true
+	);
+
+	wp_localize_script( 'extrachill-community-term-picker', 'extrachillTermPicker', $config );
+
+	$style_path = EXTRACHILL_COMMUNITY_PLUGIN_DIR . $style_rel;
+	if ( file_exists( $style_path ) ) {
+		wp_enqueue_style(
+			'extrachill-community-term-picker',
+			EXTRACHILL_COMMUNITY_PLUGIN_URL . $style_rel,
+			array(),
+			filemtime( $style_path )
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_community_enqueue_term_picker', 20 );
+
+/**
+ * Render the term-picker mount points inside the topic form.
+ *
+ * One mount div per configured taxonomy; React hydrates each. Output replaces
+ * the minimal #57 location <select> (the save handler is generalized to read
+ * the picker's array field). Hooked on the same location-form action #57 left
+ * in form-topic.php so the picker drops into the established slot.
+ */
+function extrachill_community_render_term_picker_mounts() {
+	foreach ( extrachill_community_term_picker_taxonomies() as $entry ) {
+		$tax_object = get_taxonomy( $entry['taxonomy'] );
+		if ( ! $tax_object || empty( $tax_object->show_in_rest ) ) {
+			continue;
+		}
+
+		printf(
+			'<div class="ec-term-picker-mount" data-taxonomy="%s"></div>',
+			esc_attr( $entry['taxonomy'] )
+		);
+	}
+}
+add_action( 'bbp_theme_before_topic_form_location', 'extrachill_community_render_term_picker_mounts' );

--- a/inc/core/taxonomy-location.php
+++ b/inc/core/taxonomy-location.php
@@ -32,12 +32,18 @@ function extrachill_community_register_location_for_forums() {
 add_action( 'init', 'extrachill_community_register_location_for_forums', 20 );
 
 /**
- * Persist a topic's location term on create/edit.
+ * Persist a topic's location term(s) on create/edit.
  *
- * Reads the optional `bbp_topic_location` field from the submitted topic form
- * and assigns the matching EXISTING hierarchical location term. Pick-from-
- * existing only — no freeform term creation, so the network's curated location
- * tree never drifts. An empty/zero value clears the topic's location.
+ * Reads the composer term-picker's `bbp_topic_location[]` array from the
+ * submitted topic form and assigns the matching EXISTING hierarchical location
+ * terms. Pick-from-existing only — every submitted ID is validated against a
+ * real location term, so no freeform creation and the network's curated
+ * location tree never drifts. Selecting nothing clears the topic's location.
+ *
+ * The picker submits a `bbp_topic_location_submitted` marker so we can tell a
+ * "no terms chosen, clear it" submit apart from a programmatic (ability/REST)
+ * topic creation where the field is absent entirely. A legacy scalar
+ * `bbp_topic_location` value is still honored for backward compatibility.
  *
  * bbPress verifies its own form nonce in bbp_new_topic_handler() /
  * bbp_edit_topic_handler() before firing these actions, so the POST payload is
@@ -50,28 +56,35 @@ function extrachill_community_save_topic_location( $topic_id ) {
 		return;
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
+
+	$has_picker = isset( $_POST['bbp_topic_location_submitted'] );
+	$has_legacy = isset( $_POST['bbp_topic_location'] );
+
 	// Field is optional and absent on programmatic (ability/REST) topic creation.
-	// Nonce is verified upstream by bbp_new_topic_handler() / bbp_edit_topic_handler()
-	// before these actions fire, so re-checking here would be redundant.
-	if ( ! isset( $_POST['bbp_topic_location'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
+	if ( ! $has_picker && ! $has_legacy ) {
 		return;
 	}
 
-	$term_id = absint( wp_unslash( $_POST['bbp_topic_location'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
-
-	// Empty selection clears the location.
-	if ( 0 === $term_id ) {
-		wp_set_object_terms( $topic_id, array(), 'location' );
-		return;
+	$submitted = array();
+	if ( isset( $_POST['bbp_topic_location'] ) ) {
+		$raw       = wp_unslash( $_POST['bbp_topic_location'] );
+		$submitted = is_array( $raw ) ? array_map( 'absint', $raw ) : array( absint( $raw ) );
 	}
 
-	// Pick-from-existing only: the submitted ID must be a real location term.
-	$term = get_term( $term_id, 'location' );
-	if ( ! $term || is_wp_error( $term ) ) {
-		return;
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+	// Pick-from-existing only: keep only IDs that resolve to real location terms.
+	$term_ids = array();
+	foreach ( array_unique( array_filter( $submitted ) ) as $term_id ) {
+		$term = get_term( $term_id, 'location' );
+		if ( $term && ! is_wp_error( $term ) ) {
+			$term_ids[] = (int) $term->term_id;
+		}
 	}
 
-	wp_set_object_terms( $topic_id, array( $term->term_id ), 'location' );
+	// Empty (or all-invalid) selection clears the location.
+	wp_set_object_terms( $topic_id, $term_ids, 'location' );
 }
 add_action( 'bbp_new_topic', 'extrachill_community_save_topic_location', 20 );
 add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_location', 20 );

--- a/src/term-picker/TermPicker.tsx
+++ b/src/term-picker/TermPicker.tsx
@@ -1,0 +1,383 @@
+/**
+ * Composer term-picker — curated, pick-from-existing, no freeform creation.
+ *
+ * Autocompletes against EXISTING curated network taxonomy terms via the WP
+ * REST API (NO AJAX, per the system-wide rule). Users select terms as chips;
+ * the picker writes hidden inputs (`${field}[]`) that the bbPress save handler
+ * reads on submit. Typing a non-matching string creates NOTHING — the network's
+ * curated taxonomy tree never drifts from the composer.
+ *
+ * The component is taxonomy-parameterized via TaxonomyConfig, so location today
+ * and artist/festival/venue later share one implementation.
+ */
+
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
+import type { TaxonomyConfig, Term } from './types';
+
+const SEARCH_DEBOUNCE_MS = 250;
+const MAX_SUGGESTIONS = 10;
+
+interface TermPickerProps {
+	config: TaxonomyConfig;
+}
+
+/**
+ * Build the REST search path for a taxonomy. Read-only: search only, the
+ * picker never hits a write verb on this endpoint.
+ * @param restBase
+ * @param search
+ */
+function buildSearchPath( restBase: string, search: string ): string {
+	const params = new URLSearchParams( {
+		search,
+		per_page: String( MAX_SUGGESTIONS ),
+		_fields: 'id,name,parent',
+		orderby: 'count',
+		order: 'desc',
+	} );
+	return `/wp/v2/${ restBase }?${ params.toString() }`;
+}
+
+export function TermPicker( { config }: TermPickerProps ) {
+	const {
+		taxonomy,
+		restBase,
+		label,
+		placeholder,
+		hierarchical,
+		field,
+		selected: initialSelected,
+	} = config;
+
+	const [ query, setQuery ] = useState( '' );
+	const [ suggestions, setSuggestions ] = useState< Term[] >( [] );
+	const [ selected, setSelected ] = useState< Term[] >( initialSelected );
+	const [ loading, setLoading ] = useState( false );
+	const [ open, setOpen ] = useState( false );
+	const [ activeIndex, setActiveIndex ] = useState( -1 );
+
+	const wrapperRef = useRef< HTMLDivElement | null >( null );
+	const debounceRef = useRef< ReturnType< typeof setTimeout > | null >(
+		null
+	);
+	// Parent-id -> name cache so hierarchical suggestions can show "Term, Parent".
+	const parentNameCache = useRef< Map< number, string > >( new Map() );
+
+	const selectedIds = useMemo(
+		() => new Set( selected.map( ( t ) => t.id ) ),
+		[ selected ]
+	);
+
+	/**
+	 * Resolve parent names for hierarchical context (e.g. "Charleston, South
+	 * Carolina"). Read-only REST lookups, cached to avoid repeat fetches.
+	 */
+	const resolveParentNames = useCallback(
+		async ( terms: Term[] ) => {
+			if ( ! hierarchical ) {
+				return;
+			}
+			const missing = Array.from(
+				new Set(
+					terms
+						.map( ( t ) => t.parent )
+						.filter(
+							( id ) =>
+								id > 0 && ! parentNameCache.current.has( id )
+						)
+				)
+			);
+			if ( missing.length === 0 ) {
+				return;
+			}
+			const params = new URLSearchParams( {
+				include: missing.join( ',' ),
+				per_page: String( missing.length ),
+				_fields: 'id,name',
+			} );
+			try {
+				const parents = await apiFetch<
+					Array< { id: number; name: string } >
+				>( {
+					path: `/wp/v2/${ restBase }?${ params.toString() }`,
+				} );
+				parents.forEach( ( p ) =>
+					parentNameCache.current.set( p.id, p.name )
+				);
+				// Force a re-render so freshly resolved parent names appear.
+				setSuggestions( ( prev ) => [ ...prev ] );
+			} catch {
+				// Non-fatal: suggestions still render without parent context.
+			}
+		},
+		[ hierarchical, restBase ]
+	);
+
+	// Debounced REST search against existing terms.
+	useEffect( () => {
+		if ( debounceRef.current ) {
+			clearTimeout( debounceRef.current );
+		}
+
+		const trimmed = query.trim();
+		if ( trimmed.length < 1 ) {
+			setSuggestions( [] );
+			setLoading( false );
+			return;
+		}
+
+		setLoading( true );
+		debounceRef.current = setTimeout( () => {
+			apiFetch< Term[] >( { path: buildSearchPath( restBase, trimmed ) } )
+				.then( ( results ) => {
+					setSuggestions( results );
+					setActiveIndex( results.length > 0 ? 0 : -1 );
+					void resolveParentNames( results );
+				} )
+				.catch( () => {
+					setSuggestions( [] );
+					setActiveIndex( -1 );
+				} )
+				.finally( () => setLoading( false ) );
+		}, SEARCH_DEBOUNCE_MS );
+
+		return () => {
+			if ( debounceRef.current ) {
+				clearTimeout( debounceRef.current );
+			}
+		};
+	}, [ query, restBase, resolveParentNames ] );
+
+	// Close the suggestion list on outside click.
+	useEffect( () => {
+		function onDocClick( event: MouseEvent ) {
+			if (
+				wrapperRef.current &&
+				! wrapperRef.current.contains( event.target as Node )
+			) {
+				setOpen( false );
+			}
+		}
+		document.addEventListener( 'mousedown', onDocClick );
+		return () => document.removeEventListener( 'mousedown', onDocClick );
+	}, [] );
+
+	const termLabel = useCallback(
+		( term: Term ): string => {
+			if ( hierarchical && term.parent > 0 ) {
+				const parentName = parentNameCache.current.get( term.parent );
+				if ( parentName ) {
+					return `${ term.name }, ${ parentName }`;
+				}
+			}
+			return term.name;
+		},
+		[ hierarchical ]
+	);
+
+	const addTerm = useCallback( ( term: Term ) => {
+		setSelected( ( prev ) =>
+			prev.some( ( t ) => t.id === term.id ) ? prev : [ ...prev, term ]
+		);
+		setQuery( '' );
+		setSuggestions( [] );
+		setActiveIndex( -1 );
+		setOpen( false );
+	}, [] );
+
+	const removeTerm = useCallback( ( id: number ) => {
+		setSelected( ( prev ) => prev.filter( ( t ) => t.id !== id ) );
+	}, [] );
+
+	const visibleSuggestions = useMemo(
+		() => suggestions.filter( ( t ) => ! selectedIds.has( t.id ) ),
+		[ suggestions, selectedIds ]
+	);
+
+	const onKeyDown = useCallback(
+		( event: React.KeyboardEvent< HTMLInputElement > ) => {
+			if ( ! open || visibleSuggestions.length === 0 ) {
+				if ( event.key === 'ArrowDown' && query.trim().length > 0 ) {
+					setOpen( true );
+				}
+				return;
+			}
+			switch ( event.key ) {
+				case 'ArrowDown':
+					event.preventDefault();
+					setActiveIndex(
+						( i ) => ( i + 1 ) % visibleSuggestions.length
+					);
+					break;
+				case 'ArrowUp':
+					event.preventDefault();
+					setActiveIndex(
+						( i ) =>
+							( i - 1 + visibleSuggestions.length ) %
+							visibleSuggestions.length
+					);
+					break;
+				case 'Enter':
+					// Only commit an existing suggestion. Never mint a new term
+					// from free text — curated taxonomy, pick-from-existing only.
+					if (
+						activeIndex >= 0 &&
+						activeIndex < visibleSuggestions.length
+					) {
+						event.preventDefault();
+						addTerm( visibleSuggestions[ activeIndex ] );
+					}
+					break;
+				case 'Escape':
+					setOpen( false );
+					break;
+			}
+		},
+		[ open, visibleSuggestions, activeIndex, addTerm, query ]
+	);
+
+	const listboxId = `ec-term-picker-listbox-${ taxonomy }`;
+	const inputId = `ec-term-picker-input-${ taxonomy }`;
+
+	return (
+		<div
+			className="ec-term-picker"
+			ref={ wrapperRef }
+			data-taxonomy={ taxonomy }
+		>
+			{ /* Hidden inputs the bbPress save handler reads on submit. An empty
+			     marker guarantees the field is present even with zero selections
+			     so the server can clear the relationship. */ }
+			<input type="hidden" name={ `${ field }_submitted` } value="1" />
+			{ selected.map( ( term ) => (
+				<input
+					key={ term.id }
+					type="hidden"
+					name={ `${ field }[]` }
+					value={ term.id }
+				/>
+			) ) }
+
+			<label className="ec-term-picker__label" htmlFor={ inputId }>
+				{ label }
+			</label>
+
+			{ selected.length > 0 && (
+				<ul
+					className="ec-term-picker__chips"
+					aria-label={ sprintf(
+						/* translators: %s: taxonomy label, e.g. Location */
+						__( 'Selected %s terms', 'extra-chill-community' ),
+						label
+					) }
+				>
+					{ selected.map( ( term ) => (
+						<li key={ term.id } className="ec-term-picker__chip">
+							<span className="ec-term-picker__chip-label">
+								{ termLabel( term ) }
+							</span>
+							<button
+								type="button"
+								className="ec-term-picker__chip-remove"
+								aria-label={ sprintf(
+									/* translators: %s: term name */
+									__( 'Remove %s', 'extra-chill-community' ),
+									term.name
+								) }
+								onClick={ () => removeTerm( term.id ) }
+							>
+								&times;
+							</button>
+						</li>
+					) ) }
+				</ul>
+			) }
+
+			<div className="ec-term-picker__control">
+				<input
+					id={ inputId }
+					type="text"
+					className="ec-term-picker__input"
+					value={ query }
+					placeholder={ placeholder }
+					autoComplete="off"
+					role="combobox"
+					aria-expanded={ open && visibleSuggestions.length > 0 }
+					aria-controls={ listboxId }
+					aria-autocomplete="list"
+					onChange={ ( e ) => {
+						setQuery( e.target.value );
+						setOpen( true );
+					} }
+					onFocus={ () => {
+						if ( query.trim().length > 0 ) {
+							setOpen( true );
+						}
+					} }
+					onKeyDown={ onKeyDown }
+				/>
+
+				{ open && query.trim().length > 0 && (
+					<ul
+						id={ listboxId }
+						className="ec-term-picker__suggestions"
+						role="listbox"
+					>
+						{ loading && (
+							<li
+								className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
+								aria-disabled="true"
+							>
+								{ __( 'Searching…', 'extra-chill-community' ) }
+							</li>
+						) }
+						{ ! loading && visibleSuggestions.length === 0 && (
+							<li
+								className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
+								aria-disabled="true"
+							>
+								{ __(
+									'No matching terms. You can only pick from existing terms.',
+									'extra-chill-community'
+								) }
+							</li>
+						) }
+						{ ! loading &&
+							visibleSuggestions.map( ( term, index ) => (
+								<li
+									key={ term.id }
+									id={ `${ listboxId }-option-${ term.id }` }
+									className={
+										'ec-term-picker__suggestion' +
+										( index === activeIndex
+											? ' is-active'
+											: '' )
+									}
+									role="option"
+									aria-selected={ index === activeIndex }
+									onMouseEnter={ () =>
+										setActiveIndex( index )
+									}
+									onMouseDown={ ( e ) => {
+										// mousedown (not click) so it fires before input blur.
+										e.preventDefault();
+										addTerm( term );
+									} }
+								>
+									{ termLabel( term ) }
+								</li>
+							) ) }
+					</ul>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/src/term-picker/index.tsx
+++ b/src/term-picker/index.tsx
@@ -1,0 +1,62 @@
+/**
+ * Composer term-picker entry.
+ *
+ * Mounts a TermPicker into the bbPress topic form for each configured
+ * taxonomy. Config is injected via wp_localize_script as
+ * `window.extrachillTermPicker`. Location is the only taxonomy wired today;
+ * artist / festival / venue plug in later by extending the localized
+ * `taxonomies` array — no code change here.
+ */
+
+import { createRoot } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { TermPicker } from './TermPicker';
+import type { TermPickerConfig } from './types';
+import './style.scss';
+
+const MOUNT_SELECTOR = '.ec-term-picker-mount';
+
+function init(): void {
+	const config: TermPickerConfig | undefined = window.extrachillTermPicker;
+	if (
+		! config ||
+		! Array.isArray( config.taxonomies ) ||
+		config.taxonomies.length === 0
+	) {
+		return;
+	}
+
+	// Authenticate REST requests as the logged-in user (cookie + nonce).
+	if ( config.restNonce ) {
+		apiFetch.use( apiFetch.createNonceMiddleware( config.restNonce ) );
+	}
+	if ( config.restUrl ) {
+		apiFetch.use( apiFetch.createRootURLMiddleware( config.restUrl ) );
+	}
+
+	const mounts = document.querySelectorAll< HTMLElement >( MOUNT_SELECTOR );
+	mounts.forEach( ( mount ) => {
+		if ( mount.dataset.initialized === '1' ) {
+			return;
+		}
+		mount.dataset.initialized = '1';
+
+		const taxonomySlug = mount.dataset.taxonomy;
+		const taxonomyConfig = taxonomySlug
+			? config.taxonomies.find( ( t ) => t.taxonomy === taxonomySlug )
+			: config.taxonomies[ 0 ];
+
+		if ( ! taxonomyConfig ) {
+			return;
+		}
+
+		const root = createRoot( mount );
+		root.render( <TermPicker config={ taxonomyConfig } /> );
+	} );
+}
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', init );
+} else {
+	init();
+}

--- a/src/term-picker/style.scss
+++ b/src/term-picker/style.scss
@@ -1,0 +1,99 @@
+/**
+ * Composer term-picker styles.
+ *
+ * Uses the Extra Chill theme design tokens (CSS custom properties from the
+ * theme's generated root.css) — no hard-coded colors, no !important.
+ */
+
+.ec-term-picker {
+	margin-bottom: var( --spacing-md, 16px );
+
+	&__label {
+		display: block;
+		margin-bottom: var( --spacing-xs, 4px );
+		font-weight: 600;
+	}
+
+	&__chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var( --spacing-xs, 4px );
+		margin: 0 0 var( --spacing-sm, 8px );
+		padding: 0;
+		list-style: none;
+	}
+
+	&__chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var( --spacing-xs, 4px );
+		padding: 2px var( --spacing-sm, 8px );
+		background: var( --card-background, #f2f2f2 );
+		border: 1px solid var( --border-color, #ccc );
+		border-radius: var( --border-radius-pill, 999px );
+		font-size: var( --font-size-sm, 0.85rem );
+		line-height: 1.5;
+	}
+
+	&__chip-remove {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.25em;
+		height: 1.25em;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: var( --muted-text, #666 );
+		font-size: 1.1em;
+		line-height: 1;
+		cursor: pointer;
+
+		&:hover,
+		&:focus {
+			color: var( --error-color, #c00 );
+		}
+	}
+
+	&__control {
+		position: relative;
+	}
+
+	&__input {
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	&__suggestions {
+		position: absolute;
+		z-index: 20;
+		top: 100%;
+		left: 0;
+		right: 0;
+		margin: 2px 0 0;
+		padding: 0;
+		max-height: 240px;
+		overflow-y: auto;
+		list-style: none;
+		background: var( --background-color, #fff );
+		border: 1px solid var( --border-color, #ccc );
+		border-radius: var( --border-radius-sm, 4px );
+		box-shadow: 0 4px 12px rgba( 0, 0, 0, 0.12 );
+	}
+
+	&__suggestion {
+		padding: var( --spacing-xs, 4px ) var( --spacing-sm, 8px );
+		cursor: pointer;
+		line-height: 1.4;
+
+		&.is-active {
+			background: var( --card-background, #eee );
+		}
+
+		&--status {
+			color: var( --muted-text, #666 );
+			cursor: default;
+			font-style: italic;
+		}
+	}
+}

--- a/src/term-picker/types.ts
+++ b/src/term-picker/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared types for the composer term-picker.
+ *
+ * The picker is taxonomy-PARAMETERIZED: location is the only taxonomy wired
+ * today, but artist / festival / venue can be enabled later purely by adding
+ * entries to the localized `taxonomies` config — no new component per taxonomy.
+ */
+
+/**
+ * A single curated network term as returned by the WP REST taxonomy endpoint
+ * (e.g. GET /wp/v2/location?search=...). Users may only SELECT these; the
+ * picker never creates new terms.
+ */
+export interface Term {
+	id: number;
+	name: string;
+	parent: number;
+}
+
+/**
+ * Per-taxonomy configuration. One entry per taxonomy the picker offers.
+ *
+ * `restBase` is the taxonomy's REST base (location -> /wp/v2/location). The
+ * picker is read-only against that endpoint: it searches existing terms, it
+ * never POSTs new ones.
+ */
+export interface TaxonomyConfig {
+	/** Taxonomy slug, e.g. "location". */
+	taxonomy: string;
+	/** REST base used to build the search URL, e.g. "location". */
+	restBase: string;
+	/** Visible field label, e.g. "Location". */
+	label: string;
+	/** Placeholder shown in the search input. */
+	placeholder: string;
+	/** Hierarchical taxonomies show parent context in suggestions. */
+	hierarchical: boolean;
+	/**
+	 * Name of the POST field the bbPress save handler reads. Values are
+	 * submitted as `${field}[]` so the server can assign multiple terms.
+	 */
+	field: string;
+	/** Pre-selected terms (topic edit flow) used to seed the chips. */
+	selected: Term[];
+}
+
+/**
+ * Localized config injected via wp_localize_script as `extrachillTermPicker`.
+ */
+export interface TermPickerConfig {
+	restUrl: string;
+	restNonce: string;
+	taxonomies: TaxonomyConfig[];
+}
+
+declare global {
+	interface Window {
+		extrachillTermPicker?: TermPickerConfig;
+	}
+}

--- a/src/types/externals.d.ts
+++ b/src/types/externals.d.ts
@@ -1,1 +1,2 @@
 declare module '@extrachill/components/styles/components.scss';
+declare module '*.scss';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,30 @@
 /**
  * Custom webpack extends @wordpress/scripts defaults.
  *
- * Disables strict ESM resolution for .mjs files so that
- * @extrachill/tokens (and similar packages) can import
- * internal modules without explicit extensions.
+ * - Disables strict ESM resolution for .mjs files so that
+ *   @extrachill/tokens (and similar packages) can import
+ *   internal modules without explicit extensions.
+ * - Adds the standalone composer term-picker entry (not a block — it mounts
+ *   into the server-rendered bbPress topic form) alongside the default
+ *   block.json-discovered entries.
  */
+const path = require( 'path' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+
+// wp-scripts exposes `entry` as a function that discovers block entries.
+const defaultEntry = defaultConfig.entry;
 
 module.exports = {
 	...defaultConfig,
+	entry: ( ...args ) => {
+		const blockEntries =
+			typeof defaultEntry === 'function' ? defaultEntry( ...args ) : defaultEntry;
+
+		return {
+			...blockEntries,
+			'term-picker': path.resolve( process.cwd(), 'src/term-picker/index.tsx' ),
+		};
+	},
 	module: {
 		...defaultConfig.module,
 		rules: [


### PR DESCRIPTION
Closes #59.

Adds a React + TypeScript term-picker to the bbPress topic composer so users tag their post with **existing curated network taxonomy terms** (location first, designed to generalize to artist/festival/venue). Every tag is a real network term, so it badges and cross-links automatically via the canonical engine wired in #57.

## Architecture decisions (per the issue + RULES/MEMORY)

- **Curated network `location` taxonomy via REST — NOT the freeform `topic-tag` system.** Autocomplete searches existing terms through the WP REST API (`GET /wp/v2/location?search=...`). The freeform bbPress `topic-tag` taxonomy is deliberately **not** the backing store — that recreates exactly the `Charleston` / `Charleston, SC` drift being cleaned up in `extrachill-multisite#40`.
- **Users cannot mint terms.** The picker is read-only against the term list: it only commits an existing suggestion (Enter/click on a real result). Typing a partial or non-matching string creates **nothing** — the network's shared, hierarchical taxonomy tree never drifts from the composer.
- **No AJAX.** All term search and parent-context lookups go through `@wordpress/api-fetch` against `/wp/v2/<rest_base>` (cookie + `wp_rest` nonce). No `admin-ajax`. Headless React + TS only.
- **Taxonomy-parameterized seam.** One `TaxonomyConfig`-driven `TermPicker` component plus a filterable PHP config (`extrachill_community_term_picker_taxonomies`, filter `extrachill_community_term_picker_taxonomies`). Location is the only taxonomy wired today; enabling `artist`/`festival`/`venue` later is a **config addition** (one array entry + ensure the taxonomy is registered for `topic` and REST-enabled), **not** a new component. Per the non-goals, no artist/festival/venue UI is built here — only the seam is left.

## Coexistence with #57

#57 (PR #61) registered `location` on the `topic` post type, added canonical badge rendering, and shipped a **minimal `wp_dropdown_categories` location `<select>`** plus a save handler on `bbp_new_topic` / `bbp_edit_topic`.

This PR **supersedes that minimal `<select>`** cleanly:
- The React picker mounts via the **same** `bbp_theme_before_topic_form_location` action #57 left in `form-topic.php` (both location hooks are **preserved** so other plugins can still target the slot). The old `<select>` markup is removed.
- The #57 save handler `extrachill_community_save_topic_location()` is **generalized**, not duplicated or fought: it now reads the picker's `bbp_topic_location[]` array, validates every submitted ID against a real `location` term (pick-from-existing), clears on empty, and **stays backward-compatible** with the legacy scalar `bbp_topic_location` value. A `bbp_topic_location_submitted` marker distinguishes a "cleared" submit from programmatic (ability/REST) topic creation where the field is absent. The badge engine renders all assigned terms, so multi-select works end to end.

## Files

- `src/term-picker/` — React/TS picker (`TermPicker.tsx`, `index.tsx` mount, `types.ts`, `style.scss` using theme design tokens).
- `inc/content/editor/composer-term-picker.php` — taxonomy config (the generalization seam), localized REST config, conditional enqueue on the topic-form context, and the per-taxonomy mount-point rendering.
- `bbpress/form-topic.php` — removes the minimal #57 `<select>`, keeps the location hooks.
- `inc/core/taxonomy-location.php` — save handler generalized to the multi-term array, pick-from-existing validation, legacy-compatible.
- `webpack.config.js` — adds the standalone `term-picker` entry alongside the default block.json-discovered entries.
- `extrachill-community.php`, `src/types/externals.d.ts` — wiring.

## Verification

- `npm run build` succeeds; emits `build/term-picker.js` + `build/style-term-picker.css` with a correct `.asset.php` (`wp-api-fetch`, `wp-element`, `wp-i18n`, `react-jsx-runtime`). `build/` is gitignored (built at deploy time).
- `npx tsc --noEmit`: 0 type errors in the new files.
- `homeboy lint --changed-since main`: 0 findings in the new/edited files (`composer-term-picker.php`, `taxonomy-location.php`). The one `form-topic.php` finding is a pre-existing bbPress custom-capability warning on unchanged legacy code.
- Confirmed `GET /wp/v2/location?search=charl` returns hierarchical terms on `community.extrachill.com` (Charleston → South Carolina → United States), enabling parent-context suggestions and cross-site badge links via the #57 engine.

**Do not merge — leaving for review.**