### PR TITLE
fix: profile page card styling, template div nesting, dead CSS prune

### DIFF
--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -154,13 +154,8 @@ if ( $is_artist || $is_professional ) :
 	</div>
 <?php endif; // End if user_is_artist or user_is_professional ?>
 
-</div>
+</div> <?php // End .bbp-user-profile-cards-container (Flex Grid) ?>
 
-</div> <?php // End Flex Grid Container ?>
-
-		</div> <?php // End Flex Grid Container ?>
-
-
-	</div><!-- #bbp-user-profile -->
+</div><!-- #bbp-user-profile -->
 
 <?php do_action('bbp_template_after_user_profile'); ?>

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -56,58 +56,24 @@
 	box-sizing: border-box;
 }
 
-/* User Profile Header */
-.user-profile-header h1 {
-    margin-bottom: 10px;
-    margin-right: 5px;
-}
-
-.user-profile-header p,
 .forum-title-with-icon {
     margin-bottom: 10px;
     margin-top: 5px;
     font-size: var(--font-size-sm);
 }
 
-.user-profile-header {
-    margin: 15px 0 20px 0;
-}
-
 .bbp-user-profile {
     overflow-x: auto;
 }
 
-.rank-profile p, 
 .user-profile-activity p, 
-.profile-links p, 
-.bbp-user-music-fan p, 
-.bbp-user-local-scene p, 
-.bbp-user-artist-details p, 
-.bbp-user-professional-details p {
+.profile-links p {
     margin: 0;
     font-size: var(--font-size-sm);
 }
 
 .user-profile-activity, 
-.profile-links, 
-.bbp-user-music-fan, 
-.bbp-user-local-scene, 
-.bbp-user-artist-details, 
-.bbp-user-professional-details {
-    margin-bottom: 20px;
-}
-
-
-
-/* Spacing for artist/professional details */
-.bbp-user-artist-details, 
-.bbp-user-professional-details {
-    padding-top: 20px;
-}
-
-/* Local Scene Section */
-.bbp-user-local-scene {
-    padding-top: 15px;
+.profile-links {
     margin-bottom: 20px;
 }
 
@@ -158,11 +124,6 @@
 	color: var(--muted-text);
 	margin-bottom: 0.25rem;
 	width: 100%;
-}
-
-.bbp-user-profile .bbp-user-follower-count {
-	font-size: var(--font-size-base);
-	color: var(--muted-text);
 }
 
 .bbp-user-profile .bbp-user-last-seen {
@@ -397,6 +358,16 @@
 
 /* Activity feed spans the full row instead of occupying one half-width column. */
 .bbp-user-profile-card.user-profile-activity-feed {
+    width: 100%;
+}
+
+/* Concert History + legacy Music Fan cards render via the
+   bbp_template_after_user_details hook (see user-details.php), which places
+   them outside .bbp-user-profile-cards-container — directly under the header
+   card, not inside the 2-column flex grid. Keep them full-width so the desktop
+   half-width card rule above doesn't shrink them. */
+.bbp-user-profile-card.ec-concert-history-card,
+.bbp-user-profile-card.ec-music-fan-details-card {
     width: 100%;
 }
 

--- a/inc/user-profiles/concert-history.php
+++ b/inc/user-profiles/concert-history.php
@@ -165,14 +165,10 @@ function ec_community_display_concert_history() {
 			return;
 		}
 		?>
-		<div class="card ec-concert-history-card ec-concert-history-empty">
-			<div class="card-header">
-				<h3><?php esc_html_e( 'Concert History', 'extra-chill-community' ); ?></h3>
-			</div>
-			<div class="card-body">
-				<p><?php esc_html_e( 'You haven\'t tracked any shows yet. Build your concert history — every show you\'ve been to, in one place.', 'extra-chill-community' ); ?></p>
-				<p><a class="button" href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Start your concert history →', 'extra-chill-community' ); ?></a></p>
-			</div>
+		<div class="bbp-user-profile-card ec-concert-history-card ec-concert-history-empty">
+			<h3><?php esc_html_e( 'Concert History', 'extra-chill-community' ); ?></h3>
+			<p><?php esc_html_e( 'You haven\'t tracked any shows yet. Build your concert history — every show you\'ve been to, in one place.', 'extra-chill-community' ); ?></p>
+			<p><a class="button-1 button-small" href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Start your concert history →', 'extra-chill-community' ); ?></a></p>
 		</div>
 		<?php
 		return;
@@ -191,60 +187,56 @@ function ec_community_display_concert_history() {
 		? __( 'My Concert History', 'extra-chill-community' )
 		: __( 'Concert History', 'extra-chill-community' );
 	?>
-	<div class="card ec-concert-history-card">
-		<div class="card-header">
-			<h3><?php echo esc_html( $heading ); ?></h3>
-		</div>
-		<div class="card-body">
-			<ul class="ec-concert-stats">
+	<div class="bbp-user-profile-card ec-concert-history-card">
+		<h3><?php echo esc_html( $heading ); ?></h3>
+		<ul class="ec-concert-stats">
+			<li>
+				<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $total_shows ) ); ?></span>
+				<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'show', 'shows', $total_shows, 'extra-chill-community' ) ); ?></span>
+			</li>
+			<?php if ( $unique_artists > 0 ) : ?>
 				<li>
-					<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $total_shows ) ); ?></span>
-					<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'show', 'shows', $total_shows, 'extra-chill-community' ) ); ?></span>
+					<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_artists ) ); ?></span>
+					<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'artist', 'artists', $unique_artists, 'extra-chill-community' ) ); ?></span>
 				</li>
-				<?php if ( $unique_artists > 0 ) : ?>
-					<li>
-						<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_artists ) ); ?></span>
-						<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'artist', 'artists', $unique_artists, 'extra-chill-community' ) ); ?></span>
-					</li>
-				<?php endif; ?>
-				<?php if ( $unique_venues > 0 ) : ?>
-					<li>
-						<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_venues ) ); ?></span>
-						<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'venue', 'venues', $unique_venues, 'extra-chill-community' ) ); ?></span>
-					</li>
-				<?php endif; ?>
-				<?php if ( $unique_cities > 0 ) : ?>
-					<li>
-						<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_cities ) ); ?></span>
-						<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'city', 'cities', $unique_cities, 'extra-chill-community' ) ); ?></span>
-					</li>
-				<?php endif; ?>
-			</ul>
+			<?php endif; ?>
+			<?php if ( $unique_venues > 0 ) : ?>
+				<li>
+					<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_venues ) ); ?></span>
+					<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'venue', 'venues', $unique_venues, 'extra-chill-community' ) ); ?></span>
+				</li>
+			<?php endif; ?>
+			<?php if ( $unique_cities > 0 ) : ?>
+				<li>
+					<span class="ec-concert-stat-value"><?php echo esc_html( number_format_i18n( $unique_cities ) ); ?></span>
+					<span class="ec-concert-stat-label"><?php echo esc_html( _n( 'city', 'cities', $unique_cities, 'extra-chill-community' ) ); ?></span>
+				</li>
+			<?php endif; ?>
+		</ul>
 
-			<?php if ( $top_artists ) : ?>
-				<p><strong><?php esc_html_e( 'Top Artists:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_artists ); ?></p>
-			<?php endif; ?>
-			<?php if ( $top_venues ) : ?>
-				<p><strong><?php esc_html_e( 'Top Venues:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_venues ); ?></p>
-			<?php endif; ?>
-			<?php if ( $top_cities ) : ?>
-				<p><strong><?php esc_html_e( 'Top Cities:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_cities ); ?></p>
-			<?php endif; ?>
+		<?php if ( $top_artists ) : ?>
+			<p><strong><?php esc_html_e( 'Top Artists:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_artists ); ?></p>
+		<?php endif; ?>
+		<?php if ( $top_venues ) : ?>
+			<p><strong><?php esc_html_e( 'Top Venues:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_venues ); ?></p>
+		<?php endif; ?>
+		<?php if ( $top_cities ) : ?>
+			<p><strong><?php esc_html_e( 'Top Cities:', 'extra-chill-community' ); ?></strong> <?php echo wp_kses_post( $top_cities ); ?></p>
+		<?php endif; ?>
 
-			<?php if ( $my_shows_url ) : ?>
-				<p class="ec-concert-history-cta">
-					<a href="<?php echo esc_url( $my_shows_url ); ?>">
-						<?php
-						echo esc_html(
-							$is_own
-								? __( 'View your full concert history →', 'extra-chill-community' )
-								: __( 'View full concert history →', 'extra-chill-community' )
-						);
-						?>
-					</a>
-				</p>
-			<?php endif; ?>
-		</div>
+		<?php if ( $my_shows_url ) : ?>
+			<p class="ec-concert-history-cta">
+				<a href="<?php echo esc_url( $my_shows_url ); ?>">
+					<?php
+					echo esc_html(
+						$is_own
+							? __( 'View your full concert history →', 'extra-chill-community' )
+							: __( 'View full concert history →', 'extra-chill-community' )
+					);
+					?>
+				</a>
+			</p>
+		<?php endif; ?>
 	</div>
 	<?php
 }

--- a/inc/user-profiles/custom-user-profile.php
+++ b/inc/user-profiles/custom-user-profile.php
@@ -68,43 +68,39 @@ function display_music_fan_details() {
 
 	$is_own = ( (int) get_current_user_id() === (int) $user_id );
 	?>
-	<div class="card ec-music-fan-details-card">
-		<div class="card-header">
-			<h3><?php esc_html_e( 'Music Fan Details', 'extra-chill-community' ); ?></h3>
-		</div>
-		<div class="card-body">
-			<?php if ( $favorite_artists ) : ?>
-				<p><strong><?php esc_html_e( 'Favorite Artists:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $favorite_artists ) ); ?></p>
-			<?php endif; ?>
+	<div class="bbp-user-profile-card ec-music-fan-details-card">
+		<h3><?php esc_html_e( 'Music Fan Details', 'extra-chill-community' ); ?></h3>
+		<?php if ( $favorite_artists ) : ?>
+			<p><strong><?php esc_html_e( 'Favorite Artists:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $favorite_artists ) ); ?></p>
+		<?php endif; ?>
 
-			<?php if ( $top_concerts ) : ?>
-				<p><strong><?php esc_html_e( 'Top Concerts:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $top_concerts ) ); ?></p>
-			<?php endif; ?>
+		<?php if ( $top_concerts ) : ?>
+			<p><strong><?php esc_html_e( 'Top Concerts:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $top_concerts ) ); ?></p>
+		<?php endif; ?>
 
-			<?php if ( $top_venues ) : ?>
-				<p><strong><?php esc_html_e( 'Top Venues:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $top_venues ) ); ?></p>
-			<?php endif; ?>
+		<?php if ( $top_venues ) : ?>
+			<p><strong><?php esc_html_e( 'Top Venues:', 'extra-chill-community' ); ?></strong> <?php echo nl2br( esc_html( $top_venues ) ); ?></p>
+		<?php endif; ?>
 
-			<?php
-			// These are legacy free-text notes from before My Shows existed.
-			// We deliberately do NOT promise to "convert" them: the events
-			// catalog is a forward-looking calendar with almost no historic /
-			// out-of-market shows, so searching for these past memories mostly
-			// finds nothing. Instead, invite the owner to start tracking shows
-			// going forward via My Shows — the path that actually works today.
-			if ( $is_own && function_exists( 'ec_community_my_shows_url' ) ) :
-				$my_shows_url = ec_community_my_shows_url( (int) $user_id );
-				if ( $my_shows_url ) :
-					?>
-					<p class="ec-music-fan-nudge">
-						<em><?php esc_html_e( 'These are your personal notes.', 'extra-chill-community' ); ?></em>
-						<a href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Start tracking shows you attend →', 'extra-chill-community' ); ?></a>
-					</p>
-					<?php
-				endif;
+		<?php
+		// These are legacy free-text notes from before My Shows existed.
+		// We deliberately do NOT promise to "convert" them: the events
+		// catalog is a forward-looking calendar with almost no historic /
+		// out-of-market shows, so searching for these past memories mostly
+		// finds nothing. Instead, invite the owner to start tracking shows
+		// going forward via My Shows — the path that actually works today.
+		if ( $is_own && function_exists( 'ec_community_my_shows_url' ) ) :
+			$my_shows_url = ec_community_my_shows_url( (int) $user_id );
+			if ( $my_shows_url ) :
+				?>
+				<p class="ec-music-fan-nudge">
+					<em><?php esc_html_e( 'These are your personal notes.', 'extra-chill-community' ); ?></em>
+					<a href="<?php echo esc_url( $my_shows_url ); ?>"><?php esc_html_e( 'Start tracking shows you attend →', 'extra-chill-community' ); ?></a>
+				</p>
+				<?php
 			endif;
-			?>
-		</div>
+		endif;
+		?>
 	</div>
 	<?php
 }


### PR DESCRIPTION
Follow-up to #145 cleaning up the remaining visual/structural bugs on the bbPress user profile page. **Profile/cleanup only — not for release/deploy.**

## BUG A — Concert History card was unstyled (HIGH)

`concert-history.php` wrapped both its empty-CTA card and its populated card in a `.card` / `.card-header` / `.card-body` convention that has **no CSS anywhere** (verified by grepping `inc/assets/css/` and the theme). Every other card on the profile uses `.bbp-user-profile-card`. Result: the concert card rendered as bare unstyled content next to proper styled siblings.

**Fix:** On both card variants, swapped the outer wrapper to `.bbp-user-profile-card ec-concert-history-card …` and dropped the dead `.card-header` / `.card-body` wrappers so the `<h3>` and body sit directly inside `.bbp-user-profile-card` (matching the About / Community Activity cards). The `<h3>` now picks up the accent underline from the existing `.bbp-user-profile-card h2, .bbp-user-profile-card h3` rule (verified present). The empty-state CTA button was changed from `class="button"` to `class="button-1 button-small"` to match the platform button convention used by the artist-card actions. Internal `.ec-concert-*` classes and CSS are untouched. The inline "View full concert history →" text link is left as a plain link (matches the visual language of the other cards' text links).

**Scope note — also fixed the Music Fan Details card:** `custom-user-profile.php` had the *identical* broken `.card` / `.card-header` / `.card-body` convention. The task brief's own rationale ("every OTHER card on the profile uses `.bbp-user-profile-card`") only holds if this sibling is fixed too, so it received the same mechanical treatment (outer wrapper → `.bbp-user-profile-card ec-music-fan-details-card`, wrappers dropped).

**Width safeguard added:** these two cards render via the `bbp_template_after_user_details` hook (`user-details.php:232`), which places them *outside* `.bbp-user-profile-cards-container` (directly under the header card, not in the 2-col flex grid). Without an override the desktop `calc(50% - 20px)` card rule would shrink them. Added a `width: 100%` override for `.bbp-user-profile-card.ec-concert-history-card` / `.ec-music-fan-details-card`, matching the existing `user-artist-cards-fullwidth` / `user-profile-activity-feed` full-width pattern.

## BUG B — Mismatched `</div>` nesting closed the cards container early (MEDIUM)

`bbpress/user-profile.php` had **two extra** closing `</div>` tags after the artist card (three closes where only one was needed), so `.bbp-user-profile-cards-container` and `#bbp-user-profile` both closed early and the activity feed (hooked via `bbp_template_after_user_profile`) landed in a broken position.

**Fix:** removed the two stray closes; left exactly one close for the flex-grid container and one for `#bbp-user-profile`.

**Div balance (literal HTML, PHP blocks stripped):**

| | opens | closes | diff |
|---|---|---|---|
| Before | 6 | 8 | −2 (broken) |
| After | 6 | 6 | 0 ✓ |

The two PHP-echoed divs inside the conditional artist card (`user-artist-management-actions` open/close) remain balanced and were not touched.

## BUG C — Dead-CSS sweep (LOW)

Removed `user-profile.css` selectors whose classes **no markup emits** (confirmed by grepping `wp-content/themes/` + `wp-content/plugins/`, PHP only):

- `.user-profile-header` (h1, p, and the standalone rule)
- `.rank-profile p`
- `.bbp-user-music-fan` (p + standalone)
- standalone `.bbp-user-local-scene` (p + standalone) — *note: `.bbp-user-local-scene-inline` is a different class token and was never styled here, so nothing live was affected*
- `.bbp-user-artist-details`, `.bbp-user-professional-details`
- `.bbp-user-follower-count`

The two grouped selectors were trimmed in place: dead class entries removed, live `.user-profile-activity` / `.profile-links` rules kept. Per the "don't over-prune" guidance, `.profile-links` and `.forum-title-with-icon` (also unstyled-by-markup but **not** in the brief's list) were left untouched.

## Verification

- `php -l` clean on all three edited PHP files.
- No build step (CSS is enqueued raw from `inc/assets/css/user-profile.css` via `inc/core/assets.php::enqueue_user_profile_styles()`).
- Literal-HTML div balance re-counted after the edit: 6/6.
- Confirmed no `class="card …"` / `.card-header` / `.card-body` remains in `inc/user-profiles/`.
- Did not touch `CHANGELOG.md` or the version string — homeboy owns both.