### PR TITLE
feat: show 'last seen' / 'online now' status on forum profiles

### DIFF
--- a/bbpress/user-details.php
+++ b/bbpress/user-details.php
@@ -81,6 +81,25 @@ defined( 'ABSPATH' ) || exit;
 			| <b>Points:</b> <?php echo esc_html(extrachill_display_user_points(bbp_get_displayed_user_id())); ?>
 		</p>
 		<?php
+		// "Last seen" status. Composes the ec_get_last_seen() primitive from
+		// extrachill-users (Network: true), which formats the centralized
+		// last_active timestamp into "Online now" / "Last seen X ago". Guarded
+		// so the profile renders cleanly if that plugin's helper is absent
+		// (e.g. before it is deployed). Shown on all profiles — last_active is
+		// a public signal.
+		if ( function_exists( 'ec_get_last_seen' ) ) {
+			$last_seen = ec_get_last_seen( bbp_get_displayed_user_id() );
+			if ( '' !== $last_seen ) {
+				$is_online = ( __( 'Online now', 'extrachill-users' ) === $last_seen );
+				printf(
+					'<p class="bbp-user-last-seen%s">%s</p>',
+					$is_online ? ' is-online' : '',
+					esc_html( $last_seen )
+				);
+			}
+		}
+		?>
+		<?php
 		// Rank-progress bar. Depends on ec_get_rank_progress() from extrachill-users
 		// (Network: true). Guard so the profile renders cleanly if it is absent
 		// (e.g. before that plugin's rank-registry change is deployed).

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -172,7 +172,7 @@
 }
 
 .bbp-user-profile .bbp-user-last-seen.is-online {
-	color: var(--accent);
+	color: var(--success-color);
 	font-weight: 600;
 }
 
@@ -183,8 +183,19 @@
 	height: 0.5rem;
 	margin-right: 0.4rem;
 	border-radius: 50%;
-	background-color: #2ecc71;
+	background-color: var(--success-color);
 	vertical-align: middle;
+	animation: bbp-last-seen-pulse 2s ease-in-out infinite;
+}
+
+@keyframes bbp-last-seen-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
 }
 
 /* User Actions Area */

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -165,6 +165,28 @@
 	color: var(--muted-text);
 }
 
+.bbp-user-profile .bbp-user-last-seen {
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+	margin-bottom: 0.25rem;
+}
+
+.bbp-user-profile .bbp-user-last-seen.is-online {
+	color: var(--accent);
+	font-weight: 600;
+}
+
+.bbp-user-profile .bbp-user-last-seen.is-online::before {
+	content: "";
+	display: inline-block;
+	width: 0.5rem;
+	height: 0.5rem;
+	margin-right: 0.4rem;
+	border-radius: 50%;
+	background-color: #2ecc71;
+	vertical-align: middle;
+}
+
 /* User Actions Area */
 .bbp-user-profile .bbp-user-actions-area {
 	position: absolute;


### PR DESCRIPTION
Wires a "last seen" element into the bbPress profile header, composing the `last_active` page-activity primitive from extrachill-users. Companion to **Extra-Chill/extrachill-users#157** (the primitive + helper live there).

## What this adds

- **`bbpress/user-details.php`** — a `bbp-user-last-seen` line under the Title/Rank/Points row in the profile header card. It calls `ec_get_last_seen( $user_id )` (from extrachill-users), which returns either **"Online now"** (user active within the 15-min activity window) or **"Last seen X ago"** (`human_time_diff`).
- **`inc/assets/css/user-profile.css`** — styling for `.bbp-user-last-seen`, with an `.is-online` variant (accent color + green status dot).

## Why `last_active` (not `last_login`)

`last_active` = last *page activity* while logged in — the correct signal for a forum "last seen / online now" badge. `last_login` (the new auth-event primitive in #157) would wrongly show "logged in 3 weeks ago" for someone browsing daily on a long-lived session. This element deliberately reads activity, not auth.

## Composition, not new infra

This is a thin **consumer** of an existing primitive:
- The `last_active` meta is written by `ec_record_user_activity()` in extrachill-users (single activity writer, throttled to 15 min, stored on the community blog). **No new tracking path is added here.**
- The "Online now" threshold and the format string live in `ec_get_last_seen()` (extrachill-users), so the template doesn't re-derive them. Other surfaces compose the same helper.

## Decisions

- **Shown on all profiles**, not own-profile-only — `last_active` is a public field on `get-user-by-id`, so "last seen" is a public signal (matches the founder's intent for a forum presence indicator).
- **`function_exists( 'ec_get_last_seen' )` guard** — matches the existing `ec_get_rank_progress` guard in the same template, so the profile renders cleanly if extrachill-users isn't deployed yet. **Merge order: extrachill-users#157 first** (it ships the helper), then this.
- "Online now" cutoff = 900s, matching the `ec_record_user_activity()` throttle — within that window the user is online; the meta simply hasn't been rewritten.

## Verification

- `php -l bbpress/user-details.php` — clean.
- CSS is enqueued via `inc/core/assets.php` with `filemtime` cache-busting, so the new rule picks up automatically.
- No tests cover this template (server-rendered bbPress template).

## Dependency

Requires `ec_get_last_seen()` from **Extra-Chill/extrachill-users#157**. Guarded, so safe to merge in either order, but the helper PR should land first for the element to appear.