### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/content/editor/draft-abilities-category.php
+++ b/inc/content/editor/draft-abilities-category.php
@@ -16,6 +16,14 @@ if ( did_action( 'wp_abilities_api_categories_init' ) ) {
 }
 
 function extrachill_community_register_ability_category() {
+	if ( ! function_exists( 'wp_register_ability_category' ) ) {
+		return;
+	}
+
+	if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'extrachill-community' ) ) {
+		return;
+	}
+
 	wp_register_ability_category(
 		'extrachill-community',
 		array(


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "extrachill-community" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On this multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. Core's `WP_Ability_Categories_Registry::register()` warns via `_doing_it_wrong` every time an already-registered category is re-registered. This plugin called `wp_register_ability_category( 'extrachill-community', ... )` unconditionally inside its `wp_abilities_api_categories_init` callback, so the second fire tripped the notice.

## The fix

Guard the registration with core's idempotency check `wp_has_ability_category()` (and a `function_exists` guard for both API functions), so a repeat fire is a clean no-op. Slug, label, description, and hook are unchanged.