### PR TITLE
fix: add .npmrc legacy-peer-deps to unblock release build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Problem

`homeboy release extrachill-community` fails at the package step because homeboy's universal build script runs `npm install` with npm 7+ strict peer-dependency resolution, which trips an `ERESOLVE` conflict (`@wordpress/blocks@15.20.0` peer `react@^19.2.4` vs resolved `react@19.2.7`). This blocks every release of this repo, not just the current one.

## Fix

Add `.npmrc` with `legacy-peer-deps=true` — the same canonical pattern already used by `data-machine-editor`. Verified locally: `npm install` resolves cleanly and `wp-scripts build` compiles all blocks successfully with this setting.

Scoped to this repo's build config only; no source changes.