### PR TITLE
feat(notifications): click-to-read on the notifications page

### DIFF
--- a/inc/assets/css/notifications.css
+++ b/inc/assets/css/notifications.css
@@ -1,3 +1,27 @@
+/* Notifications page header: section title + "Mark all as read" control. */
+.extrachill-notifications-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.extrachill-notifications-header h2 {
+    margin: 0;
+}
+
+.extrachill-notifications-mark-all-read {
+    font-size: 0.85em;
+    color: var(--muted-text);
+    text-decoration: underline;
+    white-space: nowrap;
+}
+
+.extrachill-notifications-mark-all-read:hover {
+    color: var(--link-color);
+}
+
 /* Notification Card Styles */
 .notification-card {
     background-color: var(--card-background);

--- a/inc/social/notifications/notification-card.php
+++ b/inc/social/notifications/notification-card.php
@@ -32,12 +32,25 @@ function extrachill_render_notification_card($notification) {
 
 	// Extract core data. The network substrate enriches each row with `title`.
 	$type               = $notification['type'];
+	$notification_id    = isset( $notification['id'] ) ? (int) $notification['id'] : 0;
+	$is_unread          = empty( $notification['read'] );
 	$actor_id           = $notification['actor_id'] ?? null;
 	$actor_display_name = $notification['actor_display_name'] ?? 'Someone';
 	$actor_profile_link = $notification['actor_profile_link'] ?? '#';
 	$topic_title        = $notification['title'] ?? '';
 	$link               = $notification['link'] ?? '#';
 	$time               = $notification['time'] ?? '';
+
+	// Route UNREAD notifications through the click-to-read redirect so opening
+	// one marks just that notification read (and decrements the bell badge),
+	// instead of the old behavior where merely viewing the list marked every
+	// notification read at once. Read notifications keep their direct link.
+	// The builder lives in extrachill-users (the substrate owner); guard so a
+	// missing helper degrades to the plain target link.
+	if ( $is_unread && $notification_id > 0 && '#' !== $link
+		&& function_exists( 'ec_notifications_read_redirect_url' ) ) {
+		$link = ec_notifications_read_redirect_url( $notification_id, $link );
+	}
 
 	// Format timestamp. The network substrate stores created_at in UTC, so
 	// convert to the site's local timezone for display.

--- a/inc/social/notifications/notifications-content.php
+++ b/inc/social/notifications/notifications-content.php
@@ -45,15 +45,35 @@ function extrachill_display_notifications() {
 	);
 
 	if ( ! empty( $new_notifications ) ) {
-		echo '<h2>New Notifications</h2><div class="extrachill-notifications">';
+		echo '<div class="extrachill-notifications-header">';
+		echo '<h2>New Notifications</h2>';
+
+		// Explicit "Mark all as read" control (no AJAX): a GET link into the
+		// read-all redirect route in extrachill-users, returning to this page.
+		if ( function_exists( 'ec_notifications_mark_all_read_url' ) ) {
+			$here             = get_permalink();
+			$mark_all_url     = ec_notifications_mark_all_read_url( $here ? $here : '' );
+			printf(
+				'<a class="extrachill-notifications-mark-all-read" href="%s">%s</a>',
+				esc_url( $mark_all_url ),
+				esc_html__( 'Mark all as read', 'extrachill-community' )
+			);
+		}
+
+		echo '</div>';
+
+		echo '<div class="extrachill-notifications">';
 		foreach ( $new_notifications as $notification ) {
 			echo wp_kses_post( extrachill_render_notification_card( $notification ) );
 		}
 		echo '</div>';
 	}
 
-	// Mark all unread notifications as read in the substrate.
-	extrachill_community_mark_notifications_read( $current_user_id );
+	// NOTE: notifications are NOT bulk-marked read on page view. Each unread
+	// card links through the click-to-read redirect (extrachill-users), so a
+	// notification is marked read only when the user actually opens it. This
+	// keeps the bell badge honest instead of zeroing it the instant the page
+	// loads. An explicit "Mark all as read" control is offered below.
 
 	$old_notifications = array_filter(
 		$notifications,
@@ -106,31 +126,6 @@ function extrachill_community_fetch_notifications( $user_id ) {
 	}
 
 	return $result;
-}
-
-/**
- * Mark all unread notifications as read for a user via the substrate.
- *
- * @param int $user_id User ID.
- * @return void
- */
-function extrachill_community_mark_notifications_read( $user_id ) {
-	if ( ! function_exists( 'wp_get_ability' ) ) {
-		return;
-	}
-
-	$ability = wp_get_ability( 'extrachill/mark-notifications-read' );
-	if ( ! $ability ) {
-		return;
-	}
-
-	// notification_id 0 marks ALL unread for the user.
-	$ability->execute(
-		array(
-			'user_id'         => (int) $user_id,
-			'notification_id' => 0,
-		)
-	);
 }
 
 /**


### PR DESCRIPTION
## Summary

Part 2 of 2 for Extra-Chill/extrachill-users#115 (page side). Stops the notifications page from marking **every** notification read the instant it loads — which zeroed the bell badge even for items the user never saw.

- Unread cards link through the click-to-read redirect (`ec_notifications_read_redirect_url` from extrachill-users); read cards keep their direct link.
- Remove the auto mark-all-read on page render (and the now-dead local wrapper).
- Add an explicit **"Mark all as read"** control (GET link into the read-all redirect route, returns to the page).
- Header + control styled with theme design tokens.

Guarded with `function_exists` so a missing substrate helper degrades to plain links.

## Pairs with

extrachill-users PR (same branch `notifications-click-to-read`) which adds the redirect endpoints. Land/deploy that one first.

## Testing notes

- `php -l` clean; `homeboy lint` clean on changed files.