### PR TITLE
Fix no-JS new-topic button fallback (homepage has no topic form post-#66)

### DIFF
--- a/inc/home/new-topic-button.php
+++ b/inc/home/new-topic-button.php
@@ -2,8 +2,14 @@
 /**
  * New Topic Button
  *
- * Renders the "New Topic" button that triggers the modal on the community homepage.
- * Fallback href for no-JS navigates to homepage where forum topic forms exist.
+ * Renders the "New Topic" buttons that trigger the topic-creation modal on
+ * the community homepage.
+ *
+ * No-JS fallback: each button's href points at the Music Discussion forum
+ * permalink, where bbPress renders a real "new topic" form
+ * (bbpress/content-single-forum.php → form/topic). The previous fallback
+ * pointed at the homepage ("/"), but the feed-first homepage (#66) no longer
+ * carries an inline topic form, so a no-JS user had no way to create a topic.
  *
  * @package ExtraChillCommunity
  */
@@ -15,14 +21,20 @@ if ( ! defined('ABSPATH') ) {
 
 <?php
 $music_discussion_forum = get_page_by_path( 'music-discussion', OBJECT, bbp_get_forum_post_type() );
+
+// No-JS fallback target: the forum permalink (which renders a topic form).
+// Fall back to the recent activity page if the forum can't be resolved.
+$new_topic_fallback_url = ( $music_discussion_forum instanceof WP_Post )
+	? get_permalink( $music_discussion_forum )
+	: home_url( '/recent' );
 ?>
 
 <div class="community-section-header">
 	<div class="community-home-topic-actions">
-		<a href="/" id="new-topic-modal-trigger" class="button-1 button-medium" data-modal-mode="discussion"><?php esc_html_e( 'Create Discussion', 'extra-chill-community' ); ?></a>
+		<a href="<?php echo esc_url( $new_topic_fallback_url ); ?>" id="new-topic-modal-trigger" class="button-1 button-medium" data-modal-mode="discussion"><?php esc_html_e( 'Create Discussion', 'extra-chill-community' ); ?></a>
 
 		<?php if ( $music_discussion_forum instanceof WP_Post ) : ?>
-			<a href="/" id="share-music-modal-trigger" class="button-2 button-medium" data-modal-mode="share_music" data-forum-id="<?php echo esc_attr( (string) $music_discussion_forum->ID ); ?>"><?php esc_html_e( 'Share Music', 'extra-chill-community' ); ?></a>
+			<a href="<?php echo esc_url( get_permalink( $music_discussion_forum ) ); ?>" id="share-music-modal-trigger" class="button-2 button-medium" data-modal-mode="share_music" data-forum-id="<?php echo esc_attr( (string) $music_discussion_forum->ID ); ?>"><?php esc_html_e( 'Share Music', 'extra-chill-community' ); ?></a>
 		<?php endif; ?>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

Another stale-after-#66 cleanup. The homepage **"Create Discussion"** and **"Share Music"** buttons open a JS modal to create a topic. Their **no-JS fallback `href` was `/`** (the homepage), and the docblock claimed *"navigates to homepage where forum topic forms exist."*

That's no longer true: the feed-first homepage (#66) removed the inline forum topic form. So a **no-JS user clicking the button landed on the homepage with no way to start a topic** — a dead-end accessibility gap.

## Fix

Point both fallbacks at the **Music Discussion forum permalink**, where bbPress renders a real new-topic form (`bbpress/content-single-forum.php` → `form/topic`). Falls back to `/recent` if that forum can't be resolved.

- "Share Music" already resolved the music-discussion forum (for its `data-forum-id`) — now its href uses that permalink too.
- "Create Discussion" (general) also falls back to the music-discussion forum permalink.

## No behavior change with JS on

The modal handler (`inc/home/assets/js/new-topic-modal.js`) calls `e.preventDefault()` and opens the modal from `data-modal-mode` / `data-forum-id` — it **never reads the href**. So:
- **JS on:** href ignored, modal opens (unchanged).
- **JS off:** href now lands on a working topic form instead of the broken homepage `/`.

No JS touched → no build needed.

## Verification

- `php -l` clean; `homeboy lint --changed-since main`: **PHPCS passed, 0 findings** (phpstan clean on this single-file change too).
- Confirmed `content-single-forum.php` renders `form/topic` for the forum permalink.

File: `inc/home/new-topic-button.php`.

Part of the post-#107/#121 cleanup sweep (stale "homepage" assumptions left by the feed-first migration).