### PR TITLE
Phase 4: fill The Lab (open web × music × build-in-public) + re-home support strays + retire Independent Artists predecessor

### DIFF
--- a/inc/core/activation.php
+++ b/inc/core/activation.php
@@ -197,7 +197,7 @@ function extrachill_create_community_forums() {
 		array(
 			'title'       => 'The Lab',
 			'slug'        => 'the-lab',
-			'description' => 'The open web, WordPress, AI × music, and build-in-public. Site-building help for artists, dev logs, and tinkering with how independent music lives online.',
+			'description' => 'The differentiator room: the open web, WordPress, AI × music, and build-in-public. Dev logs, roadmap, feature requests, and practical site-building help for artists — how independent music should live online, owning your corner of the web instead of renting it. Music always leads; this is the evidence we walk the walk.',
 		),
 	);
 

--- a/scripts/migrate-phase-4-the-lab.php
+++ b/scripts/migrate-phase-4-the-lab.php
@@ -1,0 +1,333 @@
+<?php
+/**
+ * Phase 4 — The Lab fill + cleanup migration (issue #69).
+ *
+ * One-time, idempotent, dry-runnable data migration. NOT loaded by the plugin —
+ * run once against the community site (blog 2). `eval-file` passes positional
+ * args through `$args`, so pass the literal word `dry-run` (no leading dashes)
+ * for a no-write preview:
+ *
+ *   # Preview (no writes):
+ *   wp --allow-root --path=/var/www/extrachill.com \
+ *      --url=community.extrachill.com \
+ *      eval-file scripts/migrate-phase-4-the-lab.php dry-run
+ *
+ *   # Apply (ONLY after the plan is reviewed on the PR):
+ *   wp --allow-root --path=/var/www/extrachill.com \
+ *      --url=community.extrachill.com \
+ *      eval-file scripts/migrate-phase-4-the-lab.php
+ *
+ * What it does:
+ *   1. Refreshes The Lab (13548) forum description so its differentiator
+ *      identity is visible: open web · WordPress · AI × music · build-in-public
+ *      · dev log · roadmap / feature requests.
+ *   2. MIGRATE gathered Lab-material INTO The Lab (13548):
+ *        - 554   "Community Website Ideas"   (from Extra Chill Team 547)
+ *        - 11342 "Need a Website? Affordable WordPress Dev for Bands…" (from
+ *                 The Back Bar 81)
+ *      (5298 "Tool" stays in Music Discussion — it's about the band Tool /
+ *       Danny Carey, not a software tool. Verified by body.)
+ *   3. Re-home support strays OUT of The Lab into The Back Bar (81):
+ *        - 14114 "Can't edit link page"
+ *        - 13554 "How to Use The Extra Chill Community"
+ *        - 13580 "Question about inserting a Spotify preview…"
+ *        - 13639 "Comedy Board?"
+ *      (13563/13564/13582/13642/13663 stay — genuine Lab-material.)
+ *   4. Retire the dead "Independent Artists" predecessor (5432):
+ *        - Repoint the 4 stray reply `_bbp_forum_id` refs (1424, 1425, 1465,
+ *          8535) to whatever forum each reply's parent topic actually lives in
+ *          (all three parent topics — 1420, 1393, 2225 — are live in Artist
+ *          Corner 14120, so the refs become 14120).
+ *        - Trash forum 5432 (0 topics; no nav/template/code links).
+ *   5. Recalculate bbPress counts on every affected forum.
+ *
+ * bbPress reassignment contract honored (same as #58/#63):
+ *   - Topic: post_parent -> dest forum; _bbp_forum_id meta via
+ *     bbp_update_topic_forum_id().
+ *   - Replies: _bbp_forum_id meta via bbp_update_reply_forum_id()
+ *     (reply post_parent stays = topic_id, which is correct for bbPress).
+ *   - Counts recalculated directly (bbp_update_forum() only recounts inside
+ *     bbp_deleted_topic/save_post filters, so we call the count helpers).
+ *
+ * Idempotent: re-running is safe. Topics already in the destination forum are
+ * skipped; refs already repointed are left as-is; an already-trashed 5432 is
+ * left as-is.
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+$script_args = (array) ( $args ?? array() );
+$dry_run     = in_array( 'dry-run', $script_args, true )
+	|| in_array( '--dry-run', $script_args, true );
+
+/**
+ * Echo helper.
+ *
+ * @param string $msg Message.
+ */
+$log = static function ( $msg ) {
+	WP_CLI::log( $msg );
+};
+
+if ( $dry_run ) {
+	$log( '=== DRY RUN — no writes will be performed ===' );
+}
+
+/** ---------------------------------------------------------------------------
+ * Configuration.
+ * ------------------------------------------------------------------------- */
+
+$the_lab_forum_id    = 13548; // The Lab.
+$back_bar_forum_id    = 81;   // The Back Bar (off-topic / catch-all).
+$artist_corner_id     = 14120; // Artist Corner.
+$independent_artists  = 5432; // Dead predecessor to Artist Corner.
+
+// The Lab's refreshed description — the differentiator identity, made visible.
+$the_lab_description = 'The differentiator room: the open web, WordPress, AI × music, and build-in-public. '
+	. 'Dev logs, roadmap, feature requests, and practical site-building help for artists — how independent '
+	. 'music should live online, owning your corner of the web instead of renting it. Music always leads; '
+	. 'this is the evidence we walk the walk.';
+
+// Lab-material to GATHER into The Lab (topic_id => human-readable label).
+$gather_into_lab = array(
+	554   => 'Community Website Ideas (from Extra Chill Team 547)',
+	11342 => 'Need a Website? Affordable WordPress Dev for Bands (from The Back Bar 81)',
+);
+
+// Support / off-topic strays to re-home OUT of The Lab into The Back Bar.
+$rehome_to_back_bar = array(
+	14114 => "Can't edit link page (support)",
+	13554 => 'How to Use The Extra Chill Community (help)',
+	13580 => 'Question about inserting a Spotify preview (support)',
+	13639 => 'Comedy Board? (off-topic)',
+);
+
+// Stray reply refs pointing at the dead predecessor forum 5432. Each is
+// repointed to its parent topic's actual forum.
+$predecessor_reply_refs = array( 1424, 1425, 1465, 8535 );
+
+/** ---------------------------------------------------------------------------
+ * Helper: recalc all bbPress counts for a forum.
+ * ------------------------------------------------------------------------- */
+$recalc_forum = static function ( $forum_id ) use ( $log, $dry_run ) {
+	if ( ! $forum_id ) {
+		return;
+	}
+	if ( $dry_run ) {
+		$log( "  [dry-run] would recalc counts for forum {$forum_id}" );
+		return;
+	}
+	bbp_update_forum_topic_count( $forum_id );
+	bbp_update_forum_topic_count_hidden( $forum_id );
+	bbp_update_forum_reply_count( $forum_id );
+	bbp_update_forum_reply_count_hidden( $forum_id );
+	bbp_update_forum_last_topic_id( $forum_id );
+	bbp_update_forum_last_reply_id( $forum_id );
+	bbp_update_forum_last_active_id( $forum_id );
+	bbp_update_forum_last_active_time( $forum_id );
+	$log( "  recalculated counts for forum {$forum_id} (topics=" . bbp_get_forum_topic_count( $forum_id, true, true ) . ')' );
+};
+
+/** ---------------------------------------------------------------------------
+ * Helper: reassign a single topic (and its replies) to a destination forum.
+ * Returns true if a move actually happened.
+ * ------------------------------------------------------------------------- */
+$move_topic = static function ( $topic_id, $dest_forum_id ) use ( $log, $dry_run ) {
+	$topic_post = get_post( $topic_id );
+	if ( ! $topic_post || bbp_get_topic_post_type() !== $topic_post->post_type ) {
+		WP_CLI::warning( "  topic {$topic_id} not found or not a topic — skipping." );
+		return false;
+	}
+
+	$current_parent = (int) $topic_post->post_parent;
+	if ( $current_parent === (int) $dest_forum_id ) {
+		$log( "  topic {$topic_id} already in forum {$dest_forum_id} — skip" );
+		return false; // Idempotent skip.
+	}
+
+	$title = get_the_title( $topic_id );
+
+	if ( $dry_run ) {
+		$log( "  [dry-run] would move topic {$topic_id} ({$title}) from {$current_parent} -> {$dest_forum_id}" );
+		return true;
+	}
+
+	// Move the topic post_parent.
+	wp_update_post(
+		array(
+			'ID'          => $topic_id,
+			'post_parent' => $dest_forum_id,
+		)
+	);
+
+	// Update topic _bbp_forum_id meta (canonical bbPress helper).
+	bbp_update_topic_forum_id( $topic_id, $dest_forum_id );
+
+	// Update every reply's _bbp_forum_id meta. Replies keep post_parent =
+	// topic_id (correct for bbPress); only the forum-id meta changes.
+	$reply_ids = get_posts(
+		array(
+			'post_type'      => bbp_get_reply_post_type(),
+			'post_status'    => array( 'publish', 'closed', 'private', 'hidden', 'pending', 'spam', 'trash' ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_key'       => '_bbp_topic_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_value'     => $topic_id,       // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+		)
+	);
+	foreach ( $reply_ids as $reply_id ) {
+		bbp_update_reply_forum_id( $reply_id, $dest_forum_id );
+	}
+
+	$log( "  moved topic {$topic_id} ({$title}) -> forum {$dest_forum_id} (" . count( $reply_ids ) . ' replies)' );
+	return true;
+};
+
+/** ===========================================================================
+ * STEP 1 — Refresh The Lab forum description.
+ * ======================================================================== */
+$log( "\n== Step 1: refresh The Lab description ==" );
+$lab = get_post( $the_lab_forum_id );
+if ( $lab && 'forum' === $lab->post_type ) {
+	if ( trim( $lab->post_content ) === trim( $the_lab_description ) ) {
+		$log( '  The Lab description already current — skip' );
+	} elseif ( $dry_run ) {
+		$log( "  [dry-run] would update forum {$the_lab_forum_id} description" );
+	} else {
+		wp_update_post(
+			array(
+				'ID'           => $the_lab_forum_id,
+				'post_content' => $the_lab_description,
+			)
+		);
+		$log( "  updated The Lab ({$the_lab_forum_id}) description" );
+	}
+} else {
+	WP_CLI::warning( "The Lab forum {$the_lab_forum_id} not found — skipping description refresh." );
+}
+
+/** ===========================================================================
+ * STEP 2 — Gather Lab-material INTO The Lab.
+ * ======================================================================== */
+$log( "\n== Step 2: gather Lab-material into The Lab ==" );
+foreach ( $gather_into_lab as $topic_id => $label ) {
+	$log( "  {$topic_id}: {$label}" );
+	$move_topic( $topic_id, $the_lab_forum_id );
+}
+
+/** ===========================================================================
+ * STEP 3 — Re-home support strays out of The Lab into The Back Bar.
+ * ======================================================================== */
+$log( "\n== Step 3: re-home support strays into The Back Bar ==" );
+foreach ( $rehome_to_back_bar as $topic_id => $label ) {
+	$log( "  {$topic_id}: {$label}" );
+	$move_topic( $topic_id, $back_bar_forum_id );
+}
+
+/** ===========================================================================
+ * STEP 4 — Retire the Independent Artists predecessor (5432).
+ *
+ * Repoint each stray reply's _bbp_forum_id to its parent topic's actual forum,
+ * then trash 5432 (only if it has no topics/subforums).
+ * ======================================================================== */
+$log( "\n== Step 4: retire Independent Artists predecessor (5432) ==" );
+
+foreach ( $predecessor_reply_refs as $reply_id ) {
+	$reply = get_post( $reply_id );
+	if ( ! $reply || bbp_get_reply_post_type() !== $reply->post_type ) {
+		WP_CLI::warning( "  ref {$reply_id} not found or not a reply — skipping." );
+		continue;
+	}
+
+	$current_ref = (int) get_post_meta( $reply_id, '_bbp_forum_id', true );
+	if ( $current_ref !== $independent_artists ) {
+		$log( "  reply {$reply_id} _bbp_forum_id already {$current_ref} (not 5432) — skip" );
+		continue;
+	}
+
+	// Resolve the reply's parent topic and that topic's real forum.
+	$topic_id = (int) get_post_meta( $reply_id, '_bbp_topic_id', true );
+	if ( ! $topic_id ) {
+		$topic_id = (int) $reply->post_parent; // bbPress reply post_parent = topic_id.
+	}
+	$topic = $topic_id ? get_post( $topic_id ) : null;
+
+	if ( $topic && bbp_get_topic_post_type() === $topic->post_type ) {
+		$dest_forum = (int) $topic->post_parent; // The topic's live forum.
+	} else {
+		// Parent topic missing — fall back to Artist Corner (the successor).
+		$dest_forum = $artist_corner_id;
+		WP_CLI::warning( "  reply {$reply_id} parent topic {$topic_id} missing — repointing to Artist Corner {$artist_corner_id}." );
+	}
+
+	if ( $dry_run ) {
+		$log( "  [dry-run] would repoint reply {$reply_id} _bbp_forum_id 5432 -> {$dest_forum} (topic {$topic_id})" );
+		continue;
+	}
+	bbp_update_reply_forum_id( $reply_id, $dest_forum );
+	$log( "  repointed reply {$reply_id} _bbp_forum_id -> {$dest_forum} (topic {$topic_id})" );
+}
+
+// Trash 5432 if empty.
+$ia = get_post( $independent_artists );
+if ( ! $ia || 'forum' !== $ia->post_type ) {
+	$log( "  forum {$independent_artists} not found — nothing to trash" );
+} elseif ( 'trash' === $ia->post_status ) {
+	$log( "  forum {$independent_artists} already trashed — skip" );
+} else {
+	$remaining_topics = get_posts(
+		array(
+			'post_type'      => bbp_get_topic_post_type(),
+			'post_parent'    => $independent_artists,
+			'post_status'    => array( 'publish', 'closed', 'private', 'hidden', 'pending' ),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+	$subforums = get_posts(
+		array(
+			'post_type'      => 'forum',
+			'post_parent'    => $independent_artists,
+			'post_status'    => array( 'publish', 'private', 'hidden' ),
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+
+	if ( ! empty( $remaining_topics ) ) {
+		WP_CLI::warning( "  forum {$independent_artists} still has topics — NOT trashing." );
+	} elseif ( ! empty( $subforums ) ) {
+		WP_CLI::warning( "  forum {$independent_artists} still has subforums — NOT trashing." );
+	} elseif ( $dry_run ) {
+		$log( "  [dry-run] would trash empty predecessor forum {$independent_artists}" );
+	} else {
+		wp_trash_post( $independent_artists );
+		$log( "  trashed empty predecessor forum {$independent_artists}" );
+	}
+}
+
+/** ===========================================================================
+ * STEP 5 — Recalculate counts on every affected forum.
+ * ======================================================================== */
+$log( "\n== Step 5: recalculate bbPress counts ==" );
+$affected = array_unique(
+	array(
+		$the_lab_forum_id,
+		$back_bar_forum_id,
+		$artist_corner_id,
+		547,  // Extra Chill Team (source of 554).
+		1983, // Music Discussion (unchanged but harmless to recalc).
+		$independent_artists,
+	)
+);
+foreach ( $affected as $forum_id ) {
+	if ( $forum_id > 0 ) {
+		$recalc_forum( $forum_id );
+	}
+}
+
+WP_CLI::success( $dry_run ? 'Dry run complete.' : 'Phase 4 The Lab migration complete.' );

--- a/scripts/seed-the-lab-roadmap-stub.php
+++ b/scripts/seed-the-lab-roadmap-stub.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Phase 4 — The Lab "Roadmap / What we're building" pinned stub (issue #69).
+ *
+ * One-time, idempotent, dry-runnable. NOT loaded by the plugin. Creates a
+ * SINGLE structural pinned topic in The Lab (13548) that frames the room and
+ * points at the existing feature-request flow. This is STRUCTURE, not
+ * fabricated dev-log history — no fake activity is authored.
+ *
+ *   # Preview (no writes):
+ *   wp --allow-root --path=/var/www/extrachill.com \
+ *      --url=community.extrachill.com \
+ *      eval-file scripts/seed-the-lab-roadmap-stub.php dry-run
+ *
+ *   # Apply (ONLY after the plan is reviewed on the PR):
+ *   wp --allow-root --path=/var/www/extrachill.com \
+ *      --url=community.extrachill.com \
+ *      eval-file scripts/seed-the-lab-roadmap-stub.php
+ *
+ * Idempotent: keyed on slug `the-lab-roadmap`. Re-running will not duplicate.
+ * The topic author defaults to the first administrator on the community site;
+ * override with `EC_LAB_ROADMAP_AUTHOR=<user_id>` if needed.
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	return;
+}
+
+$script_args = (array) ( $args ?? array() );
+$dry_run     = in_array( 'dry-run', $script_args, true )
+	|| in_array( '--dry-run', $script_args, true );
+
+$log = static function ( $msg ) {
+	WP_CLI::log( $msg );
+};
+
+if ( $dry_run ) {
+	$log( '=== DRY RUN — no writes will be performed ===' );
+}
+
+$the_lab_forum_id = 13548;
+$stub_slug        = 'the-lab-roadmap';
+$stub_title       = 'Roadmap / What we\'re building';
+
+// Structural framing only — no fabricated history, no fake dev-log entries.
+$stub_body = <<<'HTML'
+<p>Welcome to <strong>The Lab</strong> — the open-web, build-in-public corner of Extra Chill. This is where we talk about how independent music should live online: WordPress, the open web, AI × music, dev logs, and the tools artists actually use to own their corner of the internet instead of renting it.</p>
+
+<h2>What lives here</h2>
+<ul>
+<li><strong>Dev log &amp; build-in-public</strong> — what we shipped, what we're tinkering with, what the platform is becoming.</li>
+<li><strong>Roadmap &amp; feature requests</strong> — what's next, and your input on it.</li>
+<li><strong>Site-building for artists</strong> — practical help with link pages, websites, and the music × web-ownership intersection.</li>
+</ul>
+
+<h2>Got a feature idea or found a bug?</h2>
+<p>Post it in <a href="https://community.extrachill.com/t/bug-reports-feature-requests">Bug Reports / Feature Requests</a>. Requests there feed our build pipeline directly — this is the real entry point, not a suggestion box that goes nowhere.</p>
+
+<p>Music always leads at Extra Chill. The Lab is the evidence we walk the walk: an independent music platform built in public, on the open web.</p>
+HTML;
+
+/** ---------------------------------------------------------------------------
+ * Idempotency: bail if a topic with this slug already exists in The Lab.
+ * ------------------------------------------------------------------------- */
+global $wpdb;
+$existing = $wpdb->get_var(
+	$wpdb->prepare(
+		"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND post_name = %s AND post_status NOT IN ( 'trash', 'auto-draft' ) LIMIT 1",
+		bbp_get_topic_post_type(),
+		$stub_slug
+	)
+);
+if ( $existing ) {
+	$log( "  roadmap stub already exists (topic {$existing}) — nothing to do" );
+	WP_CLI::success( 'Roadmap stub already present.' );
+	return;
+}
+
+// Resolve forum.
+$lab = get_post( $the_lab_forum_id );
+if ( ! $lab || 'forum' !== $lab->post_type ) {
+	WP_CLI::error( "The Lab forum {$the_lab_forum_id} not found." );
+}
+
+// Resolve an author (env override, else first admin).
+$author_id = (int) getenv( 'EC_LAB_ROADMAP_AUTHOR' );
+if ( ! $author_id ) {
+	$admins    = get_users(
+		array(
+			'role'    => 'administrator',
+			'number'  => 1,
+			'orderby' => 'ID',
+			'order'   => 'ASC',
+			'fields'  => 'ID',
+		)
+	);
+	$author_id = ! empty( $admins ) ? (int) $admins[0] : 0;
+}
+if ( ! $author_id ) {
+	WP_CLI::error( 'No administrator found to author the roadmap stub. Pass EC_LAB_ROADMAP_AUTHOR=<user_id>.' );
+}
+
+if ( $dry_run ) {
+	$log( "  [dry-run] would create pinned topic '{$stub_title}' (slug {$stub_slug}) in forum {$the_lab_forum_id} by user {$author_id}" );
+	WP_CLI::success( 'Dry run complete.' );
+	return;
+}
+
+/** ---------------------------------------------------------------------------
+ * Create via bbp_insert_topic so all bbPress topic meta is set correctly.
+ * ------------------------------------------------------------------------- */
+$topic_id = bbp_insert_topic(
+	array(
+		'post_parent'  => $the_lab_forum_id,
+		'post_author'  => $author_id,
+		'post_title'   => $stub_title,
+		'post_name'    => $stub_slug,
+		'post_content' => $stub_body,
+		'post_status'  => bbp_get_public_status_id(),
+	),
+	array(
+		'forum_id' => $the_lab_forum_id,
+	)
+);
+
+if ( is_wp_error( $topic_id ) || ! $topic_id ) {
+	WP_CLI::error( 'Failed to create the roadmap stub topic.' );
+}
+
+// Pin it (super-sticky to the forum).
+bbp_stick_topic( $topic_id, true );
+
+// Recalc forum counts.
+bbp_update_forum_topic_count( $the_lab_forum_id );
+bbp_update_forum_last_topic_id( $the_lab_forum_id );
+bbp_update_forum_last_active_id( $the_lab_forum_id );
+bbp_update_forum_last_active_time( $the_lab_forum_id );
+
+$log( "  created + pinned roadmap stub topic {$topic_id} in The Lab ({$the_lab_forum_id})" );
+WP_CLI::success( 'Roadmap stub created.' );


### PR DESCRIPTION
Closes #69. Child of #53 (Phase 4). Refs the #63 bbPress-reassignment contract.

> **Plan-for-review, not applied.** Per #69's hard constraint (a prior phase minion ran an unauthorized live migration — do not repeat), **NO production data was mutated.** Every data change is an **idempotent, dry-runnable** WP-CLI script. The migration dry-run was validated read-only against prod (blog 2) — output below. Apply only after this plan is reviewed. **PR only — do not merge.**

---

## What WAS applied (code-only, no prod data)
- `inc/core/activation.php` — sharpened The Lab fresh-install description toward the differentiator identity (open web · WordPress · AI × music · build-in-public · dev log · roadmap / feature requests).
- `scripts/migrate-phase-4-the-lab.php` — **new**, idempotent/dry-runnable data migration (not loaded by the plugin).
- `scripts/seed-the-lab-roadmap-stub.php` — **new**, idempotent/dry-runnable optional pinned roadmap stub (structure only, zero fabricated dev-log history).

## What AWAITS review before applying to prod
Everything under "Proposed migration" below. The scripts exist and dry-run clean; they have **not** been run for-real.

---

## Part A — Lab-material content audit (titles AND bodies, all 6 forums)

Searched every active forum's topic **titles + bodies** and **reply bodies** (`_bbp_forum_id` / `_bbp_topic_id` joins, REGEXP on wordpress|website|dev log|roadmap|feature request|build-in-public|open web|extrachill.link|link page|AI|plugin|domain|hosting…). The prior search only checked titles; this dug into content.

### Confirmed Lab-material currently OUTSIDE The Lab → **migrate IN**
| Topic | Title | Currently in | Verdict |
|---|---|---|---|
| **554** | Community Website Ideas | Extra Chill Team (547, hidden) | ✅ feature ideas/requests = Lab |
| **11342** | Need a Website? Affordable WordPress Dev for Bands | The Back Bar (81) | ✅ music × web-ownership — exactly The Lab's intersection |

### Checked candidate, REJECTED (stays put)
| Topic | Title | Why it's NOT Lab |
|---|---|---|
| **5298** | "Tool" | Body verified: it's about the **band Tool / Danny Carey**, not a software tool. Stays in Music Discussion. |

### Other keyword hits, all REJECTED (false positives / leave)
- **2244** "Donuts - J Dilla" — `wordpress.com` only in an image URL; music album writeup. Leave.
- **11562** "New Music 2025" (reply 13537) — `extrachill.link` is just a band's bio URL, not Lab discussion. Leave.
- **14090** "Hello from Sarai Chinwag" — an AI bot's first-post/test in The Back Bar (build-in-public flavored but a test stub, not a dev-log). **Discretionary** — I leaned *leave*; flagging for your call.
- **11519** "Sarai Chinwag Test" — explicit bot test stub in the internal Team forum. Leave.

> **Reframe honored:** Part A is a content **audit + migration proposal**, not authoring. No build-in-public posts were fabricated. The richest build-in-public history lives in Discord, not the forum — genuinely-new seed posts are a human's job later.

---

## The Lab — current state (correction to the issue)
The issue listed 8 topics; prod actually has **9**. The undocumented one is genuine Lab-material and **stays**:
- **13563** "Extrachill.link Documentation" (closed) — tool documentation paired with the 13564 feedback thread. ✅ keep.

Full keep set in The Lab after this change: 13582 (Developer Log), 13642 (Bug Reports/Feature Requests), 13663 (chris, fix the things), 13564 (Extrachill.Link Feedback), 13563 (Extrachill.link Documentation) + the two gathered (554, 11342) + the optional roadmap stub.

---

## Part B — Proposed migration: re-home support strays OUT of The Lab
The Lab has no business holding support tickets. There is **no dedicated Support forum** in the current 6-forum set, and creating one would be premature infrastructure (against the platform ethos). Cleanest existing home = **The Back Bar (81)**, the general/catch-all room.

| Topic | Title | Replies | → Destination |
|---|---|---|---|
| 14114 | Can't edit link page | 2 | The Back Bar (81) |
| 13554 | How to Use The Extra Chill Community | 3 | The Back Bar (81) |
| 13580 | Question about inserting a Spotify preview | 1 | The Back Bar (81) |
| 13639 | Comedy Board? (off-topic) | 2 | The Back Bar (81) |

> **Open question for review:** sending support tickets to The Back Bar slightly dilutes its "party" identity. Alternatives: (a) a single pinned "Help / How-to" thread, or (b) leave 13554 (genuine onboarding help) where it is. Happy to adjust — flagged rather than decided.

---

## Part C — Proposed retirement: Independent Artists predecessor (5432)
`Independent Artists` (5432, **hidden, 0 topics**) is the dead predecessor to Artist Corner (14120). Verified:
- **0 topics** under it.
- **4 stray reply `_bbp_forum_id` refs**: 1424, 1425, 1465, 8535. All 4 parent topics (1420, 1393, 2225) are **live (publish) and already in Artist Corner (14120)**.
- **No code/nav/template links** to 5432 — grepped the community plugin, the theme, and `extrachill-artist-platform`; the only "5432" hit anywhere is a hex color `#654321` in `root.css`. No menu items (`_menu_item_object_id=5432` → empty).

Plan: repoint the 4 refs to their parent topics' real forum (14120), then trash the empty 5432.

| Reply | Parent topic | Topic's forum | New ref |
|---|---|---|---|
| 1424 (draft) | 1420 *Jtrawwww – Charleston, SC* | Artist Corner 14120 | 14120 |
| 1425 (draft) | 1393 *American Fried Rice* | Artist Corner 14120 | 14120 |
| 1465 (draft) | 1393 *American Fried Rice* | Artist Corner 14120 | 14120 |
| 8535 (spam) | 2225 *Nordista Freeze* | Artist Corner 14120 | 14120 |

---

## bbPress contract (same as #58/#63)
- Topic: `post_parent` → dest forum; `_bbp_forum_id` via `bbp_update_topic_forum_id()`.
- Replies: `_bbp_forum_id` via `bbp_update_reply_forum_id()` (reply `post_parent` stays = topic_id — correct for bbPress).
- Counts recalculated directly on every affected forum (13548, 81, 14120, 547, 1983, 5432).
- 5432 refs repointed before the forum is trashed; trash guarded on "0 topics + 0 subforums".

## Roadmap stub (optional, structure-only)
`scripts/seed-the-lab-roadmap-stub.php` creates ONE pinned topic "Roadmap / What we're building" framing the room + pointing at the existing `file_feature_request` roadie flow (via the 13642 Bug Reports / Feature Requests thread). No fabricated history. Idempotent on slug `the-lab-roadmap`. Apply separately after review.

---

## Dry-run output (read-only against prod, no writes)

```
== Step 1: refresh The Lab description ==
  [dry-run] would update forum 13548 description
== Step 2: gather Lab-material into The Lab ==
  [dry-run] would move topic 554 -> 13548
  [dry-run] would move topic 11342 -> 13548
== Step 3: re-home support strays into The Back Bar ==
  [dry-run] would move topic 14114 -> 81
  [dry-run] would move topic 13554 -> 81
  [dry-run] would move topic 13580 -> 81
  [dry-run] would move topic 13639 -> 81
== Step 4: retire Independent Artists predecessor (5432) ==
  [dry-run] would repoint reply 1424 _bbp_forum_id 5432 -> 14120 (topic 1420)
  [dry-run] would repoint reply 1425 _bbp_forum_id 5432 -> 14120 (topic 1393)
  [dry-run] would repoint reply 1465 _bbp_forum_id 5432 -> 14120 (topic 1393)
  [dry-run] would repoint reply 8535 _bbp_forum_id 5432 -> 14120 (topic 2225)
  [dry-run] would trash empty predecessor forum 5432
```

## How to apply (after review)
```bash
# Dry-run again:
wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com \
   eval-file scripts/migrate-phase-4-the-lab.php dry-run
# Apply:
wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com \
   eval-file scripts/migrate-phase-4-the-lab.php
# Optional roadmap stub:
wp --allow-root --path=/var/www/extrachill.com --url=community.extrachill.com \
   eval-file scripts/seed-the-lab-roadmap-stub.php
```

## Verification done
- PHP syntax clean on all 3 touched files; scripts mirror the lint-clean #58/#63 migration template (same helpers, same `phpcs:ignore` annotations).
- No assets touched → no `npm run build` needed.
- No code references to 5432 anywhere (community plugin, theme, artist-platform, menus).

## Non-goals
- Cross-network feed / auto-threading (Phase 3 — own design pass).
- Homepage (Phase 2, done).
- Authoring fabricated build-in-public content (explicitly out per the reframe).

**DO NOT MERGE — awaiting review of the proposed migration plan.**