### PR TITLE
Add 'Real Estate Web Player vs Spotify' (14001) to The Lab gather-list

### DIFF
--- a/scripts/migrate-phase-4-followup-cleanup.php
+++ b/scripts/migrate-phase-4-followup-cleanup.php
@@ -19,10 +19,13 @@
  * This is the follow-up to the merged Phase 4 migration (#70). The first pass
  * missed three things found in a deeper platform-wide sweep:
  *
- *   1. GATHER 14090 "Hello from Sarai Chinwag" INTO The Lab (13548). It's the
- *      first post via Data Machine bearer token / agentic auth going live —
- *      build-in-public × AI × platform. (The original #70 migration merged
- *      without this entry; this re-adds it.)
+ *   1. GATHER Lab-material INTO The Lab (13548):
+ *        - 14090 "Hello from Sarai Chinwag" — first post via DM bearer token /
+ *          agentic auth going live (the #70 migration merged without it).
+ *        - 14001 "Real Estate Web Player vs Spotify" — open-web feature request
+ *          to chubes ("music can live outside of the streaming platforms...
+ *          can you make something like this for Extra Chill?"). Textbook Lab
+ *          soul; was sitting in Artist Corner (14120).
  *
  *   2. RETIRE the dead "Shakedown Street" marketplace forum (120, draft) — an
  *      abandoned buy/sell idea that never launched. Its 2 stale 2024 topics
@@ -91,6 +94,7 @@ $shakedown_id      = 120;   // Shakedown Street (dead marketplace, draft).
 $gather_into_lab = array(
 	14090 => 'Hello from Sarai Chinwag — agentic auth / build-in-public (from The Back Bar 81)',
 	2342  => 'Moving to Austin & the Evolution of Extra Chill — founder narrative (salvaged from Team 547)',
+	14001 => 'Real Estate Web Player vs Spotify — open-web feature request to chubes (from Artist Corner 14120)',
 );
 
 // Shakedown Street topics to preserve in The Back Bar before trashing 120.


### PR DESCRIPTION
Refs #69. Tiny follow-up to the merged #78 cleanup migration.

A final forum-organization sweep (before applying the #78 migration) found one more clear Lab-soul post sitting in **Artist Corner**:

**14001 'Real Estate Web Player vs Spotify'** — an open-web feature request to chubes:
> *'the joy that comes with playing music on a website... brings me back to a simpler time on the internet... This is a great example of the open web and how music can live outside of the streaming platforms. Hey @chubes can you make something like this for Extra Chill?'*

That's textbook **The Lab** (open web × music × build-in-public + a feature request), not an artist self-intro/drop. Adds it to the gather list in `migrate-phase-4-followup-cleanup.php` (14120 → 13548).

**Also checked + deliberately LEFT in place:**
- 13005 'Artists Who Left Spotify' (Music Discussion) — a journalism/discussion prompt about the open-web theme, not a platform/build post. Great Music Discussion thread; stays.
- 13560 'A4ordable Lifestyles' (Music Discussion) — artist brand/gear promo, 0 replies; not a clean self-intro. Stays.

Dry-run validated against prod. Still **not applied** — same hold-for-review as #78. Conventional commit; no CHANGELOG/version touched.

Closes nothing new — part of the #69 cleanup. DO NOT MERGE until the combined migration is greenlit.