### PR TITLE
refactor(blocks): migrate community blocks to wp-native-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@wordpress/scripts": "^30.15.0"
   },
   "dependencies": {
-    "@extrachill/api-client": "^0.3.0",
     "@extrachill/components": "^0.5.2",
     "@extrachill/tokens": "^0.3.1",
     "@wordpress/api-fetch": "^7.0.0",
@@ -48,7 +47,8 @@
     "@wordpress/data": "^10.36.0",
     "@wordpress/element": "^6.0.0",
     "@wordpress/i18n": "^5.0.0",
-    "@wordpress/icons": "^10.0.0"
+    "@wordpress/icons": "^10.0.0",
+    "wp-native-client": "^0.0.1"
   },
   "private": true
 }

--- a/src/blocks/edit-profile/view.tsx
+++ b/src/blocks/edit-profile/view.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { createRoot } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { ExtraChillClient } from '@extrachill/api-client';
-import { WpApiFetchTransport } from '@extrachill/api-client/wordpress';
+import { WPNativeClient } from 'wp-native-client';
+import { WpApiFetchTransport } from 'wp-native-client/wordpress';
 import {
 	ActionRow,
 	BlockShell,
@@ -16,9 +16,9 @@ import {
 } from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 import { cssVar, spacing, colors } from '@extrachill/tokens';
-import type { UserProfile, UserLink } from '@extrachill/api-client';
+import type { UserProfile, UserLink } from '../../types/users';
 
-const client = new ExtraChillClient( new WpApiFetchTransport( apiFetch ) );
+const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
 
 const styles = {
 	avatarContainer: {
@@ -85,8 +85,22 @@ function AvatarUpload( {
 		setUploading( true );
 
 		try {
-			const formData = client.media.buildUploadForm( 'user_avatar', userId, file );
-			const result = await client.media.upload( formData );
+			// B1 exception: avatar upload is a multipart POST with no backing
+			// ability (the Abilities API run endpoint is JSON-only). It stays on
+			// the existing extrachill/v1/media REST route, called directly via
+			// apiFetch — mirroring the former api-client media.upload() wire.
+			const formData = new FormData();
+			formData.append( 'context', 'user_avatar' );
+			if ( userId ) {
+				formData.append( 'target_id', String( userId ) );
+			}
+			formData.append( 'file', file );
+
+			const result = await apiFetch< { url?: string } >( {
+				path: 'extrachill/v1/media',
+				method: 'POST',
+				body: formData,
+			} );
 			if ( result.url ) {
 				onAvatarChange( result.url );
 			}
@@ -214,7 +228,7 @@ function EditProfileApp( {
 	const [ avatarUrl, setAvatarUrl ] = useState( '' );
 
 	useEffect( () => {
-		client.users.getProfile().then( ( data ) => {
+		client.execute< UserProfile >( 'extrachill/get-user-profile', { user_id: userId } ).then( ( data ) => {
 			setProfile( data );
 			setCustomTitle( data.custom_title || '' );
 			setBio( data.bio || '' );
@@ -226,7 +240,7 @@ function EditProfileApp( {
 			setError( err instanceof Error ? err.message : 'Failed to load profile.' );
 			setLoading( false );
 		} );
-	}, [] );
+	}, [ userId ] );
 
 	useEffect( () => {
 		const hash = window.location.hash.replace( '#tab-', '' );
@@ -245,12 +259,12 @@ function EditProfileApp( {
 
 		try {
 			const [ profileResult ] = await Promise.all( [
-				client.users.updateProfile( {
+				client.execute< UserProfile >( 'extrachill/update-user-profile', {
 					custom_title: customTitle,
 					bio,
 					local_city: localCity,
 				} ),
-				client.users.updateLinks( { links } ),
+				client.execute( 'extrachill/update-user-links', { links } ),
 			] );
 
 			setProfile( profileResult );

--- a/src/blocks/leaderboard/view.tsx
+++ b/src/blocks/leaderboard/view.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { createRoot } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { ExtraChillClient } from '@extrachill/api-client';
-import { WpApiFetchTransport } from '@extrachill/api-client/wordpress';
+import { WPNativeClient } from 'wp-native-client';
+import { WpApiFetchTransport } from 'wp-native-client/wordpress';
 import { ActionRow, BlockShell, BlockShellHeader, BlockShellInner, Panel, BlockIntro } from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 import { cssVar, colors, fontSize } from '@extrachill/tokens';
-import type { LeaderboardResponse, LeaderboardEntry } from '@extrachill/api-client';
+import type { LeaderboardResponse, LeaderboardEntry } from '../../types/users';
 
-const client = new ExtraChillClient( new WpApiFetchTransport( apiFetch ) );
+const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
@@ -102,8 +102,8 @@ function Leaderboard( { perPage, spriteUrl }: LeaderboardProps ) {
 	const load = useCallback( ( targetPage: number ) => {
 		setLoading( true );
 		setError( null );
-		client.users
-			.leaderboard( targetPage, perPage )
+		client
+			.execute< LeaderboardResponse >( 'extrachill/users-leaderboard', { page: targetPage, per_page: perPage } )
 			.then( ( response ) => {
 				setData( response );
 				setLoading( false );

--- a/src/blocks/user-settings/render.php
+++ b/src/blocks/user-settings/render.php
@@ -31,9 +31,10 @@ $can_create_artists = function_exists( 'ec_can_create_artist_profiles' )
 	: false;
 
 printf(
-	'<div class="%1$s" data-artist-site-url="%2$s" data-has-artists="%3$s" data-can-create-artists="%4$s"></div>',
+	'<div class="%1$s" data-artist-site-url="%2$s" data-has-artists="%3$s" data-can-create-artists="%4$s" data-user-id="%5$d"></div>',
 	esc_attr( $class ),
 	esc_url( $artist_site_url ),
 	$has_artists ? '1' : '0',
-	$can_create_artists ? '1' : '0'
+	$can_create_artists ? '1' : '0',
+	(int) $current_user_id
 );

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -1,21 +1,22 @@
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { createRoot } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { ExtraChillClient } from '@extrachill/api-client';
-import { WpApiFetchTransport } from '@extrachill/api-client/wordpress';
+import { WPNativeClient } from 'wp-native-client';
+import { WpApiFetchTransport } from 'wp-native-client/wordpress';
 import { BlockShell, BlockShellInner, ResponsiveTabs, Panel, PanelHeader, ActionRow, FieldGroup, BlockShellHeader, BlockIntro } from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 import { cssVar, spacing, colors } from '@extrachill/tokens';
 import type {
 	UserSettings,
+	UserProfile,
 	ChangeEmailResponse,
 	ChangePasswordResponse,
 	UserSubscriptions,
 	FollowedArtist,
 	RequestArtistAccessResponse,
-} from '@extrachill/api-client';
+} from '../../types/users';
 
-const client = new ExtraChillClient( new WpApiFetchTransport( apiFetch ) );
+const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
 
 const styles = {
 	button: {
@@ -51,7 +52,7 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 		setSaving( true );
 		setNotice( null );
 		try {
-			const result = await client.users.updateSettings( { first_name: firstName, last_name: lastName, display_name: displayName } );
+			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', { first_name: firstName, last_name: lastName, display_name: displayName } );
 			onUpdate( result );
 			setNotice( { type: 'success', message: result.message || 'Account details updated.' } );
 		} catch ( err ) {
@@ -94,7 +95,7 @@ function SecurityTab( { settings, onSettingsChange }: { settings: UserSettings; 
 		setEmailSaving( true );
 		setNotice( null );
 		try {
-			const result: ChangeEmailResponse = await client.users.changeEmail( { new_email: newEmail } );
+			const result = await client.execute< ChangeEmailResponse >( 'extrachill/change-user-email', { new_email: newEmail } );
 			setNotice( { type: 'success', message: result.message } );
 			setNewEmail( '' );
 			onSettingsChange( { ...settings, pending_email: result.pending_email } );
@@ -108,7 +109,7 @@ function SecurityTab( { settings, onSettingsChange }: { settings: UserSettings; 
 		setPasswordSaving( true );
 		setNotice( null );
 		try {
-			const result: ChangePasswordResponse = await client.users.changePassword( { current_password: currentPassword, new_password: newPassword, confirm_password: confirmPassword } );
+			const result = await client.execute< ChangePasswordResponse >( 'extrachill/change-user-password', { current_password: currentPassword, new_password: newPassword, confirm_password: confirmPassword } );
 			setNotice( { type: 'success', message: result.message } );
 			setCurrentPassword( '' );
 			setNewPassword( '' );
@@ -153,7 +154,7 @@ function SubscriptionsTab() {
 	const [ consented, setConsented ] = useState< Set<number> >( new Set() );
 
 	useEffect( () => {
-		client.users.getSubscriptions().then( ( result ) => {
+		client.execute< UserSubscriptions >( 'extrachill/get-subscriptions' ).then( ( result ) => {
 			setData( result );
 			const ids = new Set<number>();
 			result.followed_artists.forEach( ( a: FollowedArtist ) => { if ( a.email_consent ) ids.add( a.artist_id ); } );
@@ -174,7 +175,7 @@ function SubscriptionsTab() {
 		setSaving( true );
 		setNotice( null );
 		try {
-			await client.users.updateSubscriptions( { consented_artists: Array.from( consented ) } );
+			await client.execute( 'extrachill/update-subscriptions', { consented_artists: Array.from( consented ) } );
 			setNotice( { type: 'success', message: 'Subscription preferences updated.' } );
 		} catch ( err ) {
 			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
@@ -209,7 +210,7 @@ function ArtistPlatformTab( { artistAccess, artistSiteUrl, hasArtists, canCreate
 		setSubmitting( true );
 		setNotice( null );
 		try {
-			const result: RequestArtistAccessResponse = await client.users.requestArtistAccess( { type: accessType } );
+			const result = await client.execute< RequestArtistAccessResponse >( 'extrachill/request-artist-access', { type: accessType } );
 			setNotice( { type: 'success', message: result.message } );
 			setCurrentStatus( 'pending' );
 		} catch ( err ) {
@@ -230,7 +231,7 @@ function ArtistPlatformTab( { artistAccess, artistSiteUrl, hasArtists, canCreate
 
 type TabId = 'account-details' | 'security' | 'subscriptions' | 'artist-platform';
 
-function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists }: { artistSiteUrl: string; hasArtists: boolean; canCreateArtists: boolean } ) {
+function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId }: { artistSiteUrl: string; hasArtists: boolean; canCreateArtists: boolean; userId: number } ) {
 	const [ activeTab, setActiveTab ] = useState<TabId>( 'account-details' );
 	const [ settings, setSettings ] = useState<UserSettings | null>( null );
 	const [ loading, setLoading ] = useState( true );
@@ -238,7 +239,10 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists }: { art
 	const [ artistAccess, setArtistAccess ] = useState<{ status: string; type: string; request_type?: string; requested_at?: number }>( { status: 'none', type: '' } );
 
 	useEffect( () => {
-		Promise.all( [ client.users.getSettings(), client.users.getProfile() ] ).then( ( [ settingsData, profileData ] ) => {
+		Promise.all( [
+			client.execute< UserSettings >( 'extrachill/get-user-settings' ),
+			client.execute< UserProfile >( 'extrachill/get-user-profile', { user_id: userId } ),
+		] ).then( ( [ settingsData, profileData ] ) => {
 			setSettings( settingsData );
 			setArtistAccess( profileData.artist_access );
 			setLoading( false );
@@ -298,8 +302,9 @@ function init(): void {
 		const artistSiteUrl = container.dataset.artistSiteUrl || 'https://artist.extrachill.com';
 		const hasArtists = container.dataset.hasArtists === '1';
 		const canCreateArtists = container.dataset.canCreateArtists === '1';
+		const userId = Number( container.dataset.userId || '0' );
 		const root = createRoot( container );
-		root.render( <UserSettingsApp artistSiteUrl={ artistSiteUrl } hasArtists={ hasArtists } canCreateArtists={ canCreateArtists } /> );
+		root.render( <UserSettingsApp artistSiteUrl={ artistSiteUrl } hasArtists={ hasArtists } canCreateArtists={ canCreateArtists } userId={ userId } /> );
 	} );
 }
 

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,0 +1,125 @@
+/**
+ * User-related types for community blocks.
+ *
+ * Re-homed locally from the former @extrachill/api-client package as part of
+ * the migration to wp-native-client (which is type-light: execute() returns
+ * the ability's raw result, typed at the call site). These interfaces mirror
+ * the output shapes of the extrachill-users abilities consumed by the
+ * edit-profile, leaderboard, and user-settings blocks.
+ *
+ * Ability output sources (extrachill-users, inc/core/abilities/):
+ *   - extrachill/get-user-profile, update-user-profile, update-user-links
+ *   - extrachill/users-leaderboard
+ *   - extrachill/get-user-settings, update-user-settings,
+ *     change-user-email, change-user-password
+ *   - extrachill/get-subscriptions, update-subscriptions
+ *   - extrachill/request-artist-access
+ */
+
+// ─── Leaderboard ──────────────────────────────────────────────────────────────
+
+export interface LeaderboardBadge {
+	icon: string;
+	class_name: string;
+	title: string;
+}
+
+export interface LeaderboardEntry {
+	id: number;
+	display_name: string;
+	username: string;
+	slug: string;
+	avatar_url?: string;
+	profile_url?: string;
+	registered: string;
+	points: number;
+	rank: string;
+	badges: LeaderboardBadge[];
+	position: number;
+}
+
+export interface LeaderboardPagination {
+	page: number;
+	per_page: number;
+	total: number;
+	total_pages: number;
+}
+
+export interface LeaderboardResponse {
+	items: LeaderboardEntry[];
+	pagination: LeaderboardPagination;
+}
+
+// ─── User Settings ──────────────────────────────────────────────────────────
+
+export interface UserSettings {
+	user_id: number;
+	first_name: string;
+	last_name: string;
+	display_name: string;
+	display_name_options: string[];
+	email: string;
+	pending_email: string | null;
+}
+
+export interface ChangeEmailResponse {
+	success: boolean;
+	message: string;
+	pending_email: string;
+}
+
+export interface ChangePasswordResponse {
+	success: boolean;
+	message: string;
+}
+
+// ─── User Profile ─────────────────────────────────────────────────────────────
+
+export interface UserLink {
+	type_key: string;
+	url: string;
+	custom_label?: string;
+}
+
+export interface ArtistAccessStatus {
+	status: 'none' | 'pending' | 'approved';
+	type: string;
+	request_type?: string;
+	requested_at?: number;
+}
+
+export interface UserProfile {
+	user_id: number;
+	display_name: string;
+	username: string;
+	avatar_url: string;
+	custom_title: string;
+	bio: string;
+	local_city: string;
+	links: UserLink[];
+	link_types: Record<string, string>;
+	artist_access: ArtistAccessStatus;
+}
+
+// ─── User Subscriptions ───────────────────────────────────────────────────────
+
+export interface FollowedArtist {
+	artist_id: number;
+	name: string;
+	url: string;
+	email_consent: boolean;
+}
+
+export interface UserSubscriptions {
+	user_id: number;
+	followed_artists: FollowedArtist[];
+}
+
+// ─── Artist Access Request ──────────────────────────────────────────────────
+
+export interface RequestArtistAccessResponse {
+	success: boolean;
+	message: string;
+	user_id: number;
+	type: string;
+}


### PR DESCRIPTION
## Summary
Migrates the three community front-end blocks (`user-settings`, `edit-profile`, `leaderboard`) off the deprecated `@extrachill/api-client` (`ExtraChillClient`) and onto `wp-native-client` (`WPNativeClient` + `WpApiFetchTransport`).

- All writes call `client.execute('extrachill/<ability>', {...})` with **no client-supplied `user_id`** — the server resolves the current user. This was unblocked by **extrachill-users#99** (`show_in_rest=true` + IDOR-safe self-resolve).
- Only the public `get-user-profile` read still passes `{ user_id }` (viewing other users — correct).
- Avatar upload stays a raw `apiFetch` POST to `/extrachill/v1/media` (documented exception; no equivalent ability yet — tracked as blocker B1 in studio#84).
- `wp-native-client` is type-light (`execute()` returns the ability's raw result typed at the call site), so the user-facing interfaces are re-homed locally to `src/types/users.ts`.
- `render.php` now emits `data-user-id` for the self-resolve handshake.
- `package.json`: dropped `@extrachill/api-client`, added `wp-native-client ^0.0.1`. `@extrachill/components`/`@extrachill/tokens` retained (still used for BlockShell/tokens).

## Verification
- `npm install --legacy-peer-deps` + `npm run build` → **webpack compiled successfully**, no TS/module errors.
- `--legacy-peer-deps` is required by a **pre-existing** React 18 vs 19 peer-range conflict between `@wordpress/blocks@^15.9.0` (wants react 19) and `@wordpress/block-editor@^14.0.0` (wants react 18). This conflict exists on `main` independent of this PR; the migration does not introduce it.
- Build artifacts confirmed for all three blocks; no `ExtraChillClient`/`@extrachill/api-client` reference remains in the bundles.

## CI note
This repo has known pre-existing PHPCS lint debt (**community#39**, ~4447 findings). If the Lint check fails only on pre-existing PHPCS in files this PR did not touch, that is expected — this PR touches only TS/PHP-render for the three blocks and does not attempt to clear the lint backlog.

## Refs
- Unblocked by Extra-Chill/extrachill-users#99
- Part of the API-client migration punch-list in studio#84
- Community slice of #23