### PR TITLE
style: phpcbf autofix sweep for WordPress coding standards (#39)

### DIFF
--- a/scripts/migrate-phase-4-followup-cleanup.php
+++ b/scripts/migrate-phase-4-followup-cleanup.php
@@ -227,7 +227,7 @@ if ( ! $shakedown || 'forum' !== $shakedown->post_type ) {
 			'fields'         => 'ids',
 		)
 	);
-	$subforums = get_posts(
+	$subforums        = get_posts(
 		array(
 			'post_type'      => 'forum',
 			'post_parent'    => $shakedown_id,

--- a/scripts/migrate-phase-4-the-lab.php
+++ b/scripts/migrate-phase-4-the-lab.php
@@ -82,9 +82,9 @@ if ( $dry_run ) {
  * ------------------------------------------------------------------------- */
 
 $the_lab_forum_id    = 13548; // The Lab.
-$back_bar_forum_id    = 81;   // The Back Bar (off-topic / catch-all).
-$artist_corner_id     = 14120; // Artist Corner.
-$independent_artists  = 5432; // Dead predecessor to Artist Corner.
+$back_bar_forum_id   = 81;   // The Back Bar (off-topic / catch-all).
+$artist_corner_id    = 14120; // Artist Corner.
+$independent_artists = 5432; // Dead predecessor to Artist Corner.
 
 // The Lab's refreshed description — the differentiator identity, made visible.
 $the_lab_description = 'The differentiator room: the open web, WordPress, AI × music, and build-in-public. '
@@ -288,7 +288,7 @@ if ( ! $ia || 'forum' !== $ia->post_type ) {
 			'fields'         => 'ids',
 		)
 	);
-	$subforums = get_posts(
+	$subforums        = get_posts(
 		array(
 			'post_type'      => 'forum',
 			'post_parent'    => $independent_artists,


### PR DESCRIPTION
## Summary

Mechanical **phpcbf autofix sweep** against the WordPress PHPCS standard, per #39. This PR contains **only** the auto-fixable formatting changes — no logic or behavior changes.

### ⚠️ The #39 baseline was stale
Issue #39 cites **4,447 findings (~4,017 auto-fixable)**. That count reflected the tree **before** the recent cleanup work landed. This branch is cut from **current `main`**, where PRs **#72 / #76 / #77 / #83** (dead-code removal + topic-reply god-file split) already eliminated the vast majority of that debt.

Running the repo's own tooling (`homeboy lint --extension wordpress`) against current `main` reports the **real** starting state:

| | Errors | Warnings | Auto-fixable | Files with issues |
|---|---|---|---|---|
| **Before** (this branch base = main) | 0 | 38 | 5 | 20 / 102 |
| **After** (this PR) | 0 | 33 | 0 | ~18 / 102 |

So the autofix portion of #39 is effectively a no-op beyond **5 equals-sign alignment** fixes — the heavy lifting was already done by the merged cleanup PRs.

## What the autofix changed (high level)
- `Generic.Formatting.MultipleStatementAlignment.NotSameWarning` — equals-sign alignment normalization only.
- Affected files (both are one-shot migration scripts):
  - `scripts/migrate-phase-4-the-lab.php`
  - `scripts/migrate-phase-4-followup-cleanup.php`
- `php -l` verified clean on all changed files.

## Remaining findings (33 warnings, non-auto-fixable — follow-up)
These require human code judgment and are intentionally **not** touched here. Categorized for a separate follow-up:

| Sniff | ~Count | Needs |
|---|---|---|
| `WordPress.WP.Capabilities.Unknown` | ~17 | **Config, not code.** Custom bbPress-style caps (`moderate`, `edit_topic`, `edit_others_topics`, `read_topic`, `assign_moderators`, `assign_topic_tags`, etc.) are real platform capabilities. Fix = declare them via the `custom_capabilities` property in a project `phpcs.xml`, not edit the calls. |
| `WordPress.Security.NonceVerification.Recommended` | ~6 | Real security review — read-only `$_GET` filter-bar / topic-loop reads. Confirm each is a safe read (no state change) before annotating/suppressing. |
| `WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode` | ~2 | `urlencode()` → `rawurlencode()` — behavior-affecting, needs per-call verification. |
| `WordPress.PHP.NoSilencedErrors.Discouraged` | ~2 | `@$dom->loadHTML()` error-suppression in content filters — intentional for malformed-HTML parsing; needs proper `libxml_use_internal_errors()` refactor. |
| `WordPress.PHP.DevelopmentFunctions.error_log_error_log` | ~2 | `error_log()` debug calls in `topic-reply-formatters.php` — decide keep-behind-WP_DEBUG vs remove. |
| `Squiz.PHP.CommentedOutCode.Found` | ~2 | Commented-out code in `form-reply.php` / `topic-sidebar.php` — human call whether to delete. |
| `WordPress.WP.AlternativeFunctions.parse_url_parse_url` | ~1 | `parse_url()` → `wp_parse_url()`. |
| `WordPress.PHP.StrictInArray.FoundNonStrictFalse` | ~1 | `in_array()` needs `true` strict arg — verify type semantics. |

The single highest-leverage follow-up is the **`Capabilities.Unknown`** cluster (~half the remaining warnings): it's a one-line `phpcs.xml` ruleset config declaring the platform's custom capabilities, which would clear ~17 warnings at once without touching any PHP.

## Constraints honored
- Formatting-only; no behavior changes.
- Conventional commit (`style:`). No CHANGELOG / version edits.
- Worked entirely in the `lint-39-phpcbf-sweep` worktree.

References #39. Does **not** fully close it — the non-auto-fixable cluster above is the remaining work (a ruleset-config + small security-review follow-up).