### PR TITLE
Correct stale "homepage" copy on forum-archive display wiring (cosmetic)

### DIFF
--- a/bbpress/loop-forums.php
+++ b/bbpress/loop-forums.php
@@ -16,6 +16,10 @@ defined( 'ABSPATH' ) || exit;
 	<h2>Community Forums</h2>
 </div>
 <?php
+// Forums opted into the archive list via the "Forum Archive Display"
+// metabox. The meta key is still `_show_on_homepage` (legacy name from
+// before the feed-first homepage moved this list onto the forum archive,
+// #66); a keyed rename + migration is tracked separately.
 $args = array(
 	'post_parent'    => 0,
 	'meta_query'     => array(
@@ -41,5 +45,5 @@ if ( bbp_has_forums( $args ) ) :
 		<?php endwhile; ?>
 	</div>
 <?php else : ?>
-	<p>No forums are currently set to display on the homepage.</p>
+	<p><?php esc_html_e( 'No forums are currently set to display in the forum archive.', 'extra-chill-community' ); ?></p>
 <?php endif; ?>

--- a/inc/home/homepage-forum-display.php
+++ b/inc/home/homepage-forum-display.php
@@ -1,9 +1,15 @@
 <?php
 /**
- * Forum Homepage Display Management
+ * Forum Archive Display Management
  *
- * Admin functionality for controlling which forums display on the community homepage.
- * Adds checkbox to forum edit pages for homepage display control.
+ * Admin functionality for controlling which forums display in the forum
+ * archive (/forums/) list. Adds a checkbox to forum edit pages.
+ *
+ * Naming note: the underlying meta key is `_show_on_homepage` and the
+ * function/metabox names still say "homepage" — a leftover from before the
+ * feed-first homepage (#66) moved the forum list off the homepage and onto
+ * the forum archive. The stored key + ability field rename (with migration)
+ * is tracked separately; this file keeps the user-facing copy honest.
  *
  * @package ExtraChillCommunity
  * @version 1.0.0
@@ -18,7 +24,7 @@ if ( ! defined('ABSPATH') ) {
 function extrachill_add_homepage_display_meta_box() {
 	add_meta_box(
 		'extrachill_homepage_display',
-		'Homepage Display',
+		__( 'Forum Archive Display', 'extra-chill-community' ),
 		'extrachill_homepage_display_meta_box_callback',
 		'forum',
 		'side',
@@ -37,16 +43,16 @@ function extrachill_homepage_display_meta_box_callback($post) {
 	<p>
 		<label for="show_on_homepage">
 			<input type="checkbox" name="_show_on_homepage" id="show_on_homepage" value="1" <?php checked($show_on_homepage, '1'); ?> />
-			<?php esc_html_e('Show on Homepage', 'extra-chill-community'); ?>
+			<?php esc_html_e('Show in forum archive', 'extra-chill-community'); ?>
 		</label>
 		<br />
-		<span class="description"><?php esc_html_e('Display this forum in the homepage forum list.', 'extra-chill-community'); ?></span>
+		<span class="description"><?php esc_html_e('Display this forum in the forum archive (/forums/) list.', 'extra-chill-community'); ?></span>
 	</p>
 	<?php
 }
 
 
-// Function to save the homepage display setting
+// Function to save the forum-archive display setting.
 function save_forum_homepage_display($post_id) {
 	// Check if this is an autosave
 	if ( defined('DOING_AUTOSAVE') && DOING_AUTOSAVE ) {


### PR DESCRIPTION
## Summary

Cleanup pass after #121. The forum-index list controlled by the old "Homepage Display" metabox now renders on the **forum archive** (`/forums/`), not the homepage — the homepage went feed-first in #66 and #121 finished its layout. The user-facing copy and code comments still said "homepage", which is misleading. This corrects that copy.

**Cosmetic-only. No stored data or API contract is touched.**

## Changes

- Metabox title → **"Forum Archive Display"**
- Checkbox label → **"Show in forum archive"**; help text now names `/forums/`
- Empty-state sentence now names the forum archive (and is now translatable via `esc_html_e`)
- Docblock + inline comments explain the meta key is still `_show_on_homepage` (legacy name) and point to the tracked rename

## Deliberately UNCHANGED (stored-data / API bindings)

These are the load-bearing identifiers; renaming them needs a data migration + API-contract change, so they're **out of scope here** and tracked in **#123**:

- `_show_on_homepage` post meta key
- `show_on_homepage` ability field + `community-toggle-forum-homepage` ability name
- PHP function names, metabox id (`extrachill_homepage_display`), nonce names
- HTML `name`/`id` attributes (`_show_on_homepage` / `show_on_homepage`)

Verified: `_show_on_homepage` occurrences in the two touched files are unchanged (6 + 2).

## Follow-up

Tracked the risky half — meta-key rename + ability rename + one-time migration — in **#123**. That's where the stored-data/contract changes belong.

## Verification

- `homeboy lint --changed-since main`: **PHPCS passed, 0 findings**. (phpstan step exits non-zero from missing WP stubs in the worktree — env-only, not these changes; edits are strings/comments.)
- No behavior change: same meta key, same query, same POST handling.

Files: `inc/home/homepage-forum-display.php`, `bbpress/loop-forums.php`.

Refs #107, #121. Follow-up: #123.