### PR TITLE
style: clear WPCS yoda lint left on main after #109

### DIFF
--- a/inc/home/browse-rooms.php
+++ b/inc/home/browse-rooms.php
@@ -95,7 +95,8 @@ if ( ! function_exists( 'extrachill_community_get_room_chips' ) ) {
 		$rooms = array_filter(
 			$found,
 			static function ( $room ) use ( $public_status ) {
-				return $public_status === get_post_status( $room );
+				$room_status = get_post_status( $room );
+				return $public_status === $room_status;
 			}
 		);
 		$rooms = array_values( $rooms );


### PR DESCRIPTION
## Summary

Follow-up to #109 (issue #104). The behavioral fix merged correctly, but the intended lint-cleanup commit never landed before the worktree was torn down, so `main` shipped with a **failing PHPCS lint** on `inc/home/browse-rooms.php`:

```
98 | ERROR | Use Yoda Condition checks, you must. (WordPress.PHP.YodaConditions.NotYoda)
```

The `array_filter` closure compared `$public_status === get_post_status( $room )` (variable-vs-function-call), which the WPCS Yoda sniff flags as `NotYoda` regardless of operand order. This PR assigns the call result to `$room_status` first so the comparison is var-vs-var, which passes cleanly.

## Verification

- `php -l inc/home/browse-rooms.php` → no syntax errors
- `phpcs --standard=WordPress-Extra inc/home/browse-rooms.php` → **0 errors, 0 warnings**
- **No behavior change** — pure lint fix.