### PR TITLE
chore(deps): bump @extrachill/components to ^0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ajv": "^8.20.0"
   },
   "dependencies": {
-    "@extrachill/components": "^0.5.2",
+    "@extrachill/components": "^0.8.0",
     "@extrachill/tokens": "^0.3.1",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^14.0.0",


### PR DESCRIPTION
## Summary

Bumps `@extrachill/components` from `^0.5.2` → `^0.8.0` in **extrachill-community** and rebuilds the block bundles.

As of `@extrachill/components@0.8.0`, the shared `ResponsiveTabs` component broadcasts the active tab to the client-context registry **by default** (so Roadie/agents can see which tab the user is on) with zero per-block code. extrachill-community uses `ResponsiveTabs` in two blocks (`src/blocks/user-settings/view.tsx` and `src/blocks/edit-profile/view.tsx`), so this dep bump + rebuild makes both blocks' tabs broadcast the active tab to agents automatically — **no source changes to the tabs were needed** (default-on in 0.8.0).

## Details

- **Bumped file:** root `package.json` — the sole `package.json` declaring `@extrachill/components` (pin `^0.5.2` → `^0.8.0`).
- **Build command:** `npm run build` (`wp-scripts build --webpack-copy-php`) — compiled successfully.
- **Installed version:** `@extrachill/components@0.8.0` confirmed in `node_modules`.
- **Bundle verification:** `ecClientContextRegistry` is present in both rebuilt bundles:
  - `build/blocks/user-settings/view.js`
  - `build/blocks/edit-profile/view.js`

## Notes

- `build/` and `package-lock.json` are gitignored in this repo, so this PR is `package.json`-only by convention. Build artifacts are produced by homeboy at release time.
- No `CHANGELOG.md` edits and no version-string bumps — homeboy owns both.