### PR TITLE
feat: attach artist taxonomy to community topic

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -33,6 +33,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/assets.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/bbpress-templates.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-location.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-artist.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/breadcrumb-filter.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/page-templates.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/bbpress-spam-adjustments.php';

--- a/inc/core/taxonomy-artist.php
+++ b/inc/core/taxonomy-artist.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Artist Taxonomy Integration for bbPress
+ *
+ * Registers the shared 'artist' taxonomy (defined in the Extra Chill theme)
+ * for bbPress topics, enabling artist-based identity on forum content. This is
+ * the keystone wire for the artist/fan engagement loop (epics #53, #80).
+ *
+ * The taxonomy itself is defined in the theme's custom-taxonomies.php on the
+ * 'post' type at init priority 5; this file only attaches it to the community
+ * 'topic' CPT, mirroring the existing 'location' integration.
+ *
+ * @package ExtraChillCommunity
+ * @subpackage Core
+ */
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register the artist taxonomy for the bbPress topic post type.
+ *
+ * The 'artist' taxonomy is defined in the Extra Chill theme (network-active on
+ * all sites) and registered on the 'post' type at init priority 5. This runs at
+ * priority 20 so the taxonomy already exists when we attach it, matching the
+ * 'location' integration in taxonomy-location.php.
+ *
+ * Scope: topics only. Replies inherit their parent topic's artist context, so
+ * tagging at the topic level is the high-value target; attaching to 'reply'
+ * would duplicate identity per-post without adding signal.
+ */
+function extrachill_register_artist_for_bbpress() {
+    if ( ! taxonomy_exists( 'artist' ) ) {
+        return;
+    }
+
+    register_taxonomy_for_object_type( 'artist', 'topic' );
+}
+add_action( 'init', 'extrachill_register_artist_for_bbpress', 20 );
+
+// Note: theme registers the 'artist' taxonomy; this file only attaches it to
+// the bbPress 'topic' CPT.


### PR DESCRIPTION
## Summary

Attaches the shared `artist` taxonomy to the bbPress `topic` CPT on community.extrachill.com so forum topics can carry artist identity — the keystone wire for the artist/fan engagement loop.

Closes #97. Relates to epics #53 and #80; unblocks artist-platform layer work (artist drops → community threads, cross-linking artist profiles ↔ forum conversation).

## What changed

- **New file:** `inc/core/taxonomy-artist.php` — registers `register_taxonomy_for_object_type( 'artist', 'topic' )` on `init` priority **20**, guarded by `taxonomy_exists( 'artist' )`.
- **Loader wiring:** `extrachill-community.php` now `require_once`s the new file (the plugin loads features via explicit `require_once`, not a directory scan, so the file must be registered or it never loads — directly below the existing `taxonomy-location.php` require).
- **Nothing else touched** — no theme, no `CHANGELOG.md`, no version strings.

## Precedent mirrored

Follows the existing `location` integration exactly (`inc/core/taxonomy-location.php`):

| | `location` (existing) | `artist` (this PR) |
|---|---|---|
| Registered by | theme `custom-taxonomies.php`, `init` p0, on `post` | theme `custom-taxonomies.php`, `init` p0, on `post` |
| Attached by community | `init` p20 via `register_taxonomy_for_object_type` | `init` p20 via `register_taxonomy_for_object_type` |
| Guard | `taxonomy_exists()` | `taxonomy_exists()` |
| Loaded via | explicit `require_once` in main plugin file | explicit `require_once` in main plugin file |

The theme owns registration; the community plugin owns attaching it to community CPTs. Same hook, same timing (p20, after the theme's p0 registration), same guard, same loader pattern.

## Cross-blog availability — verified

The `artist` taxonomy is registered in the **theme** (`themes/extrachill/inc/core/custom-taxonomies.php`), not the community plugin:

```php
register_taxonomy( 'artist', array( 'post' ), $args ); // extra_chill_register_custom_taxonomies, init priority 0
```

`$args` for `artist`: `show_ui`, `show_admin_column`, `show_in_rest`, `query_var` all `true`, flat (non-hierarchical, like tags). The Extra Chill theme is the active theme on **all 9 network sites**, so `artist` is registered on the community blog exactly the way `location` is. Since `location` works cross-blog with this pattern, `artist` does too. The `taxonomy_exists()` guard makes the attach a safe no-op if the taxonomy were ever absent.

Timing is safe: theme registers at `init` priority **0**, this attaches at `init` priority **20** — taxonomy always exists when we attach (identical to `location`).

Because the taxonomy already declares `show_ui` + `show_in_rest`, attaching it to `topic` makes it editable in admin and queryable via REST/`tax_query` with no extra flags — no bbPress-specific `show_ui`/`show_in_rest` handling needed beyond what the taxonomy declares (mirroring `location`).

## Topic vs reply decision — `topic` only

Implemented on `topic` only, per the issue's lean. Reasoning:
- **Replies inherit their parent topic's context.** Artist identity belongs to the conversation (the topic), not each individual reply. Tagging at topic level is the high-value, low-noise target.
- Attaching to `reply` would duplicate identity per-post without adding signal and would clutter the reply admin/query surface.
- Matches `location`, which attaches to `topic` (and `forum`) but not `reply`.

> Note: `location` also attaches to `forum`. `artist` is intentionally **topic-only** — forums are structural containers; artist identity lives on the conversation, not the room. (Mirrors the theme decision to exclude `artist` from taxonomy badge styling on structural surfaces.)

If a future need emerges (e.g. per-reply artist mentions for the engagement loop), `reply` can be added in one line — out of scope here to avoid over-scoping.

## Confirmation

- ✅ Did NOT touch the theme (registration stays in the theme).
- ✅ Did NOT edit `CHANGELOG.md`.
- ✅ Did NOT hand-bump any version string.
- ✅ Conventional commit (`feat:`).
- ✅ `php -l` clean on both changed files.