### PR TITLE
chore: bump @extrachill/tokens to ^0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@extrachill/components": "^0.8.0",
-    "@extrachill/tokens": "^0.3.1",
+    "@extrachill/tokens": "^0.8.1",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^14.0.0",
     "@wordpress/blocks": "^15.9.0",


### PR DESCRIPTION
## Summary

Bumps `@extrachill/tokens` from `^0.3.1` → `^0.8.1`, picking up the v0.8.1 release (new warning/info/interactive colors, font-weight + motion tokens, and the generated theme.json).

This plugin imports the JS API (`cssVar`, `colors`, `spacing`, `fontSize`) in several block view files — all four exports are unchanged in v0.8.1.

## Verification

- `npm run build` (webpack) compiles cleanly; bundles `@extrachill/tokens/dist/tokens.js` + `tokens.json` without error.
- `package-lock.json` is gitignored in this repo, so only `package.json` changes.