### PR TITLE
Finish community homepage layout — center feed, fix stale forum-archive grid

### DIFF
--- a/bbpress/loop-forums.php
+++ b/bbpress/loop-forums.php
@@ -32,7 +32,7 @@ $args = array(
 );
 if ( bbp_has_forums( $args ) ) :
 	?>
-	<div id="forums-list-homepage" class="bbp-forums-grid ec-mobile-full-width-panel">
+	<div id="forums-list-archive" class="bbp-forums-grid ec-mobile-full-width-panel">
 		<?php
 		while ( bbp_forums() ) :
 			bbp_the_forum();

--- a/inc/assets/css/home.css
+++ b/inc/assets/css/home.css
@@ -15,20 +15,51 @@
 }
 
 /* =========================================
-   Feed-first homepage (#65)
+   Feed-first homepage (#65, layout finished #107)
    "What's Happening" activity feed is the hero;
    "Browse rooms" chips are demoted nav.
+
+   Layout model: the homepage body lives inside the theme's
+   .extrachill-content wrapper (max-width: var(--container-width), 1200px).
+   A bare flex-column feed inside that wide container left the topic cards
+   pinned hard-left with a large empty void on the right. Each homepage
+   section is therefore centered and constrained to var(--content-width)
+   (800px) — the platform's canonical single-column reading width — so the
+   page reads as an intentional, finished landing column rather than a thin
+   left strip. Mobile collapses to a full-bleed single column.
+
+   Cross-network content (events / wire / artist digests) and a "who's
+   around / regulars" side rail are intentionally NOT built here — deferred
+   to Phase 3 (#73) and the presence work (#111). Stubbing an empty rail now
+   would recreate the same dead right-side void this pass removes.
    ========================================= */
+
+/* --- Shared homepage column constraint --- */
+/*
+ * Center each homepage section at the reading width and let it expand to
+ * the full container on narrower viewports. One rule keeps the CTA, feed,
+ * and browse-rooms nav vertically aligned as a single cohesive column.
+ */
+.community-activity-feed,
+.community-browse-rooms,
+.community-home-topic-actions {
+    width: 100%;
+    max-width: var(--content-width);
+    margin-left: auto;
+    margin-right: auto;
+}
 
 /* --- Activity feed (hero) --- */
 .community-activity-feed {
-    margin: 0 0 var(--spacing-lg);
+    margin: 0 auto var(--spacing-lg);
 }
 
+/*
+ * Single-column feed: topic cards stack at the full constrained width.
+ * The cards are nested inside .bbp-body, so the column treatment is applied
+ * there (not on the outer list wrapper).
+ */
 .community-activity-feed-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-md);
     margin: var(--spacing-md) 0;
 }
 
@@ -36,6 +67,14 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-md);
+    width: 100%;
+}
+
+/* Override the generic .bbp-topic-card 33%-grid width: in the feed each card
+   spans the full column. */
+.community-activity-feed-list .bbp-topic-card {
+    width: 100%;
+    margin: 0;
 }
 
 .community-activity-feed-empty {
@@ -57,7 +96,7 @@
  * parallel pill definition.
  */
 .community-browse-rooms {
-    margin: var(--spacing-lg) 0;
+    margin: var(--spacing-lg) auto;
 }
 
 .community-room-chips {
@@ -71,8 +110,32 @@
     }
 }
 
-/* --- Forums Grid Container --- */
-#forums-list-homepage.bbp-forums-grid {
+@media (max-width: 480px) {
+    .community-home-topic-actions {
+        justify-content: center;
+    }
+
+    /* Full-bleed cards on phones (handled via ec-mobile-full-width-panel
+       breakout); drop the side borders/radius so they read edge-to-edge. */
+    .bbp-topic-card {
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+        box-shadow: none;
+    }
+}
+
+/* =========================================
+   Forum archive grid (/forums/)
+   Responsive 1-col-mobile / 2-col-desktop grid for the forum-index cards
+   rendered by bbpress/loop-forums.php on the forum archive. Keyed on the
+   .bbp-forums-grid CLASS — the old #forums-list-homepage id was a stale
+   leftover from when this loop was the homepage (Phase 2 / #66 moved the
+   feed-first homepage off it; the loop now serves only the forum archive).
+   home.css loads on the forum archive (see modular_bbpress_styles), so this
+   layout belongs here.
+   ========================================= */
+.bbp-forums-grid {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-lg);
@@ -81,52 +144,29 @@
     margin: var(--spacing-lg) 0;
 }
 
-/* --- Forum Card Styles --- */
-#forums-list-homepage.bbp-forums-grid .bbp-forum-card {
+.bbp-forums-grid .bbp-forum-card {
     box-sizing: border-box;
     flex: 1 1 calc(50% - (var(--spacing-lg) / 2));
     min-width: 0;
 }
 
-/* Desktop styles (2 columns) */
-@media (min-width: 768px) {
-    #forums-list-homepage.bbp-forums-grid .bbp-forum-card {
-        flex: 1 1 calc(50% - (var(--spacing-lg) / 2));
-    }
-}
-
-/* Mobile styles (1 column) */
+/* Mobile (1 column) */
 @media (max-width: 768px) {
-    #forums-list-homepage.bbp-forums-grid {
+    .bbp-forums-grid {
         flex-direction: column;
         gap: var(--spacing-md);
     }
-    
-    #forums-list-homepage.bbp-forums-grid .bbp-forum-card {
+
+    .bbp-forums-grid .bbp-forum-card {
         flex: 1 1 100%;
     }
 }
 
 @media (max-width: 480px) {
-    .community-home-topic-actions {
-        justify-content: center;
-    }
-
-    #forums-list-homepage.bbp-forums-grid {
-        gap: var(--spacing-md);
-    }
-
-    #forums-list-homepage.bbp-forums-grid .bbp-forum-card {
+    .bbp-forums-grid .bbp-forum-card {
         width: 100%;
         max-width: 100%;
         margin: 0;
-        border-radius: 0;
-        border-left: none;
-        border-right: none;
-        box-shadow: none;
-    }
-
-    .bbp-topic-card {
         border-radius: 0;
         border-left: none;
         border-right: none;

--- a/inc/home/activity-feed.php
+++ b/inc/home/activity-feed.php
@@ -76,7 +76,7 @@ if ( ! function_exists( 'extrachill_community_render_activity_feed' ) ) {
 			<div class="community-section-header">
 				<h2 id="community-activity-feed-heading"><?php esc_html_e( "What's Happening", 'extra-chill-community' ); ?></h2>
 			</div>
-			<div class="bbp-topics-grid community-activity-feed-list ec-mobile-full-width-panel">
+			<div class="community-activity-feed-list ec-mobile-full-width-panel">
 				<div class="bbp-body">
 					<?php
 					if ( $query->have_posts() ) :


### PR DESCRIPTION
## Summary

Finishes the feed-first community homepage **layout** (LAYOUT only — cross-network content is explicitly deferred to Phase 3 / #73). Closes #107.

The "What's Happening" activity feed had no real desktop layout: it rendered as a bare flex-column inside the theme's 1200px `.extrachill-content` wrapper, so topic cards pinned **hard-left in a thin strip with a large empty void on the right**. Two competing layout systems were also fighting on the feed — the `.bbp-topics-grid` 33%-column grid vs. the feed's flex-column override.

## Desktop layout approach chosen: centered constrained column (not feed + side rail)

I chose a **centered single column constrained to `var(--content-width)` (800px)** — the platform's canonical reading width — over a feed + right side rail.

**Why not a rail:** the rail's only purpose is "who's around / regulars" (#111) and cross-network digest cards (#73) — **both explicitly deferred**. Stubbing an empty rail now would recreate the exact dead right-side void this issue is fixing, and violates the platform rule against building infrastructure before there's a consumer. A centered column reads as an intentional, finished clubhouse landing column today; the rail can be introduced when its content actually exists.

What changed:
- Center each homepage section (Start-a-conversation CTA, feed, Browse-rooms chips) at `--content-width` so the whole page coheres as one vertical column instead of a hard-left strip.
- Dropped the conflicting `.bbp-topics-grid` class from the feed markup; feed topic cards now span the full column width. Clean single column on mobile via the existing `ec-mobile-full-width-panel` breakout.

## The "orphaned" grid CSS — verified NOT dead, fixed honestly

The issue flagged `#forums-list-homepage.bbp-forums-grid` as dead CSS styling a removed element. **Verification showed it is NOT orphaned** — `bbpress/loop-forums.php` still renders that element on the **forum archive** (`/forums/`) via `content-archive-forum.php`, and `home.css` is enqueued there. Only the **id name** was stale (a leftover from when this loop *was* the homepage, before #66 moved the feed-first homepage off it). Deleting the grid CSS outright would have flattened the forum archive's responsive 2-column grid.

Fix:
- Re-keyed the responsive 1-col-mobile / 2-col-desktop grid to the honest **`.bbp-forums-grid` class** (dropping the stale id selector).
- Renamed the template id `forums-list-homepage` → `forums-list-archive` so the markup is honest.
- Forum-archive grid behavior is **preserved**, no longer keyed on a misleading "homepage" name.

No live `#forums-list-homepage` selectors remain (the only textual reference left is an explanatory CSS comment documenting the rename).

## Scope / constraints honored

- **No cross-network content sources added** — events / wire / artist digests remain deferred to Phase 3 (#73).
- Server-rendered PHP + CSS only. **Theme tokens only** (`--content-width`, `--spacing-*`), **no `!important`**.
- Genuinely mobile-first and desktop-complete.
- Conventional commit; no CHANGELOG / version edits.

## Verification

- **Desktop (≥768px):** feed is a centered 800px column inside the 1200px container — no hard-left pin, no dead right void; cards full-width and stacked; CTA + chips aligned in the same column. Forum archive keeps its 2-col grid.
- **Mobile (≤480px):** clean full-bleed single column; cards edge-to-edge.
- `homeboy lint --changed-since main`: overall **passed**, 0 findings on touched files. (Local phpstan step exits non-zero from missing WP stubs in the worktree, not from these changes — edits are CSS + one HTML id/class string change.)

Files: `inc/assets/css/home.css`, `inc/home/activity-feed.php`, `bbpress/loop-forums.php`.