### PR TITLE
style: clear phpcs lint debt (release preflight)

### DIFF
--- a/bbpress/loop-topics.php
+++ b/bbpress/loop-topics.php
@@ -64,7 +64,7 @@ if ( 'upvotes' === $current_sort ) {
 	$loop_args['order']    = 'DESC';
 } elseif ( 'popular' === $current_sort ) {
 	global $wpdb;
-	$popular_ids           = $wpdb->get_col($wpdb->prepare(
+	$popular_ids = $wpdb->get_col($wpdb->prepare(
 		"SELECT p.post_parent FROM {$wpdb->posts} p
          INNER JOIN {$wpdb->posts} t ON p.post_parent = t.ID
          WHERE p.post_type = %s AND t.post_type = %s AND p.post_date >= %s

--- a/page-templates/leaderboard-template.php
+++ b/page-templates/leaderboard-template.php
@@ -44,9 +44,9 @@ echo '<tbody>';
 foreach ( $users as $user ) {
 	$user_profile_url = bbp_get_user_profile_url($user->ID);
 	// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Display in site-local time, preserving existing rendered output.
-	$join_date        = date('Y-m-d', strtotime($user->user_registered));
-	$points           = extrachill_display_user_points($user->ID);
-	$rank             = extrachill_display_user_rank($user->ID);
+	$join_date = date('Y-m-d', strtotime($user->user_registered));
+	$points    = extrachill_display_user_points($user->ID);
+	$rank      = extrachill_display_user_rank($user->ID);
 
 	echo '<tr>';
 	echo '<td><a href="' . esc_url($user_profile_url) . '">' . esc_html($user->display_name) . '</a></td>';


### PR DESCRIPTION
## Summary

Clears the remaining **auto-fixable PHPCS findings** via `homeboy lint --fix` (phpcbf) so the release lint preflight stops needing `--skip-checks`. **Formatting only — zero logic changes.**

Refs #39.

## ⚠️ The #39 figures are stale

Issue #39 was filed when the repo had **4447 findings (4017 auto-fixable)**. Prior PRs (#52 "clear phpcs lint debt", #61) already cleared the vast majority. The **current live baseline is 98 findings**, of which only **4 phpcs findings were auto-fixable**. This PR applies those 4; the rest are documented below.

## Before / after (phpcs only — this PR's scope)

| | phpcs total | phpcs auto-fixable |
|---|---:|---:|
| before | 40 | 4 |
| after  | 36 | **0** |

`homeboy lint --fix` modified **2 PHP files, 4 lines** — all `WordPress.Arrays.MultipleStatementAlignment` / `Generic.Formatting.MultipleStatementAlignment` (equals-sign whitespace alignment). No phpcs auto-fixable findings remain.

## Diff is 100% cosmetic

```
bbpress/loop-topics.php                 | 2 +-
page-templates/leaderboard-template.php | 6 +++---
```

Only excess spaces before `=` were removed to fix alignment. **No comparison operators touched, no Yoda flips, no semantic shifts** — verified by reading the full diff.

## Remaining findings — manual review needed (NOT in this PR)

This PR is formatting-only. The remaining **94 findings** all require human judgment and are intentionally left out:

### phpcs (36 — all manual)
| Count | Rule |
|------:|------|
| 17 | `WordPress.WP.Capabilities.Unknown` (custom caps the sniff doesn't know) |
| 6 | `WordPress.Security.NonceVerification.Recommended` |
| 3 | `WordPress.DateTime.CurrentTimeTimestamp.Requested` |
| 2 | `Squiz.PHP.CommentedOutCode.Found` |
| 2 | `WordPress.PHP.DevelopmentFunctions.error_log_error_log` |
| 2 | `WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode` |
| 2 | `WordPress.PHP.NoSilencedErrors.Discouraged` |
| 1 | `WordPress.PHP.StrictInArray.FoundNonStrictFalse` |
| 1 | `WordPress.WP.AlternativeFunctions.parse_url_parse_url` |

### eslint (58 — JS/TSX, out of scope for a phpcbf formatting pass)
40 are eslint-auto-fixable (`no-var`, `curly`, `object-shorthand`, `@wordpress/dependency-group`, `import/no-duplicates`, jsdoc) but those are **JS source transforms** (e.g. `var`→`const`, adding braces), not phpcbf cosmetics — they belong in a separate dedicated JS lint PR so the mechanical PHP churn here stays trivially reviewable. The other 18 (`no-unused-vars`, `jsx-a11y`, `no-nested-ternary`, `react/no-unescaped-entities`, etc.) need eyes.

## Note on full preflight

Because 94 manual/JS findings remain, `homeboy lint` does not yet fully pass — full green requires the follow-up manual + eslint passes described in #39. This PR removes the phpcs auto-fixable debt as the safe first step.