### PR TITLE
refactor: remove dead bp_ follow-system remnants (community)

### DIFF
--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -122,7 +122,7 @@ function modular_bbpress_styles() {
 		);
 	}
 
-	if ( bbp_is_topic_archive() || bbp_is_single_forum() || is_page('recent') || is_page('following') || bbp_is_single_user() || bbp_is_search_results() || is_search() ) {
+	if ( bbp_is_topic_archive() || bbp_is_single_forum() || is_page('recent') || bbp_is_single_user() || bbp_is_search_results() || is_search() ) {
 		wp_enqueue_style(
 			'topics-loop',
 			EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/css/topics-loop.css',

--- a/inc/social/rank-system/point-calculation.php
+++ b/inc/social/rank-system/point-calculation.php
@@ -63,8 +63,6 @@ function extrachill_get_user_total_points($user_id) {
 	$total_upvotes = extrachill_get_user_total_upvotes($user_id) ?? 0;
 	$upvote_points = floatval($total_upvotes) * 0.5;
 
-	$follower_points = 0;
-
 	// Get main site post count for points calculation
 	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
 	if ( $main_blog_id ) {
@@ -107,7 +105,7 @@ function extrachill_get_user_total_points($user_id) {
 	$extra_points = (float) apply_filters( 'ec_rank_extra_points', 0.0, $user_id );
 
 	// Calculate total points
-	$total_points = $bbpress_points + $upvote_points + $follower_points + $main_site_post_points + $extra_points;
+	$total_points = $bbpress_points + $upvote_points + $main_site_post_points + $extra_points;
 
 	// Cache the total points in a transient for 1 hour
 	set_transient('user_points_' . $user_id, $total_points, HOUR_IN_SECONDS);


### PR DESCRIPTION
## Summary

The BuddyPress-style `bp_*` follow system was removed from the platform; `bp_*` is meant to be entirely gone. Two inert remnants in this plugin still pointed at the dead system.

(Re-opened: supersedes the mistakenly-closed PR #102 — same commit, branch was deleted then re-pushed.)

## Changes

- `inc/core/assets.php:125` — removed the `is_page('following')` clause from the style-enqueue condition (a `/following` page with no system behind it). Other conditions intact.
- `inc/social/rank-system/point-calculation.php:66,110` — removed `$follower_points = 0;` and dropped the `+ $follower_points` term from the `$total_points` sum. No behavior change (was always 0).

## Verification

- `git grep -nE '\bbp_[a-z]' -- '*.php' | grep -v bbp_` → returns nothing in this repo.
- `php -l` clean on both files.
- No theme / CHANGELOG / version edits.

Refs Extra-Chill/extrachill-users#103 (remnants B and C).