### PR TITLE
fix: remove phpcs:enable comment embedded in $wpdb->prepare() SQL strings (compose drafts error 1064)

### DIFF
--- a/inc/content/editor/draft-storage.php
+++ b/inc/content/editor/draft-storage.php
@@ -135,7 +135,6 @@ function extrachill_community_bbpress_drafts_upsert( $user_id, array $draft ) {
 	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
 	$sql = $wpdb->prepare(
 		"INSERT INTO {$table}
-	// phpcs:enable WordPress.DB.PreparedSQL
 			(user_id, blog_id, type, forum_id, topic_id, reply_to, title, content, updated_at)
 		VALUES (%d, %d, %s, %d, %d, %d, %s, %s, %d)
 		ON DUPLICATE KEY UPDATE
@@ -152,10 +151,9 @@ function extrachill_community_bbpress_drafts_upsert( $user_id, array $draft ) {
 		$row['content'],
 		$row['updated_at']
 	);
-
-	// phpcs:disable WordPress.DB.PreparedSQL -- Table name from $wpdb->prefix, not user input.
-	$result = $wpdb->query( $sql );
 	// phpcs:enable WordPress.DB.PreparedSQL
+
+	$result = $wpdb->query( $sql );
 	if ( false === $result ) {
 		return false;
 	}
@@ -185,7 +183,6 @@ function extrachill_community_bbpress_drafts_fetch( $user_id, array $context ) {
 	$row = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT * FROM {$table}
-	// phpcs:enable WordPress.DB.PreparedSQL
 			WHERE user_id = %d
 				AND blog_id = %d
 				AND type = %s
@@ -202,6 +199,7 @@ function extrachill_community_bbpress_drafts_fetch( $user_id, array $context ) {
 		),
 		ARRAY_A
 	);
+	// phpcs:enable WordPress.DB.PreparedSQL
 
 	return $row ? extrachill_community_bbpress_drafts_normalize_row( $row ) : null;
 }


### PR DESCRIPTION
## Summary

- Removes the `// phpcs:enable WordPress.DB.PreparedSQL` comment lines that a phpcbf autofix (PR #41, commit `f703d10`) injected **inside** the INSERT and SELECT string literals in `inc/content/editor/draft-storage.php`.
- PHP does not treat `//` as a comment inside a double-quoted string, so the text was sent to MariaDB as SQL — every compose-draft write/read failed with `ERROR 1064`. This silently broke compose drafts (new topic + new reply autosave) **network-wide since 2026-05-30**.
- The `phpcs:disable` / `phpcs:enable` pairs now wrap the statements in PHP code where they belong.

## Verification

Ran the corrected INSERT and SELECT against the live community DB (`community.extrachill.com`, `c8c_2_ec_bbpress_drafts`) using a throwaway row:

```
INSERT result: 1
FETCH title: ROUNDTRIP TEST
cleanup done
```

Round-trips cleanly, no error 1064. `php -l` passes.

## Notes

- The EDIT autosave path (WP core `/autosaves`) was never affected — this only touches the compose-draft storage helpers `extrachill_community_bbpress_drafts_upsert()` and `extrachill_community_bbpress_drafts_fetch()`.
- Root cause of the bad autofix is tracked upstream in Extra-Chill/homeboy-extensions#135.
- Breaking for all users right now — warrants a prompt hotfix release.

Closes #113