### PR TITLE
fix: correct community profile visual bugs

### DIFF
--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -22,27 +22,28 @@ do_action('bbp_template_before_user_profile');
 	$is_professional   = get_user_meta( $displayed_user_id, 'user_is_professional', true );
 	?>
 
+<?php
+// Compute About-card content up front so the card wrapper only renders when
+// there is actually something to show (avoids an empty bordered box for users
+// with no description and no local scene).
+$about_description = bbp_get_displayed_user_field('description');
+$about_local_city  = get_user_meta( bbp_get_displayed_user_id(), 'local_city', true );
+$has_about_content = ! empty( $about_description ) || ! empty( $about_local_city );
+?>
 <div class="bbp-user-profile-cards-container"> <?php // Start Flex Grid Container ?>
+<?php if ( $has_about_content ) : ?>
 <div class="bbp-user-profile-card">
-					<?php if ( bbp_get_displayed_user_field('description') ) : ?>
-						<h3><?php esc_html_e('About', 'extra-chill-community'); ?></h3>
-				<p class="bbp-user-description"><?php echo wp_kses_post(bbp_rel_nofollow(bbp_get_displayed_user_field('description'))); ?></p>
-						<?php
-			endif;
+			<?php if ( $about_description ) : ?>
+				<h3><?php esc_html_e( 'About', 'extra-chill-community' ); ?></h3>
+		<p class="bbp-user-description"><?php echo wp_kses_post( bbp_rel_nofollow( $about_description ) ); ?></p>
+			<?php endif; ?>
 
-					// --- Add Local Scene (City) here ---
-					$local_city = get_user_meta(bbp_get_displayed_user_id(), 'local_city', true);
-					if ( $local_city ) :
-						?>
-				<p class="bbp-user-local-scene-inline"><strong><?php esc_html_e('Local Scene:', 'extra-chill-community'); ?></strong> <?php echo esc_html($local_city); ?></p>
-						<?php
-			endif; // End local_city check
-					// --- End Local Scene ---
-
-					?>
+			<?php if ( $about_local_city ) : ?>
+		<p class="bbp-user-local-scene-inline"><strong><?php esc_html_e( 'Local Scene:', 'extra-chill-community' ); ?></strong> <?php echo esc_html( $about_local_city ); ?></p>
+			<?php endif; ?>
 </div>
-			<?php do_action('bbp_template_before_user_details_menu_items'); ?>
-		<hr>
+<?php endif; // End has_about_content ?>
+			<?php do_action( 'bbp_template_before_user_details_menu_items' ); ?>
 		<div class="bbp-user-profile-card">
 		<div class="user-profile-activity">
 	<h3><?php esc_html_e('Community Activity', 'extra-chill-community'); ?></h3>

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -74,7 +74,7 @@
 }
 
 .bbp-user-profile {
-    overflow: scroll;
+    overflow-x: auto;
 }
 
 .rank-profile p, 
@@ -319,10 +319,16 @@
         margin-left: 0;
         margin-right: 0;
     }
+    /* Activity feed spans the full row; reset card gutters so it cannot overflow. */
+    .bbp-user-profile-card.user-profile-activity-feed {
+        margin-left: 0;
+        margin-right: 0;
+    }
 }
 
 /* Style headings within the profile cards */
-.bbp-user-profile-card h2 {
+.bbp-user-profile-card h2,
+.bbp-user-profile-card h3 {
     margin-top: 0;
     margin-bottom: 15px;
     border-bottom: 2px solid var(--accent);
@@ -387,6 +393,25 @@
 
 .bbp-user-profile-card.user-artist-cards-fullwidth{
     width: 100%;
+}
+
+/* Activity feed spans the full row instead of occupying one half-width column. */
+.bbp-user-profile-card.user-profile-activity-feed {
+    width: 100%;
+}
+
+/* Artist list renders as pill-style buttons; suppress default list bullets. */
+.user-artist-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.user-artist-item {
+    margin: 0;
 }
 
 /* Edit-profile block gutter.


### PR DESCRIPTION
Fixes six visual bugs on the bbPress user profile page (`community.extrachill.com`).

## Bugs fixed

All changes are CSS-only except where a template change was genuinely required (BUG 3, BUG 4). No build step needed — `inc/assets/css/user-profile.css` is enqueued raw with `filemtime()` versioning (see `inc/core/assets.php`).

### BUG 1 — Artist list shows disc bullets next to button links (HIGH)
`<ul class="user-artist-list">` / `<li class="user-artist-item">` rendered with default disc bullets beside the `.button-3` pills — there was no `list-style: none` anywhere.

**Fix:** Added `.user-artist-list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem; }` and `.user-artist-item { margin: 0; }` so the artist links lay out as a wrapping flex row of pills, consistent with the existing button styling.

### BUG 2 — Recent Activity feed is half-width, huge empty right column (HIGH)
`.bbp-user-profile-card` is `width: calc(50% - 20px)` on desktop, so the activity feed (`.user-profile-activity-feed`, a `.bbp-user-profile-card`) only filled the left column and left the right side empty.

**Fix:** Added `.bbp-user-profile-card.user-profile-activity-feed { width: 100%; }` (mirroring the existing `.user-artist-cards-fullwidth` full-width pattern) and reset its desktop left/right card gutters to `0` inside the `@media (min-width: 768px)` block so the full-width card cannot overflow.

### BUG 3 — Empty "About" card renders as a hollow box
The first `.bbp-user-profile-card` (About) wrapper was emitted unconditionally, but its `<h3>About</h3>`, description, and local-scene contents are all inside conditionals. A user with no description AND no `local_city` got a blank bordered/shadowed box.

**Fix (template):** In `bbpress/user-profile.php`, compute `$has_about_content` (description OR local_city) up front, then only open/close the card wrapper when there is actual content. Also de-duplicated the double `bbp_get_displayed_user_field('description')` call into a single `$about_description` variable.

### BUG 4 — Orphan `<hr>` inside the flex container
A bare `<hr>` sat directly inside `.bbp-user-profile-cards-container` (a `display:flex` container), where it behaved unpredictably as a flex item.

**Fix (template):** Removed the stray `<hr>`. The card borders already provide separation.

### BUG 5 — `overflow: scroll` forces permanent scrollbars
`.bbp-user-profile { overflow: scroll; }` forced always-visible scrollbars.

**Fix:** Changed to `overflow-x: auto;` so scrollbars only appear when content actually overflows horizontally.

### BUG 6 — `<h3>` card headings get no accent styling
CSS only styled `.bbp-user-profile-card h2` (accent underline). The real cards use `<h3>` ("About", "Community Activity", "{User}'s Recent Activity"), so they got no heading treatment.

**Fix:** Extended the selector to `.bbp-user-profile-card h2, .bbp-user-profile-card h3` so all card headings get the consistent accent underline. Verified the artist card `<h2>` still matches.

## Verification
- `php -l` run on all edited PHP files — no syntax errors.
- CSS is enqueued raw (no build step); no `src/` files touched.
- Re-read final CSS to confirm no duplicate/conflicting selectors and that both HIGH bugs are unambiguously fixed.

## Notes
- `CHANGELOG.md` not touched; version strings not bumped (homeboy owns both).
- PR only — not released or deployed.