### PR TITLE
bbPress integration tech debt: extract template queries, accessor coupling, dead cache, workaround cleanup

### DIFF
--- a/bbpress/loop-topics.php
+++ b/bbpress/loop-topics.php
@@ -11,81 +11,9 @@ defined('ABSPATH') || exit;
 
 do_action('bbp_template_before_topics_loop');
 
-global $bbp;
-
-// Get current sort and search selections from URL
-$current_sort   = $_GET['sort'] ?? 'default';
-$current_search = $_GET['bbp_search'] ?? '';
-
-
-// --- Determine Base Query Arguments ---
-// Priority: 1. Arguments passed directly to this template part (e.g., from a custom feed).
-//           2. Arguments already set in the global $bbp->topic_query (less reliable for this).
-//           3. Default arguments for a standard forum view.
-
-$base_args = array();
-
-if ( isset($bbp->extrachill_passthrough_args) && ! empty($bbp->extrachill_passthrough_args) ) {
-	$base_args = $bbp->extrachill_passthrough_args;
-	unset($bbp->extrachill_passthrough_args); // Clean up to prevent interference elsewhere
-	// Fallback: Try $bbp->topic_query or build defaults
-	// (Original logic for $extrachill_query_args or $bbp->topic_query->query_vars would go here if this global method also fails)
-	// For now, let's be explicit about the fallback to $bbp->topic_query->query_vars directly
-} elseif ( ! empty($bbp->topic_query->query_vars) ) {
-		$base_args = $bbp->topic_query->query_vars;
-} else {
-	// Default args from your original loop-topics if query_vars also empty
-	$base_args['post_type']      = bbp_get_topic_post_type();
-	$base_args['posts_per_page'] = get_option('_bbp_topics_per_page', 15);
-	$base_args['paged']          = bbp_get_paged();
-	$base_args['post_status']    = 'publish';
-}
-
-// Ensure essential defaults if not set by any context
-$base_args['post_type']      = $base_args['post_type'] ?? bbp_get_topic_post_type();
-$base_args['posts_per_page'] = $base_args['posts_per_page'] ?? get_option('_bbp_topics_per_page', 15);
-$base_args['paged']          = $base_args['paged'] ?? bbp_get_paged(); // Crucial for pagination
-$base_args['post_status']    = $base_args['post_status'] ?? 'publish';
-
-// Working args for this loop, starting with the determined base
-$loop_args = $base_args;
-
-// --- Apply Sorting Logic (modifies $loop_args) ---
-$default_sort_args = array(
-	'orderby'   => 'meta_value',
-	'meta_key'  => '_bbp_last_active_time',
-	'meta_type' => 'DATETIME',
-	'order'     => 'DESC',
-);
-
-if ( 'upvotes' === $current_sort ) {
-	$loop_args['meta_key'] = 'upvote_count';
-	$loop_args['orderby']  = 'meta_value_num';
-	$loop_args['order']    = 'DESC';
-} elseif ( 'popular' === $current_sort ) {
-	global $wpdb;
-	$popular_ids = $wpdb->get_col($wpdb->prepare(
-		"SELECT p.post_parent FROM {$wpdb->posts} p
-         INNER JOIN {$wpdb->posts} t ON p.post_parent = t.ID
-         WHERE p.post_type = %s AND t.post_type = %s AND p.post_date >= %s
-         GROUP BY p.post_parent ORDER BY COUNT(p.ID) DESC LIMIT 100",
-		// phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Compared against post_date (site-local), not post_date_gmt.
-		bbp_get_reply_post_type(), bbp_get_topic_post_type(), date('Y-m-d H:i:s', strtotime('-45 days'))
-	));
-	$loop_args['post__in'] = ! empty($popular_ids) ? $popular_ids : array( 0 );
-	$loop_args['orderby']  = 'post__in';
-	// If 'popular' is chosen, it might override post_parent__in from a feed.
-	// unset($loop_args['post_parent__in']); // Uncomment if 'popular' should be truly global
-} else { // Default sort (or if $current_sort is 'default')
-	// Merge default sort, but prioritize what might already be in $loop_args from $base_args for these keys
-	$loop_args = array_merge($default_sort_args, $loop_args);
-}
-
-// Apply search logic (bbPress default search 's' parameter)
-if ( ! empty($current_search) ) {
-	$loop_args['s'] = sanitize_text_field($current_search);
-}
-
+// Build the context-aware loop args (sort/search resolution lives in
+// inc/content/forum-queries.php; this template stays presentational).
+$loop_args = ec_get_topics_loop_args();
 
 extrachill_filter_bar();
 

--- a/bbpress/topic-sidebar.php
+++ b/bbpress/topic-sidebar.php
@@ -18,15 +18,7 @@ defined( 'ABSPATH' ) || exit;
 		<h2>Recently Active</h2>
 		<ul>
 			<?php
-			$recent_topics_query = new WP_Query( array(
-				'post_type'      => 'topic',
-				'posts_per_page' => 6,
-				'orderby'        => 'meta_value',
-				'meta_key'       => '_bbp_last_active_time',
-				'meta_type'      => 'DATETIME',
-				'order'          => 'DESC',
-				'post__not_in'   => array( get_the_ID() ),
-			) );
+			$recent_topics_query = ec_get_recently_active_topics( 6, get_the_ID() );
 
 			if ( $recent_topics_query->have_posts() ) { // Use curly braces
 				$displayed_count = 0;

--- a/bbpress/user-details.php
+++ b/bbpress/user-details.php
@@ -19,14 +19,7 @@ defined( 'ABSPATH' ) || exit;
 	// Check for user's bbPress posts (topics or replies)
 	$user_id          = bbp_get_displayed_user_id();
 	$display_user     = wp_get_current_user();
-	$args             = array(
-		'author'         => $user_id,
-		'post_type'      => array( 'reply', 'topic' ), // Prioritize replies in the query
-		'posts_per_page' => 1,
-		'orderby'        => 'date',
-		'order'          => 'DESC',
-	);
-	$user_posts_query = new WP_Query($args);
+	$user_posts_query = ec_get_user_last_post( $user_id );
 
 	if ( $user_posts_query->have_posts() ) {
 		while ( $user_posts_query->have_posts() ) {

--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -59,6 +59,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-editor-permissions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-editor.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-abilities.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/content/forum-queries.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/content-filters.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/recent-feed.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/main-site-comments.php';

--- a/inc/content/content-filters.php
+++ b/inc/content/content-filters.php
@@ -140,93 +140,14 @@ function ec_display_forum_description() {
 add_action( 'bbp_template_before_single_forum', 'ec_display_forum_description' );
 
 /**
- * Gets raw Unix timestamp for a forum's last activity.
- * Checks _bbp_last_active_time meta, falls back to last reply/topic post_date.
- */
-function ec_get_raw_forum_timestamp($forum_id) {
-	$last_active = get_post_meta($forum_id, '_bbp_last_active_time', true);
-
-	if ( empty($last_active) ) {
-		$reply_id = bbp_get_forum_last_reply_id($forum_id);
-		if ( ! empty($reply_id) ) {
-			$last_active = get_post_field('post_date', $reply_id);
-		} else {
-			$topic_id = bbp_get_forum_last_topic_id($forum_id);
-			if ( ! empty($topic_id) ) {
-				$last_active = get_post_meta($topic_id, '_bbp_last_active_time', true);
-				if ( empty($last_active) ) {
-					$last_active = get_post_field('post_date', $topic_id);
-				}
-			}
-		}
-	}
-
-	return ! empty($last_active) ? strtotime($last_active) : 0;
-}
-
-/**
- * Recursively finds the latest timestamp across a forum and all its subforums.
- */
-function ec_get_forum_freshness_timestamp_recursive($forum_id) {
-	$latest_timestamp = ec_get_raw_forum_timestamp($forum_id);
-
-	$subforums = bbp_forum_get_subforums($forum_id);
-	foreach ( $subforums as $subforum ) {
-		$subforum_timestamp = ec_get_forum_freshness_timestamp_recursive($subforum->ID);
-		if ( $subforum_timestamp > $latest_timestamp ) {
-			$latest_timestamp = $subforum_timestamp;
-		}
-	}
-
-	return $latest_timestamp;
-}
-
-function ec_get_forum_freshness_with_subforums($forum_id) {
-	$latest_timestamp = ec_get_forum_freshness_timestamp_recursive($forum_id);
-
-	if ( $latest_timestamp > 0 ) {
-		return bbp_get_time_since(bbp_convert_date(gmdate('Y-m-d H:i:s', $latest_timestamp)));
-	}
-	return '';
-}
-
-function ec_get_forum_last_active_id_with_subforums($forum_id) {
-	remove_filter('bbp_get_forum_last_active_id', 'ec_get_forum_last_active_id_with_subforums_filter', 10);
-	$forum_last_active_id = bbp_get_forum_last_active_id($forum_id);
-	add_filter('bbp_get_forum_last_active_id', 'ec_get_forum_last_active_id_with_subforums_filter', 10, 2);
-
-	$latest_timestamp = $forum_last_active_id ? strtotime(get_post_field('post_date', $forum_last_active_id)) : 0;
-
-	$subforums = bbp_forum_get_subforums($forum_id);
-	foreach ( $subforums as $subforum ) {
-		$subforum_last_active_id = ec_get_forum_last_active_id_with_subforums($subforum->ID);
-		if ( $subforum_last_active_id ) {
-			$subforum_time = strtotime(get_post_field('post_date', $subforum_last_active_id));
-			if ( $subforum_time > $latest_timestamp ) {
-				$latest_timestamp     = $subforum_time;
-				$forum_last_active_id = $subforum_last_active_id;
-			}
-		}
-	}
-
-	return $forum_last_active_id;
-}
-
-add_filter('bbp_get_forum_last_active_time', 'ec_get_forum_last_active_time_with_subforums', 10, 2);
-function ec_get_forum_last_active_time_with_subforums($time, $forum_id) {
-	return ec_get_forum_freshness_with_subforums($forum_id);
-}
-
-add_filter('bbp_get_forum_last_active_id', 'ec_get_forum_last_active_id_with_subforums_filter', 10, 2);
-function ec_get_forum_last_active_id_with_subforums_filter($id, $forum_id) {
-	return ec_get_forum_last_active_id_with_subforums($forum_id);
-}
-
-/**
- * Filter topic revisions to only show explicitly logged edits.
+ * Restrict the revision log to edits the author explicitly chose to log.
  *
- * Fixes bbPress bug where all WordPress revisions display in the revision log,
- * regardless of whether user chose to log each individual edit.
+ * This is an Extra Chill editorial policy, not a bbPress bug fix. bbPress core
+ * (bbp_get_topic_revision_log(), includes/topics/template.php) hides the log
+ * entirely when no edit is logged, but once at least one edit is logged it
+ * lists every WordPress revision — rendering un-opted-in ones with a generic
+ * "modified by X" line and no reason. We want only opted-in edits visible, so
+ * we intersect the revision list against the _bbp_revision_log opt-in map.
  */
 add_filter('bbp_get_topic_revisions', 'extrachill_filter_logged_revisions', 10, 2);
 function extrachill_filter_logged_revisions($revisions, $topic_id) {

--- a/inc/content/forum-queries.php
+++ b/inc/content/forum-queries.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Forum Query Builders
+ *
+ * Query-building logic extracted out of bbPress template parts so the
+ * templates stay presentational. Templates call these helpers and consume a
+ * prepared loop / result set instead of assembling WP_Query args (and raw
+ * SQL) inline.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Build the WP_Query argument array for the context-aware topics loop.
+ *
+ * Resolves base args from the active bbPress topic query (falling back to
+ * sane forum defaults), then layers the current sort (default / upvotes /
+ * popular) and search selections from the request.
+ *
+ * @return array Arguments suitable for bbp_has_topics().
+ */
+function ec_get_topics_loop_args() {
+	global $bbp;
+
+	$current_sort   = isset( $_GET['sort'] ) ? sanitize_key( wp_unslash( $_GET['sort'] ) ) : 'default'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only public sort selection.
+	$current_search = isset( $_GET['bbp_search'] ) ? sanitize_text_field( wp_unslash( $_GET['bbp_search'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only public search selection.
+
+	// Determine base args from the active bbPress topic query, or defaults.
+	if ( ! empty( $bbp->topic_query->query_vars ) ) {
+		$loop_args = $bbp->topic_query->query_vars;
+	} else {
+		$loop_args = array();
+	}
+
+	// Ensure essential defaults regardless of context.
+	$loop_args['post_type']      = $loop_args['post_type'] ?? bbp_get_topic_post_type();
+	$loop_args['posts_per_page'] = $loop_args['posts_per_page'] ?? get_option( '_bbp_topics_per_page', 15 );
+	$loop_args['paged']          = $loop_args['paged'] ?? bbp_get_paged();
+	$loop_args['post_status']    = $loop_args['post_status'] ?? 'publish';
+
+	// Apply sorting.
+	if ( 'upvotes' === $current_sort ) {
+		$loop_args['meta_key'] = 'upvote_count'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		$loop_args['orderby']  = 'meta_value_num';
+		$loop_args['order']    = 'DESC';
+	} elseif ( 'popular' === $current_sort ) {
+		$popular_ids           = ec_get_popular_topic_ids();
+		$loop_args['post__in'] = ! empty( $popular_ids ) ? $popular_ids : array( 0 );
+		$loop_args['orderby']  = 'post__in';
+	} else {
+		$loop_args = array_merge(
+			array(
+				'orderby'   => 'meta_value',
+				'meta_key'  => '_bbp_last_active_time', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_type' => 'DATETIME',
+				'order'     => 'DESC',
+			),
+			$loop_args
+		);
+	}
+
+	// Apply search (bbPress default 's' parameter).
+	if ( ! empty( $current_search ) ) {
+		$loop_args['s'] = $current_search;
+	}
+
+	return $loop_args;
+}
+
+/**
+ * Get topic IDs ordered by reply activity over the last 45 days.
+ *
+ * Backs the "popular" sort. Returns parent topic IDs ordered by the number of
+ * replies they received in the window, most active first.
+ *
+ * @param int $days  Lookback window in days. Default 45.
+ * @param int $limit Maximum number of topic IDs to return. Default 100.
+ * @return int[] Topic IDs ordered by recent reply count.
+ */
+function ec_get_popular_topic_ids( $days = 45, $limit = 100 ) {
+	global $wpdb;
+
+	$since = gmdate( 'Y-m-d H:i:s', strtotime( '-' . absint( $days ) . ' days' ) );
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Aggregate ordering not expressible via WP_Query; uncached by design (live ranking).
+	$popular_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT p.post_parent FROM {$wpdb->posts} p
+			INNER JOIN {$wpdb->posts} t ON p.post_parent = t.ID
+			WHERE p.post_type = %s AND t.post_type = %s AND p.post_date >= %s
+			GROUP BY p.post_parent ORDER BY COUNT(p.ID) DESC LIMIT %d",
+			bbp_get_reply_post_type(),
+			bbp_get_topic_post_type(),
+			$since,
+			absint( $limit )
+		)
+	);
+
+	return array_map( 'intval', (array) $popular_ids );
+}
+
+/**
+ * Query the most recently active topics, optionally excluding a topic.
+ *
+ * Backs the topic sidebar's "Recently Active" list.
+ *
+ * @param int $number          Number of topics to return. Default 6.
+ * @param int $exclude_topic_id Topic ID to exclude (e.g. the current topic). Default 0.
+ * @return WP_Query
+ */
+function ec_get_recently_active_topics( $number = 6, $exclude_topic_id = 0 ) {
+	$args = array(
+		'post_type'      => bbp_get_topic_post_type(),
+		'posts_per_page' => absint( $number ),
+		'orderby'        => 'meta_value',
+		'meta_key'       => '_bbp_last_active_time', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		'meta_type'      => 'DATETIME',
+		'order'          => 'DESC',
+	);
+
+	if ( $exclude_topic_id ) {
+		$args['post__not_in'] = array( (int) $exclude_topic_id );
+	}
+
+	return new WP_Query( $args );
+}
+
+/**
+ * Query the displayed user's most recent topic or reply.
+ *
+ * Backs the "Welcome back, your last post was..." message on the user profile.
+ *
+ * @param int $user_id User ID.
+ * @return WP_Query
+ */
+function ec_get_user_last_post( $user_id ) {
+	return new WP_Query(
+		array(
+			'author'         => (int) $user_id,
+			'post_type'      => array( bbp_get_reply_post_type(), bbp_get_topic_post_type() ),
+			'posts_per_page' => 1,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		)
+	);
+}

--- a/inc/content/recent-feed.php
+++ b/inc/content/recent-feed.php
@@ -146,11 +146,11 @@ function extrachill_build_activity_feed($per_page = 15, $paged = null, $author =
 		$post_id   = get_the_ID();
 		$post_type = get_post_type();
 
-		$topic_id = ( 'topic' === $post_type ) ? $post_id : get_post_meta($post_id, '_bbp_topic_id', true);
+		$topic_id = ( 'topic' === $post_type ) ? $post_id : bbp_get_reply_topic_id($post_id);
 		if ( ! $topic_id ) {
 			$topic_id = wp_get_post_parent_id($post_id);
 		}
-		$forum_id = get_post_meta($topic_id ? $topic_id : $post_id, '_bbp_forum_id', true);
+		$forum_id = ( 'topic' === $post_type ) ? bbp_get_topic_forum_id($post_id) : bbp_get_reply_forum_id($post_id);
 
 		$items[] = array(
 			'post'              => get_post(),
@@ -298,7 +298,7 @@ function extrachill_render_recent_feed($feed, $empty_notice = '') {
 					} else {
 						$topic_id = (int) get_post_field( 'post_parent', $post->ID );
 						if ( empty( $topic_id ) ) {
-							$topic_id = (int) get_post_meta( $post->ID, '_bbp_topic_id', true );
+							$topic_id = (int) bbp_get_reply_topic_id( $post->ID );
 						}
 					}
 

--- a/inc/content/subforum-button-classes.php
+++ b/inc/content/subforum-button-classes.php
@@ -51,7 +51,7 @@ function extrachill_community_subforum_taxonomy_badges( $output, $r, $args ) {
 	foreach ( $sub_forums as $sub_forum ) {
 		$permalink   = bbp_get_forum_permalink( $sub_forum->ID );
 		$title       = bbp_get_forum_title( $sub_forum->ID );
-		$topic_count = (int) get_post_meta( $sub_forum->ID, '_bbp_topic_count', true );
+		$topic_count = (int) bbp_get_forum_topic_count( $sub_forum->ID );
 		$terms       = wp_get_object_terms( $sub_forum->ID, 'location', array( 'fields' => 'all' ) );
 
 		// Build CSS classes — taxonomy badge pattern: taxonomy-badge location-badge location-{slug}.

--- a/inc/core/cache-invalidation.php
+++ b/inc/core/cache-invalidation.php
@@ -82,7 +82,6 @@ function extrachill_handle_forum_cache_invalidation($post_id) {
 	$user_ids = array_unique(array_filter($user_ids));
 
 	extrachill_clear_user_points_cache($user_ids);
-	extrachill_clear_forum_related_transients($topic_id, $forum_id);
 	extrachill_purge_forum_edge_cache($topic_id, $forum_id);
 	extrachill_update_parent_forum_last_active_times($forum_id);
 }
@@ -147,37 +146,6 @@ function extrachill_queue_user_points_recalculation($user_ids) {
 	}
 
 	update_option('extrachill_points_recalculation_queue', $queue);
-}
-
-/**
- * Clear forum/topic transients and recent feed caches.
- *
- * @param int $topic_id Topic ID.
- * @param int $forum_id Forum ID.
- */
-function extrachill_clear_forum_related_transients($topic_id, $forum_id) {
-	$keys = array(
-		'extrachill_recent_feed',
-		'extrachill_recent_feed_pagination',
-		'extrachill_recent_topics',
-		'extrachill_homepage_forums',
-		'extrachill_forum_stats',
-	);
-
-	if ( $forum_id ) {
-		$keys[] = 'extrachill_forum_stats_' . $forum_id;
-		$keys[] = 'extrachill_forum_topics_' . $forum_id;
-	}
-
-	if ( $topic_id ) {
-		$keys[] = 'extrachill_topic_reply_ids_' . $topic_id;
-		$keys[] = 'extrachill_topic_stats_' . $topic_id;
-	}
-
-	foreach ( $keys as $key ) {
-		delete_transient($key);
-		wp_cache_delete($key, 'extrachill_community');
-	}
 }
 
 /**

--- a/inc/core/infrastructure-abilities.php
+++ b/inc/core/infrastructure-abilities.php
@@ -288,19 +288,6 @@ function extrachill_community_ability_flush_cache() {
 		extrachill_delete_leaderboard_cache();
 	}
 
-	$transients = array(
-		'extrachill_recent_feed',
-		'extrachill_recent_feed_pagination',
-		'extrachill_recent_topics',
-		'extrachill_homepage_forums',
-		'extrachill_forum_stats',
-	);
-
-	foreach ( $transients as $key ) {
-		delete_transient( $key );
-		wp_cache_delete( $key, 'extrachill_community' );
-	}
-
 	if ( function_exists( 'breeze_purge_cache' ) ) {
 		breeze_purge_cache();
 	}

--- a/inc/social/upvote-abilities.php
+++ b/inc/social/upvote-abilities.php
@@ -111,7 +111,7 @@ function extrachill_community_ability_get_upvotes( $input ) {
 
 	if ( $user_id ) {
 		$upvoted_posts = get_user_meta( $user_id, 'upvoted_posts', true );
-		$user_upvoted  = is_array( $upvoted_posts ) && in_array( $post_id, $upvoted_posts, false );
+		$user_upvoted  = is_array( $upvoted_posts ) && in_array( $post_id, $upvoted_posts, true );
 	}
 
 	return array(


### PR DESCRIPTION
Closes #116.

Cleans up the cluster of mid-tier bbPress-integration tech debt from the architecture audit. Five focused commits, one per audit group. Net **-62 lines** of code while adding structure.

## A — Extract template query/SQL logic (`refactor`)
New `inc/content/forum-queries.php` houses the query builders; the bbPress template parts become presentational.
- `loop-topics.php`: arg-building + the raw "popular topics last 45 days" `$wpdb` query → `ec_get_topics_loop_args()` / `ec_get_popular_topic_ids()`. Also drops the dead `$bbp->extrachill_passthrough_args` branch (never set anywhere).
- `topic-sidebar.php`: inline `WP_Query` → `ec_get_recently_active_topics()`.
- `user-details.php`: inline `WP_Query` → `ec_get_user_last_post()`.

## B — bbPress accessors instead of raw `_bbp_*` meta (`refactor`)
- `recent-feed.php`: `_bbp_topic_id` / `_bbp_forum_id` → `bbp_get_reply_topic_id()` / `bbp_get_reply_forum_id()` / `bbp_get_topic_forum_id()`.
- `subforum-button-classes.php`: `_bbp_topic_count` → `bbp_get_forum_topic_count()`.

## C — Strict upvote comparison (`fix`)
`upvote-abilities.php` used loose `in_array(..., false)` for vote status while the writer (`upvote.php`) uses strict. Aligned to strict (IDs are ints on both sides).

## D — Remove dead cache invalidation (`refactor`)
`extrachill_clear_forum_related_transients()` and the flush-cache transient loop deleted keys **nothing ever writes** (verified: zero `set_transient`/`wp_cache_set` for any of them). The feeds run uncached. Removed the dead invalidation; leaderboard busting + Breeze purges untouched.

## E — Workaround cleanup, corrected (`refactor`)
Both items carried inaccurate "fixes bbPress bug" framing (see #116 deep-trace against stock bbPress 2.6.14):
- **Subforum freshness recursion** — redundant. Core already recurses at write time (`bbp_update_forum_last_active_id`), the site is flat (zero subforums), and EC already propagates parent freshness via `extrachill_update_parent_forum_last_active_times()`. Removed the read-time recompute + fragile `remove_filter`/`add_filter` dance.
- **Revision-log filter** — an EC editorial policy (show only opted-in edits), not a bug fix. Re-documented; behavior unchanged.

## Verification
- `php -l` clean on all changed files.
- `homeboy lint --changed-since`: **0 errors**. Remaining warnings are pre-existing (urlencode + DOMDocument silencing in untouched code) or a false-positive "commented out code" on a pre-existing inline comment. (PHPStan step fails on an unrelated environment issue: `/tmp/bbpress does not exist`.)
- No dangling references to removed functions.
- E2 deletion validated against live data: `community.extrachill.com` has zero subforums (`post_parent = 0` for all forums).