### PR TITLE
fix: browse-rooms chips use canonical taxonomy-badge pill (#106)

### DIFF
--- a/inc/assets/css/home.css
+++ b/inc/assets/css/home.css
@@ -49,40 +49,19 @@
 }
 
 /* --- Browse rooms (demoted chip nav) --- */
+/*
+ * Room chips use the canonical .taxonomy-badge pill (theme taxonomy-badges
+ * system), matching how subforum-button-classes.php renders forum links as
+ * badges. The .taxonomy-badges wrapper already supplies the flex-wrap row
+ * layout + gap, so only homepage-specific spacing overrides live here — no
+ * parallel pill definition.
+ */
 .community-browse-rooms {
     margin: var(--spacing-lg) 0;
 }
 
 .community-room-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm);
-    list-style: none;
     margin: var(--spacing-md) 0 0;
-    padding: 0;
-}
-
-.community-room-chip {
-    margin: 0;
-}
-
-.community-room-chip-link {
-    display: inline-block;
-    padding: var(--spacing-xs) var(--spacing-md);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-pill, 999px);
-    background: var(--card-background);
-    color: var(--text-color);
-    font-size: var(--font-size-sm);
-    line-height: 1.4;
-    text-decoration: none;
-    transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
-}
-
-.community-room-chip-link:hover,
-.community-room-chip-link:focus {
-    border-color: var(--accent);
-    color: var(--link-color);
 }
 
 @media (max-width: 480px) {

--- a/inc/home/browse-rooms.php
+++ b/inc/home/browse-rooms.php
@@ -128,15 +128,13 @@ if ( ! function_exists( 'extrachill_community_get_room_chips' ) ) {
 			<div class="community-section-header">
 				<h2 id="community-browse-rooms-heading"><?php esc_html_e( 'Browse rooms', 'extra-chill-community' ); ?></h2>
 			</div>
-			<ul class="community-room-chips ec-mobile-full-width-panel">
+			<div class="taxonomy-badges community-room-chips ec-mobile-full-width-panel">
 				<?php foreach ( $rooms as $room ) : ?>
-					<li class="community-room-chip">
-						<a href="<?php echo esc_url( get_permalink( $room ) ); ?>" class="community-room-chip-link">
-							<?php echo esc_html( get_the_title( $room ) ); ?>
-						</a>
-					</li>
+					<a href="<?php echo esc_url( get_permalink( $room ) ); ?>" class="taxonomy-badge">
+						<?php echo esc_html( get_the_title( $room ) ); ?>
+					</a>
 				<?php endforeach; ?>
-			</ul>
+			</div>
 		</nav>
 		<?php
 	}


### PR DESCRIPTION
## Summary

The homepage **"Browse rooms"** chip row was a bespoke component — `.community-room-chip` / `.community-room-chip-link` pill styles invented in `inc/assets/css/home.css`. Even though it referenced theme tokens, it was a **parallel pill/badge definition** when a canonical one already exists (RULES.md: don't build a parallel component when one exists).

## Which canonical component I adopted, and why

**Adopted: the theme `taxonomy-badge` pill** (`.taxonomy-badge` inside a `.taxonomy-badges` wrapper).

The deciding factor: **this plugin already renders forum-navigation links as `taxonomy-badge` pills.** `inc/content/subforum-button-classes.php` renders location-tagged subforums as `<div class="taxonomy-badges"><a class="taxonomy-badge location-badge …">`. The browse-rooms chips are the same use case — a row of clickable top-level forum links — so they should look native to that established pattern rather than inventing a one-off pill.

Why not the alternatives:
- **`button-1/2/3`** — buttons are for *actions*; these are *navigation links to forums*, and the network's "row of clickable forum/term links" idiom is the taxonomy-badge, not a button row. (Buttons are only the *fallback* for non-location subforums in `subforum-button-classes.php`.)
- **filter-bar** (`inc/components/filter-bar.php`) — that's a `<form>` of dropdowns/search, not a row of links. Wrong primitive.
- **`@extrachill/components` `Badge.tsx`** — React/TS; these chips are PHP server-rendered, so not a fit (noted, not used).

The rooms aren't taxonomy terms, so they render with the **base `.taxonomy-badge`** look (border + pill radius + card bg + hover lift) — which is exactly what the bespoke chip was reinventing.

## What changed

- **`inc/home/browse-rooms.php`** — render each room as `<a class="taxonomy-badge">` inside a `<div class="taxonomy-badges community-room-chips …">` (was `<ul><li><a class="community-room-chip-link">`). Same 5 rooms, same links.
- **`inc/assets/css/home.css`** — removed the bespoke `.community-room-chip`, `.community-room-chip-link`, and `:hover/:focus` rules, plus the redundant `.community-room-chips` flex/gap/list-reset (the `.taxonomy-badges` wrapper already supplies `display:flex; flex-wrap:wrap; gap:var(--spacing-sm)`). Kept only the homepage-specific mobile padding override.

## Confirmation

- ✅ **Server-rendered PHP** (no React).
- ✅ **Token-based** — uses the theme `taxonomy-badges` system; no hardcoded colors, no `!important`.
- ✅ **Mobile-first** — only a `max-width: 480px` padding override remains.
- ✅ `taxonomy-badges.css` is already enqueued network-wide (`extrachill_enqueue_taxonomy_badges` on `wp_enqueue_scripts`), so no new asset enqueue is needed.
- ✅ `php -l` clean. No JS/block assets touched, so no `npm run build` required.

> Note: repo `homeboy lint` (PHPStan) errored on a missing `/tmp/bbpress` dependency path in this worktree — an environment/tooling issue, not a defect in this change (markup + CSS only, no new PHP symbols).

Closes #106