### PR TITLE
Phase 1B: consolidate geographic forums into Live Shows & Scenes (#58)

### DIFF
--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -170,7 +170,9 @@ function extrachill_create_community_pages() {
 /**
  * Create required community forums
  *
- * Creates 2 forums: Local Scenes, Music Discussion.
+ * Seeds the non-geographic room set (Phase 1B, #58): Music Discussion,
+ * Live Shows & Scenes, Artist Corner, The Lab. Place is a `location` term on
+ * topics inside Live Shows & Scenes, never a separate geographic forum.
  * Skips creation if forum with slug already exists.
  *
  * @return array Array of created forum IDs
@@ -178,14 +180,24 @@ function extrachill_create_community_pages() {
 function extrachill_create_community_forums() {
 	$forums = array(
 		array(
-			'title'       => 'Local Scenes',
-			'slug'        => 'local-scenes',
-			'description' => 'Discuss local music scenes and discover what\'s happening near you',
-		),
-		array(
 			'title'       => 'Music Discussion',
 			'slug'        => 'music-discussion',
 			'description' => 'General music discussion, recommendations, and talk about what you\'re listening to',
+		),
+		array(
+			'title'       => 'Live Shows & Scenes',
+			'slug'        => 'live-shows-scenes',
+			'description' => 'Live music, local scenes, and shows from every city. Where you are is a tag, not a wall — filter by location to find your scene.',
+		),
+		array(
+			'title'       => 'Artist Corner',
+			'slug'        => 'artist-corner',
+			'description' => 'For artists: introduce yourself, share new releases, and talk shop — DIY tools, link pages, promotion, and the business of being independent.',
+		),
+		array(
+			'title'       => 'The Lab',
+			'slug'        => 'the-lab',
+			'description' => 'The open web, WordPress, AI × music, and build-in-public. Site-building help for artists, dev logs, and tinkering with how independent music lives online.',
 		),
 	);
 

--- a/inc/core/nav.php
+++ b/inc/core/nav.php
@@ -28,8 +28,8 @@ function extrachill_community_secondary_header_items( $items ) {
 		'priority' => 5,
 	);
 	$items[] = array(
-		'url'      => ec_get_site_url( 'community' ) . '/r/local-scenes',
-		'label'    => __( 'Local Scenes', 'extra-chill-community' ),
+		'url'      => ec_get_site_url( 'community' ) . '/r/live-shows-scenes',
+		'label'    => __( 'Live Shows & Scenes', 'extra-chill-community' ),
 		'priority' => 10,
 	);
 	$items[] = array(

--- a/inc/core/taxonomy-location.php
+++ b/inc/core/taxonomy-location.php
@@ -77,12 +77,43 @@ add_action( 'bbp_new_topic', 'extrachill_community_save_topic_location', 20 );
 add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_location', 20 );
 
 /**
- * Redirect location archives to the corresponding forum
+ * Include topics in location taxonomy archives.
  *
- * When viewing /location/charleston/ on community site, redirect
- * to the Charleston subforum (the location hub).
+ * After Phase 1B consolidation (#58) the geographic forums are gone; place
+ * lives as a `location` term on topics inside "Live Shows & Scenes". The
+ * `/location/<term>/` archive becomes the canonical location-filtered VIEW —
+ * e.g. /location/charleston/ is the Charleston view of the Scenes room.
+ *
+ * The location taxonomy is registered to `post` (theme) and `forum`/`topic`
+ * (this plugin). On the main location-archive query, add `topic` so the
+ * archive renders the location-tagged topics. Forums no longer carry place
+ * terms post-migration, so they naturally drop out.
+ *
+ * @param WP_Query $query The query being prepared.
  */
-function extrachill_community_redirect_location_to_forum() {
+function extrachill_community_location_archive_include_topics( $query ) {
+	if ( is_admin() || ! $query->is_main_query() ) {
+		return;
+	}
+	if ( ! $query->is_tax( 'location' ) ) {
+		return;
+	}
+
+	$query->set( 'post_type', array( 'topic' ) );
+	// bbPress topics are publish or closed; include both so closed threads show.
+	$query->set( 'post_status', array( 'publish', 'closed' ) );
+}
+add_action( 'pre_get_posts', 'extrachill_community_location_archive_include_topics' );
+
+/**
+ * Frame the location archive as a filtered view of Live Shows & Scenes.
+ *
+ * Adds a short "← Live Shows & Scenes" backlink + framing line above the
+ * location-archive posts so visitors understand /location/charleston/ is the
+ * Charleston view of the Scenes room, not a standalone forum. Reuses the
+ * theme's `extrachill_archive_below_description` hook.
+ */
+function extrachill_community_location_archive_framing() {
 	if ( ! is_tax( 'location' ) ) {
 		return;
 	}
@@ -92,27 +123,25 @@ function extrachill_community_redirect_location_to_forum() {
 		return;
 	}
 
-	$forums = get_posts(
-		array(
-			'post_type'      => 'forum',
-			'post_status'    => 'publish',
-			'posts_per_page' => 1,
-			'tax_query'      => array(
-				array(
-					'taxonomy' => 'location',
-					'field'    => 'term_id',
-					'terms'    => $term->term_id,
-				),
-			),
+	$scenes = get_page_by_path( 'live-shows-scenes', OBJECT, 'forum' );
+	if ( ! $scenes ) {
+		return;
+	}
+
+	printf(
+		'<p class="ec-location-scenes-context"><a href="%1$s">%2$s</a> &middot; %3$s</p>',
+		esc_url( get_permalink( $scenes ) ),
+		esc_html__( '← Live Shows & Scenes', 'extra-chill-community' ),
+		esc_html(
+			sprintf(
+				/* translators: %s: location name */
+				__( 'Showing %s', 'extra-chill-community' ),
+				$term->name
+			)
 		)
 	);
-
-	if ( ! empty( $forums ) ) {
-		wp_safe_redirect( get_permalink( $forums[0] ), 301 );
-		exit;
-	}
 }
-add_action( 'template_redirect', 'extrachill_community_redirect_location_to_forum' );
+add_action( 'extrachill_archive_below_description', 'extrachill_community_location_archive_framing' );
 
 /**
  * Append cross-site links to forum description

--- a/scripts/migrate-phase-1b-forum-consolidation.php
+++ b/scripts/migrate-phase-1b-forum-consolidation.php
@@ -1,0 +1,435 @@
+<?php
+/**
+ * Phase 1B forum consolidation migration (issue #58).
+ *
+ * One-time, idempotent data migration. NOT loaded by the plugin — run once
+ * against the community site (blog 2). `eval-file` passes positional args
+ * through `$args`, so pass the literal word `dry-run` (no leading dashes) for
+ * a no-write preview:
+ *
+ *   # Preview (no writes):
+ *   wp --allow-root --path=/var/www/extrachill.com \
+ *      --url=community.extrachill.com \
+ *      eval-file scripts/migrate-phase-1b-forum-consolidation.php dry-run
+ *
+ *   # Apply:
+ *   wp --allow-root --path=/var/www/extrachill.com \
+ *      --url=community.extrachill.com \
+ *      eval-file scripts/migrate-phase-1b-forum-consolidation.php
+ *
+ * What it does:
+ *   1. Ensures the "Live Shows & Scenes" and "Artist Corner" forums exist.
+ *   2. Renames "Tech Support" -> "The Lab" (title + slug the-lab).
+ *   3. Reassigns geographic topics (Charleston/Austin/Philadelphia/Local
+ *      Scenes) into "Live Shows & Scenes", carrying each origin forum's
+ *      location term onto the moved topics.
+ *   4. Reassigns the curated Artist Corner topic set out of Music Discussion.
+ *   5. Trashes the now-empty geographic forums.
+ *   6. Recalculates bbPress counts on every affected forum.
+ *
+ * bbPress reassignment contract honored:
+ *   - Topic: post_parent -> dest forum; _bbp_forum_id meta via
+ *     bbp_update_topic_forum_id().
+ *   - Replies: _bbp_forum_id meta via bbp_update_reply_forum_id()
+ *     (reply post_parent stays = topic_id, which is correct for bbPress).
+ *   - Counts recalculated directly (bbp_update_forum() only recounts inside
+ *     bbp_deleted_topic/save_post filters, so we call the count helpers).
+ *
+ * Idempotent: re-running is safe. Topics already in the destination forum are
+ * skipped; forums already created/renamed/trashed are left as-is.
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+// `eval-file` exposes positional args via $args. Accept `dry-run` or
+// `--dry-run` defensively.
+$script_args = (array) ( $args ?? array() );
+$dry_run     = in_array( 'dry-run', $script_args, true )
+	|| in_array( '--dry-run', $script_args, true );
+
+/**
+ * Echo helper.
+ *
+ * @param string $msg Message.
+ */
+$log = static function ( $msg ) {
+	WP_CLI::log( $msg );
+};
+
+if ( $dry_run ) {
+	$log( '=== DRY RUN — no writes will be performed ===' );
+}
+
+/** ---------------------------------------------------------------------------
+ * Configuration: source forums, destination, location terms, Artist Corner set.
+ * ------------------------------------------------------------------------- */
+
+// Source geographic forums => location term slug to backfill onto moved topics.
+// Local Scenes (8889) has no location term, so its topics carry none.
+$geo_sources = array(
+	114  => 'charleston',   // Charleston
+	8891 => 'austin',       // Austin
+	8984 => 'philadelphia', // Philadelphia
+	8889 => null,           // Local Scenes (parent category, no location)
+);
+
+$tech_support_forum_id = 13548;
+
+// Curated Artist Corner topic IDs (reviewed self-promo / artist self-intro /
+// release-drop topics currently living in Music Discussion, forum 1983).
+$artist_corner_topic_ids = array(
+	14001,
+	13807,
+	13775,
+	13763,
+	13733,
+	13731,
+	13724,
+	13703,
+	13698,
+	13671,
+	13558,
+	13403,
+	11403,
+	11100,
+	10987,
+	10952,
+	9391,
+	9190,
+	8961,
+	8862,
+	8859,
+	8780,
+	8660,
+	8523,
+	7057,
+	6966,
+	6954,
+	6923,
+	6874,
+	6754,
+	6753,
+	6724,
+	6673,
+	6650,
+	6364,
+	6130,
+	5729,
+	5647,
+	5386,
+	5337,
+	5282,
+	5277,
+	5232,
+	5209,
+	5058,
+	5043,
+	4941,
+	4940,
+	4857,
+	2286,
+	2270,
+	2225,
+	2206,
+	1923,
+	1786,
+	1777,
+	1676,
+	1491,
+	1448,
+	1420,
+	1393,
+	1385,
+	1364,
+	1341,
+	1314,
+	1280,
+	1271,
+	1254,
+	1107,
+	908,
+	895,
+	892,
+	844,
+	604,
+);
+
+/** ---------------------------------------------------------------------------
+ * Helper: find a forum by exact slug (direct DB read).
+ *
+ * Uses $wpdb rather than get_posts() so the lookup is immune to bbPress's
+ * forum-query meta filters (which hide forums lacking _bbp_forum_type) and to
+ * any object-cache staleness mid-run. This is what makes creation idempotent.
+ * ------------------------------------------------------------------------- */
+$find_forum_by_slug = static function ( $slug ) {
+	global $wpdb;
+	$id = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'forum' AND post_name = %s AND post_status NOT IN ( 'trash', 'auto-draft' ) ORDER BY ID ASC LIMIT 1",
+			$slug
+		)
+	);
+	return $id ? (int) $id : 0;
+};
+
+/** ---------------------------------------------------------------------------
+ * Helper: create a forum via bbp_insert_forum (sets the bbPress identity meta
+ * — _bbp_forum_type/_bbp_status/_bbp_forum_id — that wp_insert_post omits and
+ * that forum listings/dropdowns filter on). Idempotent on slug.
+ * ------------------------------------------------------------------------- */
+$ensure_forum = static function ( $slug, $title, $content, $menu_order ) use ( $find_forum_by_slug, $log, $dry_run ) {
+	$existing = $find_forum_by_slug( $slug );
+	if ( $existing ) {
+		$log( "  forum '{$slug}' already exists (ID {$existing})" );
+		return $existing;
+	}
+	if ( $dry_run ) {
+		$log( "  [dry-run] would create forum '{$title}' (slug {$slug})" );
+		return 0;
+	}
+	$forum_id = bbp_insert_forum(
+		array(
+			'post_title'   => $title,
+			'post_name'    => $slug,
+			'post_content' => $content,
+			'menu_order'   => $menu_order,
+		)
+	);
+	if ( is_wp_error( $forum_id ) || ! $forum_id ) {
+		WP_CLI::error( "Failed to create forum '{$slug}'." );
+	}
+	$log( "  created forum '{$title}' (ID {$forum_id})" );
+	return (int) $forum_id;
+};
+
+/** ---------------------------------------------------------------------------
+ * Helper: recalc all bbPress counts for a forum.
+ * ------------------------------------------------------------------------- */
+$recalc_forum = static function ( $forum_id ) use ( $log, $dry_run ) {
+	if ( ! $forum_id ) {
+		return;
+	}
+	if ( $dry_run ) {
+		$log( "  [dry-run] would recalc counts for forum {$forum_id}" );
+		return;
+	}
+	bbp_update_forum_topic_count( $forum_id );
+	bbp_update_forum_topic_count_hidden( $forum_id );
+	bbp_update_forum_reply_count( $forum_id );
+	bbp_update_forum_reply_count_hidden( $forum_id );
+	bbp_update_forum_last_topic_id( $forum_id );
+	bbp_update_forum_last_reply_id( $forum_id );
+	bbp_update_forum_last_active_id( $forum_id );
+	bbp_update_forum_last_active_time( $forum_id );
+	$log( "  recalculated counts for forum {$forum_id} (topics=" . bbp_get_forum_topic_count( $forum_id, true, true ) . ')' );
+};
+
+/** ---------------------------------------------------------------------------
+ * Helper: reassign a single topic (and its replies) to a destination forum.
+ * Returns true if a move actually happened.
+ * ------------------------------------------------------------------------- */
+$move_topic = static function ( $topic_id, $dest_forum_id ) use ( $log, $dry_run ) {
+	$current_parent = (int) get_post_field( 'post_parent', $topic_id );
+	if ( $current_parent === (int) $dest_forum_id ) {
+		return false; // Already moved — idempotent skip.
+	}
+
+	$title = get_the_title( $topic_id );
+
+	if ( $dry_run ) {
+		$log( "  [dry-run] would move topic {$topic_id} ({$title}) from {$current_parent} -> {$dest_forum_id}" );
+		return true;
+	}
+
+	// Move the topic post_parent.
+	wp_update_post(
+		array(
+			'ID'          => $topic_id,
+			'post_parent' => $dest_forum_id,
+		)
+	);
+
+	// Update topic _bbp_forum_id meta (canonical bbPress helper).
+	bbp_update_topic_forum_id( $topic_id, $dest_forum_id );
+
+	// Update every reply's _bbp_forum_id meta. Replies keep post_parent =
+	// topic_id (correct for bbPress); only the forum-id meta changes.
+	$reply_ids = get_posts(
+		array(
+			'post_type'      => bbp_get_reply_post_type(),
+			'post_status'    => array( 'publish', 'closed', 'private', 'hidden', 'pending', 'spam', 'trash' ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_key'       => '_bbp_topic_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_value'     => $topic_id,       // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		)
+	);
+	foreach ( $reply_ids as $reply_id ) {
+		bbp_update_reply_forum_id( $reply_id, $dest_forum_id );
+	}
+
+	$log( "  moved topic {$topic_id} ({$title}) -> forum {$dest_forum_id} (" . count( $reply_ids ) . ' replies)' );
+	return true;
+};
+
+/** ===========================================================================
+ * STEP 1 — Ensure destination forums exist.
+ * ======================================================================== */
+$log( "\n== Step 1: ensure destination forums ==" );
+
+$scenes_forum_id = $ensure_forum(
+	'live-shows-scenes',
+	'Live Shows & Scenes',
+	'Live music, local scenes, and shows from every city. Where you are is a tag, not a wall — filter by location to find your scene.',
+	2
+);
+
+$artist_corner_forum_id = $ensure_forum(
+	'artist-corner',
+	'Artist Corner',
+	'For artists: introduce yourself, share new releases, and talk shop — DIY tools, link pages, promotion, and the business of being independent.',
+	4
+);
+
+/** ===========================================================================
+ * STEP 2 — Rename Tech Support -> The Lab (title + slug).
+ * ======================================================================== */
+$log( "\n== Step 2: rename Tech Support -> The Lab ==" );
+$lab = get_post( $tech_support_forum_id );
+if ( $lab && 'forum' === $lab->post_type ) {
+	if ( 'the-lab' === $lab->post_name && 'The Lab' === $lab->post_title ) {
+		$log( '  Tech Support already renamed to The Lab' );
+	} elseif ( $dry_run ) {
+		$log( "  [dry-run] would rename forum {$tech_support_forum_id} to 'The Lab' (slug the-lab)" );
+	} else {
+		wp_update_post(
+			array(
+				'ID'           => $tech_support_forum_id,
+				'post_title'   => 'The Lab',
+				'post_name'    => 'the-lab',
+				'post_content' => 'The open web, WordPress, AI × music, and build-in-public. Site-building help for artists, dev logs, and tinkering with how independent music lives online.',
+			)
+		);
+		$log( "  renamed forum {$tech_support_forum_id} -> The Lab (the-lab)" );
+	}
+} else {
+	WP_CLI::warning( "Tech Support forum {$tech_support_forum_id} not found — skipping rename." );
+}
+
+/** ===========================================================================
+ * STEP 3 — Move geographic topics into Live Shows & Scenes + backfill location.
+ * ======================================================================== */
+$log( "\n== Step 3: migrate geographic topics -> Live Shows & Scenes ==" );
+$moved_geo = 0;
+foreach ( $geo_sources as $src_forum_id => $location_slug ) {
+	$topic_ids = get_posts(
+		array(
+			'post_type'      => bbp_get_topic_post_type(),
+			'post_parent'    => $src_forum_id,
+			'post_status'    => array( 'publish', 'closed', 'private', 'hidden', 'pending' ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		)
+	);
+	$log( '  source forum ' . $src_forum_id . ': ' . count( $topic_ids ) . ' topics' );
+
+	foreach ( $topic_ids as $topic_id ) {
+		if ( $move_topic( $topic_id, $scenes_forum_id ) ) {
+			++$moved_geo;
+		}
+
+		// Backfill the origin forum's location term onto the moved topic.
+		if ( $location_slug && ! $dry_run ) {
+			$location_term = get_term_by( 'slug', $location_slug, 'location' );
+			if ( $location_term && ! is_wp_error( $location_term ) ) {
+				wp_set_object_terms( $topic_id, array( (int) $location_term->term_id ), 'location' );
+			}
+		} elseif ( $location_slug && $dry_run ) {
+			$log( "    [dry-run] would tag topic {$topic_id} with location:{$location_slug}" );
+		}
+	}
+}
+$log( "  geographic topics moved this run: {$moved_geo}" );
+
+/** ===========================================================================
+ * STEP 4 — Move curated Artist Corner topics out of Music Discussion.
+ * ======================================================================== */
+$log( "\n== Step 4: migrate curated Artist Corner topics ==" );
+$moved_artist = 0;
+foreach ( $artist_corner_topic_ids as $topic_id ) {
+	$topic_post = get_post( $topic_id );
+	if ( ! $topic_post || bbp_get_topic_post_type() !== $topic_post->post_type ) {
+		WP_CLI::warning( "  topic {$topic_id} not found or not a topic — skipping." );
+		continue;
+	}
+	if ( $move_topic( $topic_id, $artist_corner_forum_id ) ) {
+		++$moved_artist;
+	}
+}
+$log( "  Artist Corner topics moved this run: {$moved_artist}" );
+
+/** ===========================================================================
+ * STEP 5 — Trash now-empty geographic forums.
+ * ======================================================================== */
+$log( "\n== Step 5: trash emptied geographic forums ==" );
+foreach ( array_keys( $geo_sources ) as $src_forum_id ) {
+	$remaining = get_posts(
+		array(
+			'post_type'      => bbp_get_topic_post_type(),
+			'post_parent'    => $src_forum_id,
+			'post_status'    => array( 'publish', 'closed', 'private', 'hidden', 'pending' ),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+	$subforums = get_posts(
+		array(
+			'post_type'      => 'forum',
+			'post_parent'    => $src_forum_id,
+			'post_status'    => array( 'publish', 'private' ),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+
+	if ( ! empty( $remaining ) ) {
+		WP_CLI::warning( "  forum {$src_forum_id} still has topics — NOT trashing." );
+		continue;
+	}
+	if ( ! empty( $subforums ) ) {
+		WP_CLI::warning( "  forum {$src_forum_id} still has subforums — NOT trashing." );
+		continue;
+	}
+
+	$forum_status = get_post_status( $src_forum_id );
+	if ( 'trash' === $forum_status ) {
+		$log( "  forum {$src_forum_id} already trashed" );
+		continue;
+	}
+	if ( $dry_run ) {
+		$log( "  [dry-run] would trash empty forum {$src_forum_id}" );
+		continue;
+	}
+	wp_trash_post( $src_forum_id );
+	$log( "  trashed empty forum {$src_forum_id}" );
+}
+
+/** ===========================================================================
+ * STEP 6 — Recalculate counts on every affected forum.
+ * ======================================================================== */
+$log( "\n== Step 6: recalculate bbPress counts ==" );
+$affected = array_merge(
+	array_keys( $geo_sources ),
+	array( $scenes_forum_id, $artist_corner_forum_id, 1983 ) // + Music Discussion source.
+);
+foreach ( array_unique( $affected ) as $forum_id ) {
+	if ( $forum_id > 0 ) {
+		$recalc_forum( $forum_id );
+	}
+}
+
+WP_CLI::success( $dry_run ? 'Dry run complete.' : 'Phase 1B forum consolidation migration complete.' );


### PR DESCRIPTION
Closes #58. Refs #53 (community living-room epic), depends on #57/#61 (location badges — already merged).

Consolidates the community's geographic / legacy forum tree into a focused, **non-geographic** room set. Place now lives as a `location` term/badge on topics inside **Live Shows & Scenes**, not as a separate forum. Charleston becomes the prominent location-**filtered view** at `/location/charleston/` — no empty rooms advertising absence.

> **High blast radius.** The data migration has already been applied to `community.extrachill.com` (blog 2) and fully verified (see below). The migration script is committed as an idempotent, re-runnable artifact. **Do not merge without review.**

## Merge map (forum → forum)

| Source forum (retired) | ID | Topics | Destination | Notes |
|---|---|---|---|---|
| Charleston | 114 | 74 | **Live Shows & Scenes** (14119) | + `location:charleston` term backfilled |
| Austin | 8891 | 8 | **Live Shows & Scenes** (14119) | + `location:austin` term backfilled |
| Philadelphia | 8984 | 15 | **Live Shows & Scenes** (14119) | + `location:philadelphia` term backfilled |
| Local Scenes (parent) | 8889 | 1 | **Live Shows & Scenes** (14119) | no location term |
| Tech Support | 13548 | — | **The Lab** (rename, slug `tech-support`→`the-lab`) | repurposed |
| (curated) Music Discussion subset | 1983 | 74 | **Artist Corner** (14120, NEW) | see "Artist Corner seed" |

**Final room set:** Music Discussion (1983) · Live Shows & Scenes (14119, NEW) · Artist Corner (14120, NEW) · The Lab (13548) · The Back Bar (81) · Extra Chill Team (547, internal). The four geographic forums (114/8891/8984/8889) are trashed and empty.

## Redirect table (via `extrachill-seo` — no new storage)

All redirects were added with `wp extrachill seo redirects add` into the existing network-scoped `extrachill_seo_redirects` table (the SEO plugin's own storage). **No table/option/CPT was created.** Retired forum URLs 404 → the SEO matcher (priority 6 on `template_redirect`) fires the 301.

| From (path) | To | Code | Rule # |
|---|---|---|---|
| `/r/local-scenes/charleston-sc` | `/location/charleston/` | 301 | #2891 |
| `/r/local-scenes/austin-tx` | `/location/austin/` | 301 | #2892 |
| `/r/local-scenes/philadelphia-pa` | `/location/philadelphia/` | 301 | #2893 |
| `/r/local-scenes` | `/r/live-shows-scenes` | 301 | #2894 |
| `/r/tech-support` | `/r/the-lab` | 301 | #2895 |

**No per-topic redirects needed.** Topic permalinks are flat `/t/<slug>` (bbPress `_bbp_topic_slug = t`), so reassigning a topic to a new forum does **not** change its URL. Verified moved topics return 200 (`/t/help-charleston-band-win-best-of`, `/t/best-worst-taco-trucks`, `/t/babe-club-charleston-sc`).

## bbPress count-recalc approach

Reassignment honors the full bbPress contract, not just `post_parent`:
- **Topic:** `post_parent` → dest forum; `_bbp_forum_id` via `bbp_update_topic_forum_id()`.
- **Replies:** `_bbp_forum_id` via `bbp_update_reply_forum_id()` (reply `post_parent` stays = topic_id, which is correct for bbPress).
- **Counts:** recalculated directly on every affected forum — `bbp_update_forum_topic_count()` / `_hidden`, `bbp_update_forum_reply_count()` / `_hidden`, and the `bbp_update_forum_last_*` helpers. (`bbp_update_forum()` only recounts inside `bbp_deleted_topic`/`save_post` filters, so the count helpers are called explicitly.)
- **Forum identity:** new forums are created via `bbp_insert_forum()` so they get `_bbp_forum_type`/`_bbp_status`/`_bbp_forum_id` — meta that `wp_insert_post()` omits and that bbPress forum listings filter on.

## How the location→forum redirect was updated (the #58-comment requirement)

The old `extrachill_community_redirect_location_to_forum()` 301'd `/location/<term>/` → a forum tagged with that term. After the Charleston forum is gone, that target is gone too. It's **replaced** (not patched) with `extrachill_community_location_archive_include_topics()` (`pre_get_posts`): on the location archive, the query now includes the `topic` post type, so `/location/charleston/` renders the Charleston-tagged topics as the filtered Scenes view. A short "← Live Shows & Scenes · Showing Charleston" framing line is added via the theme's `extrachill_archive_below_description` hook. The #57 location badges (which link to `/location/<term>/`) now resolve to a real populated view instead of 301'ing to a deleted forum.

## Artist Corner seed (orchestrator's call)

Artist Corner was created **with a curated seed**, not empty. 74 genuine artist self-promo topics were moved out of Music Discussion: the `<Artist> – <City> (<Genre>)` self-introductions and emerging-artist single/EP release drops (e.g. *Babe Club – Charleston, SC*, *Die Spitz – Austin, TX*, *Wilmot – Debut EP Drop*). Album reviews of established acts, news, festival threads, and industry-meta topics were deliberately **excluded** and stay in Music Discussion. The full reviewed ID list lives in the migration script.

## Files changed

- `inc/core/taxonomy-location.php` — replace location→forum redirect with location-archive-includes-topics + framing line.
- `inc/core/nav.php` — secondary header: Local Scenes → Live Shows & Scenes.
- `inc/core/activation.php` — fresh-install seed → new non-geographic room set.
- `scripts/migrate-phase-1b-forum-consolidation.php` — **new**, one-time idempotent migration (not loaded by the plugin). Run: `wp --url=community.extrachill.com eval-file scripts/migrate-phase-1b-forum-consolidation.php [dry-run]`.

## Verification (on live blog 2)

- Forum counts: **Live Shows & Scenes = 98 topics / 223 replies**, **Artist Corner = 74 / 223** (zero reply overlap between them — the 223/223 is coincidence). Source forums 114/8891/8984/8889: **status=trash, 0 topics**.
- Location backfill: `/location/charleston/` → 74 topics, `/location/austin/` → 8, `/location/philadelphia/` → 15 (exactly the moved counts).
- Redirects: all 5 tested live — `/r/tech-support`→`/r/the-lab` (301), `/r/local-scenes`→`/r/live-shows-scenes` (301), `/r/local-scenes/charleston-sc`→`/location/charleston/` (301). New forum URLs return 200.
- Moved topics return 200 (URLs unchanged). Location badges render once this branch deploys (the badge code from #57/#61 isn't in production yet — neither is #57; the term backfill is done so badges light up on deploy).
- 404 scan (`extrachill analytics 404 patterns`): no NEW forum/topic 404s from the migration; existing `community-thread` 404s are pre-existing deleted/never-existed `/t/` slugs.
- Lint: `homeboy lint` clean on all touched files (the 4 changed files contribute 0 findings).

## Notes / non-goals

- Feed-first homepage (Phase 2) and cross-network feed / auto-threading (Phase 3) are out of scope.
- Badges depend on #57/#61 being deployed; the data this PR backfills is what makes them render.