### PR TITLE
refactor: relabel the live forum-archive flag so it stops posing as a homepage lever

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Custom templates in `bbpress/` directory provide enhanced forum functionality:
 ## Database Tables
 
 ### Key Meta Fields
-- `_show_on_homepage` - Boolean meta field controlling forum display on homepage
+- `_show_on_homepage` - Boolean meta field controlling forum display in the forum archive (/forums/) list (legacy key name; consumed by bbpress/loop-forums.php; rename tracked in #137)
 - `_user_profile_dynamic_links` - User profile social links
 - `ec_custom_title` - User custom titles (default: 'Extra Chillian')
 - `extrachill_notifications` - User notification data cache

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ function modular_bbpress_styles() {
 **Meta Fields**:
 ```php
 // Theme meta fields
-get_post_meta($forum_id, '_show_on_homepage'); // Boolean for homepage display
+get_post_meta($forum_id, '_show_on_homepage'); // Boolean: show in forum archive (/forums/) list (legacy key name; see #137)
 get_user_meta($user_id, '_user_profile_dynamic_links'); // User social links
 get_user_meta($user_id, 'ec_custom_title'); // Custom user titles
 get_user_meta($user_id, 'extrachill_notifications'); // User notification data

--- a/bbpress/loop-forums.php
+++ b/bbpress/loop-forums.php
@@ -17,9 +17,12 @@ defined( 'ABSPATH' ) || exit;
 </div>
 <?php
 // Forums opted into the archive list via the "Forum Archive Display"
-// metabox. The meta key is still `_show_on_homepage` (legacy name from
-// before the feed-first homepage moved this list onto the forum archive,
-// #66); a keyed rename + migration is tracked separately.
+// metabox. This is the ONE live consumer of the flag — it curates the
+// forum archive (/forums/) list, NOT the homepage (the homepage moved to
+// the feed-first layout + Browse Rooms chips, #65/#66, which select by
+// post_status and ignore this meta). The meta key is still
+// `_show_on_homepage` (legacy name); a keyed rename + migration is tracked
+// separately in #137.
 $args = array(
 	'post_parent'    => 0,
 	'meta_query'     => array(

--- a/docs/home.md
+++ b/docs/home.md
@@ -2,25 +2,31 @@
 
 Community homepage enhancements providing forum activity display, artist platform integration, and administrative controls for forum visibility.
 
-## Homepage Forum Display
+## Forum Archive Display
 
 ### Forum Visibility Control
-Administrators can control which forums appear on the community homepage through a checkbox in the forum edit interface.
+Administrators can control which forums appear in the forum archive (`/forums/`)
+list through a checkbox in the forum edit interface. This is an archive-curation
+control, NOT a homepage control — the community homepage moved to the feed-first
+layout + Browse Rooms chip row (#65/#66), which selects forums by `post_status`
+and ignores this meta. The single live consumer is `bbpress/loop-forums.php`.
 
 **Admin Interface:**
-- Located in forum edit pages under "Homepage Display" meta box
-- Checkbox: "Show on Homepage"
-- Description: "Display this forum in the homepage forum list"
+- Located in forum edit pages under "Forum Archive Display" meta box
+- Checkbox: "Show in forum archive"
+- Description: "Display this forum in the forum archive (/forums/) list"
 
 **Data Storage:**
-- Meta field: `_show_on_homepage` (boolean stored as '1' or '0')
+- Meta field: `_show_on_homepage` (boolean stored as '1' or '0'). The stored key
+  still carries the legacy "homepage" name; a keyed rename + data migration is
+  tracked separately in #137.
 - Applied to bbPress forum post types only
 
 ### Latest Activity Display
-Displays the most recent forum activity from homepage-enabled forums and artist forums.
+Displays the most recent forum activity from archive-enabled forums and artist forums.
 
 **Activity Sources:**
-- Forums marked with `_show_on_homepage` meta field
+- Forums marked with the `_show_on_homepage` meta field (legacy key name; see above)
 - Artist profile forums (linked via `_artist_forum_id` meta field)
 
 **Display Format:**

--- a/inc/core/infrastructure-abilities.php
+++ b/inc/core/infrastructure-abilities.php
@@ -54,14 +54,14 @@ function extrachill_community_register_infrastructure_abilities() {
 		'extrachill/community-list-forums',
 		array(
 			'label'               => __( 'List Forums', 'extra-chill-community' ),
-			'description'         => __( 'List all forums with topic/reply counts and homepage visibility status.', 'extra-chill-community' ),
+			'description'         => __( 'List all forums with topic/reply counts and forum-archive visibility status.', 'extra-chill-community' ),
 			'category'            => 'extrachill-community',
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'homepage_only' => array(
+					'archive_only' => array(
 						'type'        => 'boolean',
-						'description' => 'Only return forums shown on homepage',
+						'description' => 'Only return forums shown in the forum archive (/forums/) list',
 					),
 				),
 			),
@@ -85,10 +85,10 @@ function extrachill_community_register_infrastructure_abilities() {
 	);
 
 	wp_register_ability(
-		'extrachill/community-toggle-forum-homepage',
+		'extrachill/community-toggle-forum-archive',
 		array(
-			'label'               => __( 'Toggle Forum Homepage', 'extra-chill-community' ),
-			'description'         => __( 'Toggle whether a forum is shown on the community homepage.', 'extra-chill-community' ),
+			'label'               => __( 'Toggle Forum Archive Display', 'extra-chill-community' ),
+			'description'         => __( 'Toggle whether a forum is shown in the forum archive (/forums/) list.', 'extra-chill-community' ),
 			'category'            => 'extrachill-community',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -103,12 +103,12 @@ function extrachill_community_register_infrastructure_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'forum_id'         => array( 'type' => 'integer' ),
-					'title'            => array( 'type' => 'string' ),
-					'show_on_homepage' => array( 'type' => 'boolean' ),
+					'forum_id'        => array( 'type' => 'integer' ),
+					'title'           => array( 'type' => 'string' ),
+					'show_in_archive' => array( 'type' => 'boolean' ),
 				),
 			),
-			'execute_callback'    => 'extrachill_community_ability_toggle_forum_homepage',
+			'execute_callback'    => 'extrachill_community_ability_toggle_forum_archive',
 			'permission_callback' => '__return_true',
 			'meta'                => array(
 				'show_in_rest' => false,
@@ -202,7 +202,7 @@ function extrachill_community_ability_list_forums( $input ) {
 		return new WP_Error( 'bbpress_unavailable', 'bbPress is not active.' );
 	}
 
-	$homepage_only = ! empty( $input['homepage_only'] );
+	$archive_only = ! empty( $input['archive_only'] );
 
 	$args = array(
 		'post_type'      => bbp_get_forum_post_type(),
@@ -212,7 +212,8 @@ function extrachill_community_ability_list_forums( $input ) {
 		'order'          => 'ASC',
 	);
 
-	if ( $homepage_only ) {
+	if ( $archive_only ) {
+		// Stored key is still `_show_on_homepage` (legacy name; rename tracked in #137).
 		$args['meta_query'] = array(
 			array(
 				'key'   => '_show_on_homepage',
@@ -231,7 +232,7 @@ function extrachill_community_ability_list_forums( $input ) {
 			'parent_id'        => (int) $forum->post_parent,
 			'topic_count'      => function_exists( 'bbp_get_forum_topic_count' ) ? (int) bbp_get_forum_topic_count( $forum->ID ) : 0,
 			'reply_count'      => function_exists( 'bbp_get_forum_reply_count' ) ? (int) bbp_get_forum_reply_count( $forum->ID ) : 0,
-			'show_on_homepage' => (bool) get_post_meta( $forum->ID, '_show_on_homepage', true ),
+			'show_in_archive'  => (bool) get_post_meta( $forum->ID, '_show_on_homepage', true ),
 			'url'              => function_exists( 'bbp_get_forum_permalink' ) ? bbp_get_forum_permalink( $forum->ID ) : get_permalink( $forum->ID ),
 		);
 	}
@@ -240,12 +241,16 @@ function extrachill_community_ability_list_forums( $input ) {
 }
 
 /**
- * Toggle homepage visibility for a forum.
+ * Toggle forum-archive visibility for a forum.
+ *
+ * Controls whether the forum appears in the forum archive (/forums/) list,
+ * rendered by bbpress/loop-forums.php. The stored meta key is still
+ * `_show_on_homepage` (legacy name; rename tracked in #137).
  *
  * @param array $input Ability input.
  * @return array|WP_Error
  */
-function extrachill_community_ability_toggle_forum_homepage( $input ) {
+function extrachill_community_ability_toggle_forum_archive( $input ) {
 	$forum_id = isset( $input['forum_id'] ) ? (int) $input['forum_id'] : 0;
 	if ( ! $forum_id ) {
 		return new WP_Error( 'missing_forum_id', 'A forum_id is required.' );
@@ -271,9 +276,9 @@ function extrachill_community_ability_toggle_forum_homepage( $input ) {
 	}
 
 	return array(
-		'forum_id'         => $forum_id,
-		'title'            => $post->post_title,
-		'show_on_homepage' => $new_state,
+		'forum_id'        => $forum_id,
+		'title'           => $post->post_title,
+		'show_in_archive' => $new_state,
 	);
 }
 

--- a/inc/home/homepage-forum-display.php
+++ b/inc/home/homepage-forum-display.php
@@ -5,11 +5,17 @@
  * Admin functionality for controlling which forums display in the forum
  * archive (/forums/) list. Adds a checkbox to forum edit pages.
  *
- * Naming note: the underlying meta key is `_show_on_homepage` and the
- * function/metabox names still say "homepage" — a leftover from before the
- * feed-first homepage (#66) moved the forum list off the homepage and onto
- * the forum archive. The stored key + ability field rename (with migration)
- * is tracked separately; this file keeps the user-facing copy honest.
+ * This is an ARCHIVE-visibility control, NOT a homepage control. The
+ * community homepage moved to the feed-first layout + Browse Rooms chip row
+ * (#65/#66), which selects forums by post_status — it does NOT read this
+ * meta. The one live consumer of this flag is bbpress/loop-forums.php, which
+ * renders the forum archive list.
+ *
+ * Naming note: the stored meta key is still `_show_on_homepage` — a leftover
+ * from before the forum list moved off the homepage onto the forum archive.
+ * The stored-key rename (with data migration) is tracked separately (#137);
+ * this file keeps the user-facing copy, function names, and ability surface
+ * honest about the archive meaning in the meantime.
  *
  * @package ExtraChillCommunity
  * @version 1.0.0
@@ -21,28 +27,29 @@ if ( ! defined('ABSPATH') ) {
 }
 
 // WordPress meta box registration (working pattern)
-function extrachill_add_homepage_display_meta_box() {
+function extrachill_add_forum_archive_display_meta_box() {
 	add_meta_box(
-		'extrachill_homepage_display',
+		'extrachill_forum_archive_display',
 		__( 'Forum Archive Display', 'extra-chill-community' ),
-		'extrachill_homepage_display_meta_box_callback',
+		'extrachill_forum_archive_display_meta_box_callback',
 		'forum',
 		'side',
 		'high'
 	);
 }
-add_action('add_meta_boxes', 'extrachill_add_homepage_display_meta_box');
+add_action('add_meta_boxes', 'extrachill_add_forum_archive_display_meta_box');
 
 // Meta box callback function
-function extrachill_homepage_display_meta_box_callback($post) {
-	$show_on_homepage = get_post_meta($post->ID, '_show_on_homepage', true);
+function extrachill_forum_archive_display_meta_box_callback($post) {
+	// Stored key is still `_show_on_homepage` (legacy name; rename tracked in #137).
+	$show_in_archive = get_post_meta($post->ID, '_show_on_homepage', true);
 
 	// Add nonce field for security
-	wp_nonce_field('homepage_display_metabox', 'homepage_display_nonce');
+	wp_nonce_field('forum_archive_display_metabox', 'forum_archive_display_nonce');
 	?>
 	<p>
-		<label for="show_on_homepage">
-			<input type="checkbox" name="_show_on_homepage" id="show_on_homepage" value="1" <?php checked($show_on_homepage, '1'); ?> />
+		<label for="show_in_forum_archive">
+			<input type="checkbox" name="_show_in_forum_archive" id="show_in_forum_archive" value="1" <?php checked($show_in_archive, '1'); ?> />
 			<?php esc_html_e('Show in forum archive', 'extra-chill-community'); ?>
 		</label>
 		<br />
@@ -53,14 +60,14 @@ function extrachill_homepage_display_meta_box_callback($post) {
 
 
 // Function to save the forum-archive display setting.
-function save_forum_homepage_display($post_id) {
+function save_forum_archive_display($post_id) {
 	// Check if this is an autosave
 	if ( defined('DOING_AUTOSAVE') && DOING_AUTOSAVE ) {
 		return;
 	}
 
 	// Verify nonce for security
-	if ( ! isset($_POST['homepage_display_nonce']) || ! wp_verify_nonce($_POST['homepage_display_nonce'], 'homepage_display_metabox') ) {
+	if ( ! isset($_POST['forum_archive_display_nonce']) || ! wp_verify_nonce($_POST['forum_archive_display_nonce'], 'forum_archive_display_metabox') ) {
 		return;
 	}
 
@@ -74,11 +81,11 @@ function save_forum_homepage_display($post_id) {
 		return;
 	}
 
-	if ( isset($_POST['_show_on_homepage']) ) {
+	// Stored key is still `_show_on_homepage` (legacy name; rename tracked in #137).
+	if ( isset($_POST['_show_in_forum_archive']) ) {
 		update_post_meta($post_id, '_show_on_homepage', '1');
 	} else {
 		delete_post_meta($post_id, '_show_on_homepage');
 	}
 }
-add_action('save_post', 'save_forum_homepage_display');
-
+add_action('save_post', 'save_forum_archive_display');


### PR DESCRIPTION
Closes #137

## Verdict: the flag is LIVE — relabel, don't retire

`bbpress/loop-forums.php` **is live** and is the **one genuine consumer** of the `_show_on_homepage` flag. It renders the **forum archive** (`/forums/`) list — NOT the homepage.

### What I verified (before/after)
- **Template chain (code):** forum archive → `bbpress/content-archive-forum.php` → `bbp_get_template_part('loop','forums')` → our `bbpress/loop-forums.php` → `meta_query` on `_show_on_homepage='1'`. Both templates are plugin-provided overrides.
- **Live curl of `https://community.extrachill.com/forums`:** rendered HTML carries `loop-forums.php`'s unique markers (`id="forums-list-archive"`, `class="bbp-forums-grid"`, the "Community Forums" header) and shows **exactly** the published forums that carry `_show_on_homepage='1'`:
  - **The Lab (13548)**, **The Back Bar (81)**, **Music Discussion (1983)** — all `publish` + flagged → rendered.
  - **Live Shows & Scenes (14119)** and **Artist Corner (14120)** are published top-level forums but **lack the flag → correctly absent.**
  - This proves the flag is a **load-bearing archive-curation filter**, not vestigial.
- **DB:** 13 rows have `_show_on_homepage='1'` in `c8c_2_postmeta`; the non-rendered ones are `trash` (Local Scenes / Charleston / Austin / Philadelphia). Consistent with the rendered output.
- **Homepage truth:** `inc/home/browse-rooms.php` selects rooms by `post_status` via the chip row and **never reads this meta** — so the "homepage" framing was a lie.

### bbpress/loop-forums.php verdict
**LIVE.** It drives the forum archive list. Behavior is preserved untouched — the `meta_query` still filters on `_show_on_homepage`.

## What I changed vs left alone

**Relabeled (agent/CLI/admin surface → true "archive" meaning):**
- Ability `extrachill/community-toggle-forum-homepage` → **`extrachill/community-toggle-forum-archive`** (label/description updated).
- `community-list-forums`: input `homepage_only` → **`archive_only`**, output `show_on_homepage` → **`show_in_archive`**, description updated.
- Callback `..._toggle_forum_homepage` → `..._toggle_forum_archive`.
- Metabox (`inc/home/homepage-forum-display.php`): function/nonce/field names + header doc now say "Forum Archive Display" (the user-facing checkbox copy was already corrected in #124).
- Docs: `docs/home.md`, `README.md`, `CLAUDE.md` corrected to describe archive curation.

**Left alone (deliberately):**
- The **stored meta key `_show_on_homepage`** is kept (renaming it requires a data migration over the 13 live rows; tracked separately per #137). Inline comments mark it as a legacy name everywhere it appears.
- The 13 live meta rows are **preserved** — they are load-bearing.
- Homepage/feed code untouched.

## ⚠️ Sequencing note for extrachill-cli (cli#39)

This **renames the ability surface**, which will break the current `extrachill-cli` consumers until they're updated:
- `wp extrachill community forums` calls `community-list-forums` and reads `show_on_homepage` (now `show_in_archive`) + passes `homepage_only` (now `archive_only`).
- `wp extrachill community toggle-homepage` calls `extrachill/community-toggle-forum-homepage` (now `...-forum-archive`) and reads `show_on_homepage` (now `show_in_archive`).

Per the coordination note, the separate cli#39 minion was told the `show_on_homepage` column is legacy. **The CLI must be updated to the new ability ID/field names (`community-toggle-forum-archive`, `archive_only`, `show_in_archive`) — ideally renaming `toggle-homepage` → `toggle-archive` — after this merges.** This PR is the community side only; no `extrachill-cli` files were touched.

## Verification
- `php -l` clean on all 3 changed PHP files.
- `phpcs --standard=WordPress` (errors-only) on the changed files introduces **zero new errors** (repo has no phpcs config/composer.json; the few remaining findings are pre-existing house-style in the metabox/loop files, untouched by this diff).
- Live archive rendering is unchanged by design (meta_query untouched).