### PR TITLE
refactor: keep community-get-stats off the core abilities REST surface

### DIFF
--- a/inc/core/infrastructure-abilities.php
+++ b/inc/core/infrastructure-abilities.php
@@ -40,12 +40,12 @@ function extrachill_community_register_infrastructure_abilities() {
 			'execute_callback'    => 'extrachill_community_ability_get_stats',
 			'permission_callback' => '__return_true',
 			'meta'                => array(
-				// Exposed over REST so the cross-site NetworkStats loopback
-				// (blog 1 → community blog) can reach the core Abilities run
-				// route. Read-only aggregate counts rendered on the public
-				// /power page — readable, not manage-gated. Mirrors the
-				// `extrachill/get-network-stats` posture in extrachill-multisite.
-				'show_in_rest' => true,
+				// Not exposed on the generic core Abilities REST surface. The
+				// cross-site NetworkStats loopback (blog 1 → community blog)
+				// reaches this ability through the canonical
+				// /extrachill/v1/community/stats thin route in extrachill-api,
+				// and the local fast path uses in-process wp_get_ability().
+				'show_in_rest' => false,
 				'annotations'  => array(
 					'readonly'    => true,
 					'idempotent'  => true,


### PR DESCRIPTION
## Summary

Reverts the `show_in_rest => true` change from #142 on the `extrachill/community-get-stats` ability registration.

## Why this is a layering correction of #142

#140 (symptom): off-blog NetworkStats community metrics returned null. #142 (expedient fix, merged + deployed) exposed this ability on the **generic core WP Abilities REST endpoint** so the cross-site loopback could reach it — the wrong door. The canonical platform surface for cross-site reads is the `extrachill/v1` namespace (extrachill-api) via thin routes. With that route now in place, this ability no longer needs to sit on the generic core REST endpoint.

## What this PR changes

In `inc/core/infrastructure-abilities.php`, the `extrachill/community-get-stats` registration:

```diff
- 'show_in_rest' => true,
+ 'show_in_rest' => false,
```

and replaces the comment that justified the core-endpoint exposure with one explaining the canonical path (extrachill-api thin route + in-process fast path).

The ability is now reached two ways, neither of which is the core REST surface:
- **In-process fast path** — `wp_get_ability('extrachill/community-get-stats')` on the community blog / via `wp extrachill community` CLI.
- **Cross-site loopback** — through `GET /extrachill/v1/community/stats` (extrachill-api).

Confirmed via grep that the only consumer of the `/wp-abilities/.../community-get-stats/run` path was the NetworkStats provider, which is being repointed in the multisite PR. The CLI uses in-process `wp_get_ability()` and is unaffected.

## Cross-PR dependency + merge order

**PR 3 of 3.** Safe to land once the loopback no longer uses the core endpoint. Intended merge/release order:
1. extrachill-api — `GET /extrachill/v1/community/stats` (must exist first)
2. extrachill-multisite — repoint the loopback
3. **extrachill-community** — this revert

Release/deploy the three together.

Refs #140 (symptom), #142 (expedient fix being corrected), Extra-Chill/extrachill-api#98 (canonical route), Extra-Chill/extrachill-multisite (loopback repoint).