### PR TITLE
fix: expose community-get-stats over REST for cross-site NetworkStats

### DIFF
--- a/inc/core/infrastructure-abilities.php
+++ b/inc/core/infrastructure-abilities.php
@@ -40,7 +40,12 @@ function extrachill_community_register_infrastructure_abilities() {
 			'execute_callback'    => 'extrachill_community_ability_get_stats',
 			'permission_callback' => '__return_true',
 			'meta'                => array(
-				'show_in_rest' => false,
+				// Exposed over REST so the cross-site NetworkStats loopback
+				// (blog 1 → community blog) can reach the core Abilities run
+				// route. Read-only aggregate counts rendered on the public
+				// /power page — readable, not manage-gated. Mirrors the
+				// `extrachill/get-network-stats` posture in extrachill-multisite.
+				'show_in_rest' => true,
 				'annotations'  => array(
 					'readonly'    => true,
 					'idempotent'  => true,


### PR DESCRIPTION
## Root cause

On this WordPress multisite, `ec_get_network_stats()` runs from blog 1 and needs `community_members` and `community_topics` from blog 2 (community.extrachill.com). The `CommunityStatsProvider` resolves those by delegating to the `extrachill/community-get-stats` ability over a **cross-site HTTP loopback** to the core Abilities run route (`POST /wp-abilities/v1/abilities/extrachill/community-get-stats/run`).

That route only serves abilities registered with `show_in_rest => true`. The `community-get-stats` ability was registered with `show_in_rest => false`, so the loopback 404s. From blog 1 this logs:

> `Function WP_Abilities_Registry::get_registered was called incorrectly. Ability "extrachill/community-get-stats" not found`

and `NetworkStats` returns **null** for both `community_members` and `community_topics`.

This is exactly the follow-up flagged in the sibling code itself — see the `NOTE (companion follow-up)` docblock in `extrachill-multisite/inc/NetworkStats/Providers/CommunityStatsProvider.php` (lines 25-30), which says the loopback "404s until that one-line change lands in extrachill-community."

## Evidence

- `_doing_it_wrong` notice confirmed firing **live in production 23 times in the last 7 days**.
- The blog-1 `NetworkStats` call returns null for both `community_members` and `community_topics` (rendered on the public `/power` page).

## What changed

Flipped `show_in_rest` from `false` to `true` on the `extrachill/community-get-stats` ability registration in `inc/core/infrastructure-abilities.php`. One-line change plus an explanatory comment. The other three abilities in the file (`community-list-forums`, `community-toggle-forum-archive`, `community-flush-cache`) are intentionally left as `show_in_rest => false` — the fix is scoped purely to the stats ability that the loopback needs.

## Permission posture

Left `permission_callback => '__return_true'` unchanged — it was already permissive, and the payload is aggregate read-only community counts (forums/topics/replies/users/upvotes) that the public `/power` page renders. This mirrors the canonical sibling `extrachill/get-network-stats` in **extrachill-multisite** (`inc/NetworkStats/bootstrap.php`), which is the cross-site-readable stats ability that this loopback composes: it uses `show_in_rest => true`, `permission_callback => '__return_true'`, and the same `readonly`/`idempotent`/non-`destructive` annotations. Match, not invention.

## Scope

No change to `ec_get_network_stats()` or the `NetworkStats` primitive — the caller is correct (it already forces the HTTP loopback and returns an honest null on failure). The fix lives in the layer that owns the ability (canonical-home / layer purity).

Closes #140