### PR TITLE
fix: repair corrupted SQL in draft-storage (phpcs:enable spliced inside string literals)

### DIFF
--- a/inc/content/editor/draft-storage.php
+++ b/inc/content/editor/draft-storage.php
@@ -135,7 +135,6 @@ function extrachill_community_bbpress_drafts_upsert( $user_id, array $draft ) {
 	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 	$sql = $wpdb->prepare(
 		"INSERT INTO {$table}
-	// phpcs:enable WordPress.DB.PreparedSQL
 			(user_id, blog_id, type, forum_id, topic_id, reply_to, title, content, updated_at)
 		VALUES (%d, %d, %s, %d, %d, %d, %s, %s, %d)
 		ON DUPLICATE KEY UPDATE
@@ -153,7 +152,6 @@ function extrachill_community_bbpress_drafts_upsert( $user_id, array $draft ) {
 		$row['updated_at']
 	);
 
-	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 	$result = $wpdb->query( $sql );
 	// phpcs:enable WordPress.DB.PreparedSQL
 	if ( false === $result ) {
@@ -185,7 +183,6 @@ function extrachill_community_bbpress_drafts_fetch( $user_id, array $context ) {
 	$row = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT * FROM {$table}
-	// phpcs:enable WordPress.DB.PreparedSQL
 			WHERE user_id = %d
 				AND blog_id = %d
 				AND type = %s
@@ -202,6 +199,7 @@ function extrachill_community_bbpress_drafts_fetch( $user_id, array $context ) {
 		),
 		ARRAY_A
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL
 
 	return $row ? extrachill_community_bbpress_drafts_normalize_row( $row ) : null;
 }


### PR DESCRIPTION
## Summary

Repairs **code-corrupting damage** introduced by PR #41 (commit `f703d10`, "style: apply phpcbf auto-fixes for WordPress Coding Standards"). The `homeboy lint --fix` WordPress auto-fixer spliced `// phpcs:enable WordPress.DB.PreparedSQL` comments **inside** the double-quoted SQL string literals of two `$wpdb->prepare()` calls in `inc/content/editor/draft-storage.php`.

PHP does not treat `//` as a comment inside a string, so the marker text became part of the SQL:

```
INSERT INTO wp_ec_bbpress_drafts // phpcs:enable WordPress.DB.PreparedSQL (user_id, ...)
```

MariaDB rejected this with **ERROR 1064**, silently breaking **both** the INSERT (compose-draft save) and the SELECT (compose-draft fetch). The **compose-draft (new topic / new reply autosave)** feature has been broken network-wide since **2026-05-30**.

## Fix

Move the `phpcs:enable` markers **out** of the SQL strings to **after** the closing `);` of each prepared statement, so each `phpcs:disable` / `phpcs:enable` pair correctly wraps the whole statement. No markers remain inside any string literal.

## Verification

- `php -l inc/content/editor/draft-storage.php` — no syntax errors.
- Ran the corrected `$wpdb->prepare()` against the live community DB; generated SQL is clean (no `phpcs` marker, valid SQL).

## Upstream

The auto-fixer bug that caused this is tracked in **Extra-Chill/homeboy-extensions#981** — `phpcs-ignore-fixer.php` boundary finders are string-content-unaware and splice the `enable` marker into multi-line SQL strings. This PR repairs the downstream damage; the fixer fix is separate.