### PR TITLE
Decouple global /recent page from @username profile activity feed (+ add scoped profile feed)

### DIFF
--- a/bbpress/loop-single-reply-card.php
+++ b/bbpress/loop-single-reply-card.php
@@ -131,7 +131,7 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 				</div><!-- .author-header-column -->
 
 				<?php
-				if ( bbp_is_single_user_replies() || is_page_template('page-templates/recent-feed-template.php') ) :
+				if ( bbp_is_single_user_replies() || is_page_template('page-templates/recent-feed-template.php') || ( function_exists('extrachill_is_activity_feed_card') && extrachill_is_activity_feed_card() ) ) :
 					// Check for pre-fetched topic/forum data (multisite context)
 					$prefetch_topic_url   = get_query_var('prefetch_topic_url');
 					$prefetch_topic_title = get_query_var('prefetch_topic_title');
@@ -172,7 +172,7 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 			<div class="bbp-reply-content" data-reply-id="<?php bbp_reply_id(); ?>">
 				<?php do_action( 'bbp_theme_before_reply_content' ); ?>
 				<?php
-				if ( is_page_template('page-templates/recent-feed-template.php') ) {
+				if ( is_page_template('page-templates/recent-feed-template.php') || ( function_exists('extrachill_is_activity_feed_card') && extrachill_is_activity_feed_card() ) ) {
 					$content         = bbp_get_reply_content();
 					$content_length  = strlen( wp_strip_all_tags( $content ) );
 					$truncate_length = 500;

--- a/bbpress/loop-single-topic-card.php
+++ b/bbpress/loop-single-topic-card.php
@@ -98,7 +98,8 @@ if ( ! $topic_id ) {
 		if ( is_page_template('page-templates/recent-feed-template.php') ||
 			is_front_page() ||
 			is_search() ||
-			bbp_is_search() ) {
+			bbp_is_search() ||
+			( function_exists('extrachill_is_activity_feed_card') && extrachill_is_activity_feed_card() ) ) {
 			$show_forum_name_on_card = true;
 		}
 

--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -80,6 +80,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/custom-user-profile.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/profile-activity-feed.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/verification.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/settings/settings-content.php';
 

--- a/inc/content/recent-feed.php
+++ b/inc/content/recent-feed.php
@@ -78,8 +78,20 @@ function extrachill_get_avatar_url_with_custom_support($user_id, $size = 80) {
 	return get_avatar_url($user_id, array( 'size' => $size ));
 }
 
-function extrachill_get_recent_replies_args($per_page = 15, $paged = 1) {
-	return array(
+/**
+ * Build base WP_Query args for a topic+reply activity feed.
+ *
+ * Pass an author ID to scope the feed to a single user (profile activity feed);
+ * omit it (0) for the unscoped global feed.
+ *
+ * @param int $per_page Items per page.
+ * @param int $paged    Page number.
+ * @param int $author   Optional author ID to scope the feed. 0 = unscoped/global.
+ *
+ * @return array WP_Query args.
+ */
+function extrachill_get_recent_replies_args($per_page = 15, $paged = 1, $author = 0) {
+	$args = array(
 		'post_type'      => array( 'topic', 'reply' ),
 		'posts_per_page' => $per_page,
 		'paged'          => $paged,
@@ -87,9 +99,28 @@ function extrachill_get_recent_replies_args($per_page = 15, $paged = 1) {
 		'order'          => 'DESC',
 		'post_status'    => array( 'publish', 'closed', 'acf-disabled', 'private', 'hidden' ),
 	);
+
+	$author = (int) $author;
+	if ( $author > 0 ) {
+		$args['author'] = $author;
+	}
+
+	return $args;
 }
 
-function extrachill_get_recent_feed_query($per_page = 15, $paged = null) {
+/**
+ * Run an activity-feed query and shape the results for the feed renderer.
+ *
+ * Shared implementation behind both the global recent feed and the user-scoped
+ * profile activity feed. Pass an author ID to scope to a single user.
+ *
+ * @param int      $per_page Items per page.
+ * @param int|null $paged    Page number; null resolves from the current request.
+ * @param int      $author   Optional author ID to scope the feed. 0 = unscoped/global.
+ *
+ * @return array|false { items: array, pagination: ExtraChill_Community_Feed_Query } or false when empty.
+ */
+function extrachill_build_activity_feed($per_page = 15, $paged = null, $author = 0) {
 	if ( ! function_exists('bbp_get_reply_post_type') ) {
 		return false;
 	}
@@ -98,7 +129,7 @@ function extrachill_get_recent_feed_query($per_page = 15, $paged = null) {
 	$bbp_paged = function_exists('bbp_get_paged') ? bbp_get_paged() : max(1, (int) get_query_var('paged', 1));
 	$paged     = null === $paged ? $bbp_paged : max(1, (int) $paged);
 
-	$args                  = extrachill_get_recent_replies_args($per_page, $paged);
+	$args                  = extrachill_get_recent_replies_args($per_page, $paged, $author);
 	$args['no_found_rows'] = false;
 
 	$query = new WP_Query($args);
@@ -144,12 +175,154 @@ function extrachill_get_recent_feed_query($per_page = 15, $paged = null) {
 	);
 }
 
-function extrachill_get_recent_activity_query($per_page = 15, $paged = 1) {
-	$args = extrachill_get_recent_replies_args($per_page, $paged);
+/**
+ * Global recent activity feed (unscoped).
+ *
+ * Owns the /recent page's data. Intentionally forum-scoped (topics + replies
+ * across all forums) — NOT cross-network. See epic #53 Phase 3.
+ *
+ * @param int      $per_page Items per page.
+ * @param int|null $paged    Page number; null resolves from the current request.
+ *
+ * @return array|false Feed payload or false when empty.
+ */
+function extrachill_get_recent_feed_query($per_page = 15, $paged = null) {
+	return extrachill_build_activity_feed($per_page, $paged, 0);
+}
 
-	if ( empty($args) ) {
-		return new WP_Query(array( 'post__in' => array( 0 ) ));
+/**
+ * User-scoped profile activity feed.
+ *
+ * Owns a single user's profile activity feed: the same topic+reply stream as
+ * the global feed, filtered to the displayed user. Replaces the former
+ * near-duplicate extrachill_get_recent_activity_query() helper.
+ *
+ * @param int      $user_id  User to scope the feed to.
+ * @param int      $per_page Items per page.
+ * @param int|null $paged    Page number; null resolves from the current request.
+ *
+ * @return array|false Feed payload or false when empty / invalid user.
+ */
+function extrachill_get_user_activity_query($user_id, $per_page = 15, $paged = null) {
+	$user_id = (int) $user_id;
+	if ( $user_id <= 0 ) {
+		return false;
 	}
 
-	return new WP_Query($args);
+	return extrachill_build_activity_feed($per_page, $paged, $user_id);
+}
+
+/**
+ * Render an activity feed payload as bbPress reply cards.
+ *
+ * Shared renderer for both the global /recent feed and the user-scoped profile
+ * activity feed, so both surfaces produce identical card markup. Echoes the
+ * markup directly (returns nothing).
+ *
+ * @param array|false $feed         Feed payload from a feed query function.
+ * @param string      $empty_notice Message shown when the feed is empty.
+ *
+ * @return void
+ */
+/**
+ * Whether the current reply card is being rendered inside an activity feed.
+ *
+ * Set by extrachill_render_recent_feed() while it loops over feed items, so the
+ * shared loop-single-reply-card.php template can render its feed-specific chrome
+ * (the "in forum / in reply to" header and content truncation) regardless of
+ * which surface — global /recent or a user profile — is rendering the feed.
+ *
+ * @param bool|null $set Internal: pass true/false to toggle the flag. Reads when null.
+ *
+ * @return bool
+ */
+function extrachill_is_activity_feed_card($set = null) {
+	static $active = false;
+
+	if ( null !== $set ) {
+		$active = (bool) $set;
+	}
+
+	return $active;
+}
+
+function extrachill_render_recent_feed($feed, $empty_notice = '') {
+	if ( ! $feed || empty($feed['items']) ) {
+		if ( '' === $empty_notice ) {
+			$empty_notice = __('No recent activity found.', 'extra-chill-community');
+		}
+		echo '<div class="notice notice-info"><p>' . esc_html($empty_notice) . '</p></div>';
+		return;
+	}
+
+	$feed_items        = $feed['items'];
+	$pagination        = $feed['pagination'];
+	$bbp               = bbpress();
+	$previous_reply_id = isset($bbp->current_reply_id) ? $bbp->current_reply_id : 0;
+	$previous_topic_id = isset($bbp->current_topic_id) ? $bbp->current_topic_id : 0;
+	$previous_forum_id = isset($bbp->current_forum_id) ? $bbp->current_forum_id : 0;
+	?>
+	<div id="bbpress-forums" class="bbpress-wrapper">
+		<ul class="forums bbp-replies">
+			<li class="bbp-body">
+				<?php
+				global $post;
+				extrachill_is_activity_feed_card(true);
+				foreach ( $feed_items as $feed_item ) {
+					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentionally sets the global $post for setup_postdata() and the bbPress template part below.
+					$post = $feed_item['post'];
+
+					if ( ! $post || ! is_object($post) ) {
+						continue;
+					}
+
+					setup_postdata($post);
+
+					// Set pre-fetched author data for template use
+					set_query_var('prefetch_author_id', $feed_item['author_id']);
+					set_query_var('prefetch_author_name', $feed_item['author_name']);
+					set_query_var('prefetch_author_avatar_url', $feed_item['author_avatar_url']);
+
+					// Set pre-fetched topic/forum data for template use
+					set_query_var('prefetch_topic_id', $feed_item['topic_id']);
+					set_query_var('prefetch_topic_url', $feed_item['topic_url']);
+					set_query_var('prefetch_topic_title', $feed_item['topic_title']);
+					set_query_var('prefetch_forum_id', $feed_item['forum_id']);
+					set_query_var('prefetch_forum_url', $feed_item['forum_url']);
+					set_query_var('prefetch_forum_title', $feed_item['forum_title']);
+
+					$bbp->current_reply_id = $post->ID;
+
+					if ( bbp_get_topic_post_type() === $post->post_type ) {
+						$topic_id = $post->ID;
+					} else {
+						$topic_id = (int) get_post_field( 'post_parent', $post->ID );
+						if ( empty( $topic_id ) ) {
+							$topic_id = (int) get_post_meta( $post->ID, '_bbp_topic_id', true );
+						}
+					}
+
+					$bbp->current_topic_id = $topic_id;
+					$bbp->current_forum_id = $topic_id ? bbp_get_topic_forum_id($topic_id) : 0;
+
+					bbp_get_template_part('loop', 'single-reply-card');
+
+					$bbp->current_reply_id = 0;
+					$bbp->current_topic_id = 0;
+					$bbp->current_forum_id = 0;
+
+					wp_reset_postdata();
+				}
+
+				extrachill_is_activity_feed_card(false);
+				wp_reset_postdata();
+				?>
+			</li>
+		</ul>
+		<?php extrachill_pagination($pagination, 'bbpress'); ?>
+	</div>
+	<?php
+	$bbp->current_reply_id = $previous_reply_id;
+	$bbp->current_topic_id = $previous_topic_id;
+	$bbp->current_forum_id = $previous_forum_id;
 }

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -212,7 +212,7 @@ function extrachill_enqueue_scripts() {
 add_action('wp_enqueue_scripts', 'extrachill_enqueue_scripts', 20);
 
 function enqueue_content_expand_script() {
-	if ( is_page('recent') || is_page_template('page-templates/main-blog-comments-feed.php') ) {
+	if ( is_page('recent') || is_page_template('page-templates/main-blog-comments-feed.php') || ( function_exists('bbp_is_single_user_profile') && bbp_is_single_user_profile() ) ) {
 		$script_path      = '/inc/assets/js/content-expand.js';
 		$script_full_path = EXTRACHILL_COMMUNITY_PLUGIN_DIR . $script_path;
 		$version          = filemtime($script_full_path);

--- a/inc/user-profiles/profile-activity-feed.php
+++ b/inc/user-profiles/profile-activity-feed.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Profile Activity Feed
+ *
+ * Renders a user-scoped activity feed (the displayed user's topics + replies)
+ * on their bbPress profile page. This is a distinct surface from the global
+ * /recent page: it owns its own renderer and a query filtered to the displayed
+ * user via extrachill_get_user_activity_query(), so the two surfaces can no
+ * longer affect one another.
+ *
+ * Historically the global /recent template carried a dead `bbp_is_single_user()`
+ * branch that was never reachable (the template is only assigned to the /recent
+ * page), so profiles had no activity feed at all. This restores a correct,
+ * user-scoped feed.
+ *
+ * @package ExtraChillCommunity
+ */
+
+// Prevent direct access.
+if ( ! defined('ABSPATH') ) {
+	exit;
+}
+
+/**
+ * Render the displayed user's activity feed below their profile.
+ *
+ * Hooked to bbp_template_after_user_profile so it only renders on the main
+ * profile tab (bbp_is_single_user_profile()), not on the topics/replies/edit
+ * sub-tabs which already have their own bbPress loops.
+ *
+ * @return void
+ */
+function extrachill_render_profile_activity_feed() {
+	if ( ! function_exists('bbp_is_single_user_profile') || ! bbp_is_single_user_profile() ) {
+		return;
+	}
+
+	if ( ! function_exists('extrachill_get_user_activity_query') ) {
+		return;
+	}
+
+	$user_id = (int) bbp_get_displayed_user_id();
+	if ( $user_id <= 0 ) {
+		return;
+	}
+
+	$display_name = bbp_get_displayed_user_field('display_name');
+
+	$feed = extrachill_get_user_activity_query( $user_id, 15 );
+
+	echo '<div class="bbp-user-profile-card user-profile-activity-feed">';
+	printf(
+		'<h3>%s</h3>',
+		/* translators: %s: displayed user's name. */
+		esc_html( sprintf( __( "%s's Recent Activity", 'extra-chill-community' ), $display_name ) )
+	);
+
+	$empty_notice = sprintf(
+		/* translators: %s: displayed user's name. */
+		__( '%s has no recent activity yet.', 'extra-chill-community' ),
+		$display_name
+	);
+
+	extrachill_render_recent_feed( $feed, $empty_notice );
+
+	echo '</div>';
+}
+add_action( 'bbp_template_after_user_profile', 'extrachill_render_profile_activity_feed' );

--- a/page-templates/recent-feed-template.php
+++ b/page-templates/recent-feed-template.php
@@ -2,6 +2,12 @@
 /*
  * Template Name: Recent Activity Feed
  * Description: A page template to show the most recent replies across all forums in a Twitter-like stream.
+ *
+ * This template owns ONLY the global /recent activity page. It is intentionally
+ * forum-scoped (topics + replies across all forums) and NOT cross-network — see
+ * epic #53 Phase 3. The user-scoped profile activity feed lives in its own path
+ * (inc/user-profiles/profile-activity-feed.php), so this page can be changed or
+ * retired without touching profiles.
  */
 
 get_header();
@@ -9,16 +15,7 @@ get_header();
 <?php extrachill_breadcrumbs(); ?>
 
 <?php
-
-// Check if we are on a user profile page
-$isUserProfile = bbp_is_single_user();
-
-if ( $isUserProfile ) {
-	$feed_title = '@' . bbp_get_displayed_user_field('user_nicename');
-	echo '<div class="community-section-header"><h1 class="profile-title-inline">' . esc_html( $feed_title ) . '</h1></div>';
-} else {
-	echo '<div class="community-section-header"><h1>Recent Activity</h1></div>';
-}
+echo '<div class="community-section-header"><h1>' . esc_html__( 'Recent Activity', 'extra-chill-community' ) . '</h1></div>';
 
 // Output the standard WordPress content within the div
 if ( have_posts() ) :
@@ -28,83 +25,8 @@ if ( have_posts() ) :
 	endwhile;
 endif;
 
-// Set up the query to fetch the most recent replies
-$recent_feed = extrachill_get_recent_feed_query(15);
+// Global recent activity feed (unscoped, forum-wide).
+$recent_feed = extrachill_get_recent_feed_query( 15 );
+extrachill_render_recent_feed( $recent_feed );
 
-if ( $recent_feed && ! empty($recent_feed['items']) ) {
-	$feed_items        = $recent_feed['items'];
-	$pagination        = $recent_feed['pagination'];
-	$bbp               = bbpress();
-	$previous_reply_id = isset($bbp->current_reply_id) ? $bbp->current_reply_id : 0;
-	$previous_topic_id = isset($bbp->current_topic_id) ? $bbp->current_topic_id : 0;
-	$previous_forum_id = isset($bbp->current_forum_id) ? $bbp->current_forum_id : 0;
-	?>
-	<div id="bbpress-forums" class="bbpress-wrapper">
-		<ul class="forums bbp-replies">
-			<li class="bbp-body">
-				<?php
-				global $post;
-				foreach ( $feed_items as $feed_item ) {
-					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentionally sets the global $post for setup_postdata() and the bbPress template part below.
-					$post = $feed_item['post'];
-
-					if ( ! $post || ! is_object($post) ) {
-						continue;
-					}
-
-					setup_postdata($post);
-
-					// Set pre-fetched author data for template use
-					set_query_var('prefetch_author_id', $feed_item['author_id']);
-					set_query_var('prefetch_author_name', $feed_item['author_name']);
-					set_query_var('prefetch_author_avatar_url', $feed_item['author_avatar_url']);
-
-					// Set pre-fetched topic/forum data for template use
-					set_query_var('prefetch_topic_id', $feed_item['topic_id']);
-					set_query_var('prefetch_topic_url', $feed_item['topic_url']);
-					set_query_var('prefetch_topic_title', $feed_item['topic_title']);
-					set_query_var('prefetch_forum_id', $feed_item['forum_id']);
-					set_query_var('prefetch_forum_url', $feed_item['forum_url']);
-					set_query_var('prefetch_forum_title', $feed_item['forum_title']);
-
-					$bbp->current_reply_id = $post->ID;
-
-					if ( bbp_get_topic_post_type() === $post->post_type ) {
-						$topic_id = $post->ID;
-					} else {
-						$topic_id = (int) get_post_field( 'post_parent', $post->ID );
-						if ( empty( $topic_id ) ) {
-							$topic_id = (int) get_post_meta( $post->ID, '_bbp_topic_id', true );
-						}
-					}
-
-					$bbp->current_topic_id = $topic_id;
-					$bbp->current_forum_id = $topic_id ? bbp_get_topic_forum_id($topic_id) : 0;
-
-					bbp_get_template_part('loop', 'single-reply-card');
-
-					$bbp->current_reply_id = 0;
-					$bbp->current_topic_id = 0;
-					$bbp->current_forum_id = 0;
-
-					wp_reset_postdata();
-				}
-
-				wp_reset_postdata();
-				?>
-			</li>
-		</ul>
-		<?php extrachill_pagination($pagination, 'bbpress'); ?>
-	</div>
-	<?php
-	$bbp->current_reply_id = $previous_reply_id;
-	$bbp->current_topic_id = $previous_topic_id;
-	$bbp->current_forum_id = $previous_forum_id;
-} else {
-	echo '<div class="notice notice-info"><p>No recent activity found.</p></div>';
-}
-
-?>
-<?php
 get_footer();
-?>


### PR DESCRIPTION
## Summary

Decouples the global `/recent` activity page from the per-user profile activity feed, and fixes the latent correctness problem behind issue #67. Each surface now owns its own template path **and** its own query.

Closes #67.

## What the production check found (the bug, precisely)

The issue suspected the profile "activity feed" was rendering **global** activity under a user's name because the profile branch called the same unscoped query. The real situation was slightly different and worse:

- `page-templates/recent-feed-template.php` carried a `$isUserProfile = bbp_is_single_user()` branch that **could never fire**. That template is only ever assigned to the `/recent` page (verified on prod: page ID 542 is the *only* page using it), where `bbp_is_single_user()` is always `false`.
- User profiles (`/u/<name>`) render `user-profile.php` (counts + links) and had **no reply-activity feed at all**.

So the profile feed wasn't showing global-activity-under-a-username — it was **dead code plus a missing feed**. Either way the fix is the same: give the profile its own correct, user-scoped feed and let `/recent` own the global one cleanly.

## How each surface now owns its own path + query

**Query layer (`inc/content/recent-feed.php`)**
- `extrachill_build_activity_feed( $per_page, $paged, $author )` — shared internal builder; `$author = 0` is the unscoped global feed, `$author = <id>` scopes to one user.
- `extrachill_get_recent_feed_query()` — global, unscoped (unchanged signature/behavior).
- `extrachill_get_user_activity_query( $user_id, ... )` — **new**, user-scoped via `author => $user_id`. This **repurposes** the removed near-duplicate `extrachill_get_recent_activity_query()` (which had **zero callers** anywhere in the network).
- `extrachill_render_recent_feed( $feed, $empty_notice )` — shared renderer extracted from the template so both surfaces emit identical card markup.

**Global `/recent` (`page-templates/recent-feed-template.php`)**
- Dead `$isUserProfile` branch removed. The template now renders **only** the global feed via `extrachill_get_recent_feed_query()` + the shared renderer.

**Profile feed (`inc/user-profiles/profile-activity-feed.php`, new)**
- Renders the **displayed user's** activity via `extrachill_get_user_activity_query( bbp_get_displayed_user_id() )`, hooked on `bbp_template_after_user_profile` and gated to `bbp_is_single_user_profile()` so it only shows on the main profile tab.

**Card chrome decoupled from the page template**
- `loop-single-reply-card.php` / `loop-single-topic-card.php` previously gated the "in forum / in reply to" header + content truncation on `is_page_template('…/recent-feed-template.php')`. They now also honor a `extrachill_is_activity_feed_card()` context flag the shared renderer sets, so cards render correctly in **both** feed contexts (global and profile).
- `assets.php`: `content-expand.js` (read-more toggle) now also loads on profile pages so the feed's truncation works there.

## Profile feed is now user-scoped; /recent stays forum-scoped

- The profile feed is filtered to the displayed user — it can no longer render global activity.
- The global `/recent` page remains **forum-scoped** (topics + replies across all forums) and is explicitly **not** cross-network / a firehose, per epic #53 Phase 3.
- The two surfaces no longer share a template branch or a query call, so `/recent` can be changed/retired later without risking profiles.

## Verify
- `/recent` → `<h1>Recent Activity</h1>` + 15 global reply cards, paginated, scope unchanged.
- A user profile → new "<Name>'s Recent Activity" feed showing **only that user's** topics/replies.
- `php -l` clean on all touched files; `homeboy lint` reports **0 errors** (the 2 warnings on `loop-single-reply-card.php` are pre-existing `WordPress.WP.Capabilities.Unknown` on `edit_topic`/`edit_reply` at lines 218/224, untouched by this PR).
- No JS/CSS/block sources touched, so no `npm run build` artifact changes.

## Non-goals (unchanged)
- Deciding `/recent`'s ultimate fate (retire vs upgrade) — a follow-up this decoupling now unblocks.
- Any cross-network feed design (separate; epic #53 Phase 3).