### PR TITLE
feat: add GitHub-style contribution heatmap to user profiles

### DIFF
--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -55,8 +55,8 @@ $has_about_content = ! empty( $about_description ) || ! empty( $about_local_city
 		<p class="bbp-user-join-date"><b>Joined:</b> <?php echo esc_html(date_i18n(get_option('date_format'), strtotime($join_date))); ?></p>
 	<?php endif; ?>
 
-	<p class="bbp-user-topic-count"><b>Threads Started:</b> <?php echo (int) bbp_get_user_topic_count_raw( bbp_get_displayed_user_id() ); ?> <a href="<?php bbp_user_topics_created_url(); ?>"><?php /* translators: %s: user display name */ printf(esc_html__("(%s's Threads)", 'extra-chill-community'), esc_html(bbp_get_displayed_user_field('display_name'))); ?></a></p>
-	<p class="bbp-user-reply-count"><b>Total Replies:</b> <?php echo (int) bbp_get_user_reply_count_raw( bbp_get_displayed_user_id() ); ?> <a href="<?php bbp_user_replies_created_url(); ?>"><?php /* translators: %s: user display name */ printf(esc_html__("(%s's Replies Created)", 'extra-chill-community'), esc_html(bbp_get_displayed_user_field('display_name'))); ?></a></p>
+	<p class="bbp-user-topic-count"><b>Threads Started:</b> <span class="ec-activity-count"><?php echo (int) bbp_get_user_topic_count_raw( bbp_get_displayed_user_id() ); ?></span> <a href="<?php bbp_user_topics_created_url(); ?>"><?php /* translators: %s: user display name */ printf(esc_html__("(%s's Threads)", 'extra-chill-community'), esc_html(bbp_get_displayed_user_field('display_name'))); ?></a></p>
+	<p class="bbp-user-reply-count"><b>Total Replies:</b> <span class="ec-activity-count"><?php echo (int) bbp_get_user_reply_count_raw( bbp_get_displayed_user_id() ); ?></span> <a href="<?php bbp_user_replies_created_url(); ?>"><?php /* translators: %s: user display name */ printf(esc_html__("(%s's Replies Created)", 'extra-chill-community'), esc_html(bbp_get_displayed_user_field('display_name'))); ?></a></p>
 
 	<!-- Display Main Site Blog Post Count -->
 	<?php

--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -80,6 +80,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/concert-history.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/contribution-calendar.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/custom-user-profile.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/profile-activity-feed.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/verification.php';

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -457,3 +457,143 @@
 .ec-music-fan-details-card .ec-music-fan-nudge em {
 	opacity: 0.7;
 }
+
+/* ==================================================
+   Contribution Heatmap (GitHub-style activity calendar)
+   Pure CSS grid. Shade ramp uses the EC brand --accent
+   (green, #53940b) via color-mix over --card-background,
+   so it stays on-brand and respects the design system.
+   ================================================== */
+
+/* The heatmap is a full-width hero card: it renders via the
+   bbp_template_after_user_details hook, outside the 2-column flex grid.
+   Two-class selector beats the desktop half-width card rule. */
+.bbp-user-profile-card.ec-contribution-heatmap {
+	width: 100%;
+}
+
+@media (min-width: 768px) {
+	.bbp-user-profile-card.ec-contribution-heatmap {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
+.ec-contribution-heatmap > h3 {
+	margin-bottom: 0.5rem;
+}
+
+.ec-heatmap-summary {
+	margin: 0 0 0.75rem;
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ec-heatmap-summary strong {
+	color: var(--text-color, currentColor);
+}
+
+/* Horizontal scroll on narrow screens so the 53-week grid never overflows
+   the profile column. */
+.ec-heatmap-scroll {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	padding-bottom: 0.25rem;
+}
+
+.ec-heatmap {
+	display: grid;
+	/* column 1 = weekday labels, columns 2..54 = the 53 week-columns. */
+	grid-template-columns: 2em repeat(53, var(--ec-heat-cell, 12px));
+	/* row 1 = month labels, rows 2..8 = Sun..Sat. */
+	grid-template-rows: 1.4em repeat(7, var(--ec-heat-cell, 12px));
+	gap: 3px;
+	width: max-content;
+	min-width: 100%;
+}
+
+.ec-heat-month {
+	font-size: 0.7rem;
+	color: var(--muted-text);
+	line-height: 1.4em;
+	white-space: nowrap;
+}
+
+.ec-heat-weekday {
+	font-size: 0.7rem;
+	color: var(--muted-text);
+	line-height: var(--ec-heat-cell, 12px);
+	text-align: right;
+	padding-right: 2px;
+}
+
+.ec-heat-cell {
+	width: var(--ec-heat-cell, 12px);
+	height: var(--ec-heat-cell, 12px);
+	border-radius: 2px;
+	display: block;
+	background-color: var(--border-color);
+}
+
+/* Intensity ramp. level-0 = empty; 1..4 = accent blended over card bg. */
+.ec-heat-cell.level-0 {
+	background-color: var(--border-color);
+}
+.ec-heat-cell.level-1 {
+	background-color: color-mix(in srgb, var(--accent) 30%, var(--card-background));
+}
+.ec-heat-cell.level-2 {
+	background-color: color-mix(in srgb, var(--accent) 55%, var(--card-background));
+}
+.ec-heat-cell.level-3 {
+	background-color: color-mix(in srgb, var(--accent) 78%, var(--card-background));
+}
+.ec-heat-cell.level-4 {
+	background-color: var(--accent);
+}
+
+/* Legend chips render inline (outside the grid). */
+.ec-heat-cell.ec-heat-cell-legend {
+	display: inline-block;
+	margin: 0 1px;
+	vertical-align: middle;
+}
+
+.ec-heatmap-footer {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	margin-top: 0.75rem;
+	font-size: var(--font-size-sm);
+	color: var(--muted-text);
+}
+
+.ec-heatmap-legend {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+}
+
+.ec-heat-legend-label {
+	font-size: 0.75rem;
+}
+
+/* Slightly smaller cells on mobile so the grid fits common viewports. */
+@media (max-width: 768px) {
+	.ec-heatmap {
+		--ec-heat-cell: 11px;
+	}
+}
+
+/* ------------------------------------------------------
+   Community Activity card: conservative slim.
+   The heatmap is now the temporal hero, so de-emphasize the
+   raw standalone counts (topics/replies) without removing them
+   or their navigational links.
+   ------------------------------------------------------ */
+.ec-activity-count {
+	color: var(--muted-text);
+	font-weight: 600;
+}

--- a/inc/user-profiles/contribution-calendar.php
+++ b/inc/user-profiles/contribution-calendar.php
@@ -1,0 +1,522 @@
+<?php
+/**
+ * Contribution Heatmap (GitHub-style activity calendar)
+ *
+ * Adds a per-day contribution heatmap to bbPress user profiles, modeled on
+ * GitHub's contribution calendar. A "contribution" is any topic, reply, or
+ * main-site post the user authored on a given calendar day — the same
+ * date-bearing sources the rank/points system reads (see
+ * inc/social/rank-system/point-calculation.php). Upvotes and filtered
+ * extra-points are intentionally excluded: they carry no timestamp trail, and
+ * inventing one would require a new table (out of scope).
+ *
+ * This file owns three things, colocated because they are one feature:
+ *   1. The data layer (cross-site per-day aggregation + caching + busts).
+ *   2. The public ability registration + execute callback (headless-first).
+ *   3. The full-width profile card renderer (a consumer of the ability).
+ *
+ * @package ExtraChillCommunity
+ * @since 1.11.5
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Cache TTL for the per-user contribution calendar (seconds).
+ *
+ * Mirrors the points-calc caching convention (1 hour). The cache is also
+ * busted eagerly on new bbPress activity (see
+ * ec_community_invalidate_contribution_calendar()), so streaks stay fresh.
+ */
+const EC_CONTRIB_CALENDAR_CACHE_TTL = HOUR_IN_SECONDS;
+
+// ─── Data layer ─────────────────────────────────────────────────────────────
+
+/**
+ * Build a user's per-day contribution calendar over the trailing window.
+ *
+ * Counts topics + replies (community blog) and main-site posts (main blog)
+ * authored by the user, grouped by local calendar day, then merges the per-day
+ * maps. Summary metadata (total, max-day, current/longest streak) is derived
+ * from the merged map.
+ *
+ * Timezone approach: WordPress stores `post_date` in the site's configured
+ * timezone (America/New_York on this network — confirmed via
+ * `get_option('timezone_string')`). Users perceive "today" in that same zone,
+ * so `DATE(post_date)` yields correct local day boundaries with no off-by-one
+ * at day edges and no GMT conversion needed. Both the community and main blogs
+ * share the same timezone, so the two per-day maps merge on the same basis.
+ * The window endpoints themselves are computed via `wp_timezone()` so the
+ * "today" anchor is local, not UTC. This matches how the existing display
+ * code (e.g. profile join date) treats stored dates.
+ *
+ * @param int $user_id User ID.
+ * @param int $days    Window length in days. Default 365. Only the default
+ *                     window is cached (see invalidation contract); non-default
+ *                     windows are computed fresh.
+ * @return array {
+ *     @type array $days               Map of 'YYYY-MM-DD' => int count (only
+ *                                     days with >=1 contribution; absent = 0).
+ *     @type int   $total_contributions
+ *     @type int   $max_day_count
+ *     @type int   $current_streak
+ *     @type int   $longest_streak
+ *     @type string $window_start      'YYYY-MM-DD'.
+ *     @type string $window_end        'YYYY-MM-DD'.
+ * } Empty array on invalid user.
+ */
+function ec_community_get_user_contribution_calendar( int $user_id, int $days = 365 ): array {
+	if ( $user_id <= 0 ) {
+		return array();
+	}
+
+	// Bound the window: at least 1 day, at most ~3 years to keep the query
+	// and the per-day map finite regardless of caller input.
+	$days = max( 1, min( 1095, (int) $days ) );
+
+	$is_default_window = ( 365 === $days );
+	$cache_key         = 'ec_contrib_calendar_' . $user_id;
+
+	if ( $is_default_window ) {
+		$cached = get_transient( $cache_key );
+		if ( is_array( $cached ) && isset( $cached['days'] ) ) {
+			return $cached;
+		}
+	}
+
+	$tz           = wp_timezone();
+	$today        = new DateTimeImmutable( 'today', $tz );
+	$window_end   = $today;
+	$window_start = $today->modify( '-' . ( $days - 1 ) . ' days' );
+
+	// post_date is site-local on both blogs; compare directly.
+	$window_start_mysql = $window_start->format( 'Y-m-d 00:00:00' );
+
+	$days_map = array();
+
+	// --- Source 1: bbPress topics + replies on the community (current) blog.
+	global $wpdb;
+	$community_rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT DATE(post_date) AS d, COUNT(*) AS c
+			 FROM {$wpdb->posts}
+			 WHERE post_author = %d
+			   AND post_type IN ('topic', 'reply')
+			   AND post_status = 'publish'
+			   AND post_date >= %s
+			 GROUP BY DATE(post_date)",
+			$user_id,
+			$window_start_mysql
+		)
+	);
+
+	if ( is_array( $community_rows ) ) {
+		foreach ( $community_rows as $row ) {
+			$days_map[ $row->d ] = (int) $row->c;
+		}
+	}
+
+	// --- Source 2: main-site posts (cross-blog). Mirrors the switch_to_blog
+	// pattern in point-calculation.php, with restore_current_blog() in a
+	// finally so the switched context can never leak.
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( $main_blog_id ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			$main_rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DATE(post_date) AS d, COUNT(*) AS c
+					 FROM {$wpdb->posts}
+					 WHERE post_author = %d
+					   AND post_type = 'post'
+					   AND post_status = 'publish'
+					   AND post_date >= %s
+					 GROUP BY DATE(post_date)",
+					$user_id,
+					$window_start_mysql
+				)
+			);
+		} finally {
+			restore_current_blog();
+		}
+
+		if ( is_array( $main_rows ) ) {
+			foreach ( $main_rows as $row ) {
+				$existing          = isset( $days_map[ $row->d ] ) ? $days_map[ $row->d ] : 0;
+				$days_map[ $row->d ] = $existing + (int) $row->c;
+			}
+		}
+	}
+
+	$total   = array_sum( $days_map );
+	$max_day = $days_map ? (int) max( $days_map ) : 0;
+
+	// --- Current streak: consecutive contributed days ending today, with a
+	// GitHub-style grace period — if today has no contribution yet, the
+	// streak still counts up to the most recent contributed day.
+	$current_streak = 0;
+	$cursor         = $today;
+	if ( ! isset( $days_map[ $cursor->format( 'Y-m-d' ) ] ) ) {
+		$cursor = $cursor->modify( '-1 day' );
+	}
+	while ( isset( $days_map[ $cursor->format( 'Y-m-d' ) ] ) ) {
+		++$current_streak;
+		$cursor = $cursor->modify( '-1 day' );
+	}
+
+	// --- Longest streak: longest run of contributed days anywhere in window.
+	$longest_streak = 0;
+	$run            = 0;
+	$iter           = $window_start;
+	while ( $iter <= $today ) {
+		if ( isset( $days_map[ $iter->format( 'Y-m-d' ) ] ) ) {
+			++$run;
+			if ( $run > $longest_streak ) {
+				$longest_streak = $run;
+			}
+		} else {
+			$run = 0;
+		}
+		$iter = $iter->modify( '+1 day' );
+	}
+
+	$payload = array(
+		'days'                => $days_map,
+		'total_contributions' => (int) $total,
+		'max_day_count'       => $max_day,
+		'current_streak'      => $current_streak,
+		'longest_streak'      => $longest_streak,
+		'window_start'        => $window_start->format( 'Y-m-d' ),
+		'window_end'          => $window_end->format( 'Y-m-d' ),
+	);
+
+	if ( $is_default_window ) {
+		set_transient( $cache_key, $payload, EC_CONTRIB_CALENDAR_CACHE_TTL );
+	}
+
+	return $payload;
+}
+
+/**
+ * Bust a user's contribution-calendar cache on new bbPress activity.
+ *
+ * Hooked alongside the points recalculation queue (bbp_new_topic /
+ * bbp_new_reply) so streaks and counts never lag behind a fresh post. Main-site
+ * post creation happens on a different blog and has no hook here; the 1-hour
+ * TTL covers that drift (acceptable — main-site posts are infrequent).
+ *
+ * @param int $post_id Topic or reply post ID.
+ */
+function ec_community_invalidate_contribution_calendar( $post_id ) {
+	if ( ! function_exists( 'bbp_is_reply' ) ) {
+		return;
+	}
+
+	$user_id = bbp_is_reply( $post_id )
+		? bbp_get_reply_author_id( $post_id )
+		: bbp_get_topic_author_id( $post_id );
+
+	if ( $user_id ) {
+		delete_transient( 'ec_contrib_calendar_' . (int) $user_id );
+	}
+}
+add_action( 'bbp_new_topic', 'ec_community_invalidate_contribution_calendar' );
+add_action( 'bbp_new_reply', 'ec_community_invalidate_contribution_calendar' );
+
+// ─── Ability ────────────────────────────────────────────────────────────────
+
+add_action( 'wp_abilities_api_init', 'ec_community_register_contribution_calendar_ability' );
+
+/**
+ * Register the get-user-contribution-calendar ability.
+ *
+ * Registered the same way as the rank abilities
+ * (inc/social/rank-system/rank-abilities.php) so the calendar payload is
+ * available over REST / MCP / chat (headless-first). `permission_callback` is
+ * public because contribution counts are derived from public published posts.
+ */
+function ec_community_register_contribution_calendar_ability() {
+	wp_register_ability(
+		'extrachill/get-user-contribution-calendar',
+		array(
+			'label'               => __( 'Get User Contribution Calendar', 'extra-chill-community' ),
+			'description'         => __( 'Get a per-day contribution calendar (topics + replies + main-site posts) for a user over the last N days, with streak and total metadata.', 'extra-chill-community' ),
+			'category'            => 'extrachill-community',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'User ID (required).', 'extra-chill-community' ),
+					),
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Window length in days. Default 365.', 'extra-chill-community' ),
+					),
+				),
+				'required'   => array( 'user_id' ),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'days'                => array( 'type' => 'object' ),
+					'total_contributions' => array( 'type' => 'integer' ),
+					'max_day_count'       => array( 'type' => 'integer' ),
+					'current_streak'      => array( 'type' => 'integer' ),
+					'longest_streak'      => array( 'type' => 'integer' ),
+					'window_start'        => array( 'type' => 'string' ),
+					'window_end'          => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'ec_community_ability_get_user_contribution_calendar',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Execute callback for the get-user-contribution-calendar ability.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function ec_community_ability_get_user_contribution_calendar( $input ) {
+	$user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
+	if ( ! $user_id ) {
+		return new WP_Error( 'missing_user', __( 'A user_id is required.', 'extra-chill-community' ) );
+	}
+
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return new WP_Error( 'user_not_found', __( 'User not found.', 'extra-chill-community' ) );
+	}
+
+	$days = isset( $input['days'] ) ? (int) $input['days'] : 365;
+
+	return ec_community_get_user_contribution_calendar( $user_id, $days );
+}
+
+// ─── Renderer ───────────────────────────────────────────────────────────────
+
+/**
+ * Map a per-day contribution count to a 0..4 shade level.
+ *
+ * GitHub-style quartile buckets relative to the user's own max-day count, so
+ * the ramp scales with their activity level. level-0 is always zero
+ * (no contribution).
+ *
+ * @param int $count Day's contribution count.
+ * @param int $max   The user's max day count across the window.
+ * @return int 0..4.
+ */
+function ec_community_heat_level( int $count, int $max ): int {
+	if ( $count <= 0 ) {
+		return 0;
+	}
+	if ( $max <= 0 ) {
+		return 0;
+	}
+	if ( $count >= $max ) {
+		return 4;
+	}
+
+	$ratio = $count / $max;
+	if ( $ratio <= 0.25 ) {
+		return 1;
+	}
+	if ( $ratio <= 0.50 ) {
+		return 2;
+	}
+	if ( $ratio <= 0.75 ) {
+		return 3;
+	}
+	return 4;
+}
+
+/**
+ * Render the full-width contribution heatmap card on the bbPress user profile.
+ *
+ * Server-rendered CSS grid (53 week-columns x 7 day-rows, Sun..Sat), with
+ * month labels across the top, weekday labels (Mon/Wed/Fri) down the left, a
+ * summary line, streak readout, and a Less/More legend. Pure PHP + CSS, no JS.
+ * Tooltips use native `title` attributes.
+ *
+ * Hooked on `bbp_template_after_user_details` at priority 3 so it renders
+ * directly under the header card, above the Concert History card (priority 5)
+ * and above the 2-column `.bbp-user-profile-cards-container` flex grid. The
+ * `bbp_is_single_user_profile()` guard keeps it to the main profile tab only
+ * (not the topics/replies/edit sub-tabs).
+ */
+function ec_community_render_contribution_heatmap() {
+	if ( ! function_exists( 'bbp_is_single_user_profile' ) || ! bbp_is_single_user_profile() ) {
+		return;
+	}
+	if ( ! function_exists( 'bbp_get_displayed_user_id' ) ) {
+		return;
+	}
+
+	$user_id = (int) bbp_get_displayed_user_id();
+	if ( $user_id <= 0 ) {
+		return;
+	}
+
+	$data = ec_community_get_user_contribution_calendar( $user_id, 365 );
+
+	$days_map       = isset( $data['days'] ) && is_array( $data['days'] ) ? $data['days'] : array();
+	$total          = isset( $data['total_contributions'] ) ? (int) $data['total_contributions'] : 0;
+	$max_day        = isset( $data['max_day_count'] ) ? (int) $data['max_day_count'] : 0;
+	$current_streak = isset( $data['current_streak'] ) ? (int) $data['current_streak'] : 0;
+	$longest_streak = isset( $data['longest_streak'] ) ? (int) $data['longest_streak'] : 0;
+
+	$is_own  = ( (int) get_current_user_id() === $user_id );
+	$heading = $is_own
+		? __( 'My Contributions', 'extra-chill-community' )
+		: __( 'Contributions', 'extra-chill-community' );
+
+	$tz       = wp_timezone();
+	$today    = new DateTimeImmutable( 'today', $tz );
+	$today_dow = (int) $today->format( 'w' ); // 0 = Sun .. 6 = Sat.
+
+	// Grid origin: the Sunday beginning the first week. Back up from this
+	// week's Sunday by 52 weeks so the grid spans 53 week-columns ending at
+	// the current week (the GitHub layout).
+	$this_week_sunday = $today->modify( '-' . $today_dow . ' days' );
+	$first_sunday     = $this_week_sunday->modify( '-52 weeks' );
+
+	$weeks = 53;
+
+	// Weekday labels down the left (GitHub labels Mon/Wed/Fri).
+	$weekday_label_rows = array(
+		1 => 'Mon',
+		3 => 'Wed',
+		5 => 'Fri',
+	);
+
+	// Month labels: emit one on the first column whose week-start month
+	// differs from the previously emitted column's month.
+	$month_labels = array();
+	$prev_month   = null;
+	for ( $w = 0; $w < $weeks; $w++ ) {
+		$week_start = $first_sunday->modify( '+' . ( $w * 7 ) . ' days' );
+		$m          = (int) $week_start->format( 'n' );
+		if ( $prev_month !== $m ) {
+			$month_labels[ $w ] = $week_start->format( 'M' );
+			$prev_month         = $m;
+		}
+	}
+
+	$aria_label = sprintf(
+		/* translators: %s: total contributions count, formatted. */
+		__( '%s contributions in the last year', 'extra-chill-community' ),
+		number_format_i18n( $total )
+	);
+	?>
+	<div class="bbp-user-profile-card ec-contribution-heatmap">
+		<h3><?php echo esc_html( $heading ); ?></h3>
+		<p class="ec-heatmap-summary">
+			<?php
+			printf(
+				/* translators: %s: total contributions count, formatted (wrapped in <strong>). */
+				esc_html__( '%s contributions in the last year', 'extra-chill-community' ),
+				'<strong>' . esc_html( number_format_i18n( $total ) ) . '</strong>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- intentionally wrapped, inner value escaped.
+			);
+			?>
+		</p>
+
+		<div class="ec-heatmap-scroll">
+			<div class="ec-heatmap" role="img" aria-label="<?php echo esc_attr( $aria_label ); ?>">
+				<?php
+				// Month labels (grid row 1). Each placed at column = week_index + 2
+				// (column 1 is reserved for weekday labels).
+				foreach ( $month_labels as $mw => $mlabel ) {
+					printf(
+						'<span class="ec-heat-month" style="grid-column:%1$d;grid-row:1">%2$s</span>',
+						(int) $mw + 2,
+						esc_html( $mlabel )
+					);
+				}
+
+				// Weekday labels (column 1, rows 2..8). Row = dow + 2.
+				foreach ( $weekday_label_rows as $dow => $label ) {
+					printf(
+						'<span class="ec-heat-weekday" style="grid-column:1;grid-row:%1$d">%2$s</span>',
+						(int) $dow + 2,
+						esc_html( $label )
+					);
+				}
+
+				// Day cells (53 weeks x 7 days). Future slots (after today) are
+				// skipped so the current week renders partial.
+				for ( $w = 0; $w < $weeks; $w++ ) {
+					for ( $dow = 0; $dow < 7; $dow++ ) {
+						$date = $first_sunday->modify( '+' . ( $w * 7 + $dow ) . ' days' );
+						if ( $date > $today ) {
+							continue;
+						}
+
+						$date_str = $date->format( 'Y-m-d' );
+						$count    = isset( $days_map[ $date_str ] ) ? (int) $days_map[ $date_str ] : 0;
+						$level    = ec_community_heat_level( $count, $max_day );
+						$localized = wp_date( get_option( 'date_format' ), $date->getTimestamp(), $tz );
+
+						if ( $count > 0 ) {
+							$title = sprintf(
+								/* translators: 1: contribution count, 2: localized date. */
+								_n( '%1$s contribution on %2$s', '%1$s contributions on %2$s', $count, 'extra-chill-community' ),
+								$count,
+								$localized
+							);
+						} else {
+							$title = sprintf(
+								/* translators: %s: localized date. */
+								__( 'No contributions on %s', 'extra-chill-community' ),
+								$localized
+							);
+						}
+
+						printf(
+							'<span class="ec-heat-cell level-%1$d" style="grid-column:%2$d;grid-row:%3$d" title="%4$s"></span>',
+							$level,
+							(int) $w + 2,
+							(int) $dow + 2,
+							esc_attr( $title )
+						);
+					}
+				}
+				?>
+			</div>
+		</div>
+
+		<div class="ec-heatmap-footer">
+			<span class="ec-heatmap-streaks">
+				<?php
+				printf(
+					/* translators: 1: current streak days, 2: longest streak days. */
+					esc_html__( 'Current streak: %1$d days · Longest: %2$d days', 'extra-chill-community' ),
+					$current_streak,
+					$longest_streak
+				);
+				?>
+			</span>
+			<span class="ec-heatmap-legend" aria-hidden="true">
+				<span class="ec-heat-legend-label"><?php esc_html_e( 'Less', 'extra-chill-community' ); ?></span>
+				<span class="ec-heat-cell level-0 ec-heat-cell-legend"></span>
+				<span class="ec-heat-cell level-1 ec-heat-cell-legend"></span>
+				<span class="ec-heat-cell level-2 ec-heat-cell-legend"></span>
+				<span class="ec-heat-cell level-3 ec-heat-cell-legend"></span>
+				<span class="ec-heat-cell level-4 ec-heat-cell-legend"></span>
+				<span class="ec-heat-legend-label"><?php esc_html_e( 'More', 'extra-chill-community' ); ?></span>
+			</span>
+		</div>
+	</div>
+	<?php
+}
+add_action( 'bbp_template_after_user_details', 'ec_community_render_contribution_heatmap', 3 );

--- a/inc/user-profiles/profile-activity-feed.php
+++ b/inc/user-profiles/profile-activity-feed.php
@@ -24,9 +24,11 @@ if ( ! defined('ABSPATH') ) {
 /**
  * Render the displayed user's activity feed below their profile.
  *
- * Hooked to bbp_template_after_user_profile so it only renders on the main
- * profile tab (bbp_is_single_user_profile()), not on the topics/replies/edit
- * sub-tabs which already have their own bbPress loops.
+ * Hooked to bbp_template_after_user_details (priority 4) so it renders directly
+ * under the contribution heatmap (priority 3) — the chart shows the temporal
+ * pattern, this feed is its natural detail view (chart → recent items). The
+ * bbp_is_single_user_profile() guard keeps it to the main profile tab only,
+ * not the topics/replies/edit sub-tabs which have their own bbPress loops.
  *
  * @return void
  */
@@ -65,4 +67,4 @@ function extrachill_render_profile_activity_feed() {
 
 	echo '</div>';
 }
-add_action( 'bbp_template_after_user_profile', 'extrachill_render_profile_activity_feed' );
+add_action( 'bbp_template_after_user_details', 'extrachill_render_profile_activity_feed', 4 );


### PR DESCRIPTION
Closes #147.

## What this builds

A **GitHub-style contribution heatmap** on bbPress user profiles — the 53-week × 7-day intensity grid, plus the engagement metadata (total, current streak, longest streak). It becomes the profile's primary at-a-glance engagement surface and a stickiness driver.

### 1. Ability: `extrachill/get-user-contribution-calendar`
- Input: `user_id` (required), `days` (optional, default 365).
- A **contribution** = count of the user's **topics + replies + main-site posts** authored on a given calendar day. These are the date-bearing sources the rank/points system reads (`inc/social/rank-system/point-calculation.php`).
- **Excluded** (no timestamp trail): upvotes and `ec_rank_extra_points`. **No new tables.** The points scalar is never wrapped or read.
- Query: `GROUP BY DATE(post_date)` on the community blog for topics + replies, then `switch_to_blog( ec_get_blog_id('main') )` for main-site posts, merged per-day. `restore_current_blog()` in a `finally` (mirrors point-calc's pattern).
- Output: `{ days: {'YYYY-MM-DD': int}, total_contributions, max_day_count, current_streak, longest_streak, window_start, window_end }`. Absent days = 0 (renderer fills gaps).
- Cached in per-user transient `ec_contrib_calendar_{user_id}`, TTL 1h. **Busted on new bbPress activity** (`bbp_new_topic` / `bbp_new_reply`) so streaks never lag. Registered headless-first (REST/MCP/chat) like the rank abilities.

### 2. Full-width heatmap card (consumer)
- Placement: full-width `.bbp-user-profile-card`, rendered **below the header card, above the 2-column grid**, via `bbp_template_after_user_details` priority 3. Guarded to the main profile tab only (`bbp_is_single_user_profile()`).
- Server-rendered CSS grid: 53 columns (weeks) × 7 rows (days, Sun→Sat). Each cell carries a `level-0..level-4` shade class (quartile buckets relative to the user's max-day count) and a native `title` tooltip: "N contributions on {localized date}" / "No contributions on {date}".
- Month labels along the top, weekday labels (Mon/Wed/Fri) down the left (GitHub layout).
- Summary line: "X contributions in the last year" + current streak + longest streak.
- Legend: "Less ▢▢▢▢▢ More" shade key (5 chips, level 0→4), bottom-right.
- Pure PHP + CSS. **No JS.** Empty grid on a new user renders intentionally — the dead chart invites you to fill it.

### 3. Conservative collapse (preserve the MySpace-y vibe)
- **Community Activity card**: the heatmap now tells the temporal story, so the raw standalone topic/reply counts are **de-emphasized** (wrapped in `.ec-activity-count`, muted color) — but **kept**, along with every navigational link (Threads/Replies/Articles/Comments), join date, and last post. Main-site article/comment counts left untouched (less redundant; comments aren't in the heatmap at all). Nothing deleted.
- **Recent Activity feed**: **repositioned** from the very bottom of the profile (`bbp_template_after_user_profile`) to directly under the heatmap (`bbp_template_after_user_details` priority 4) so the flow reads chart → recent items. The `bbp_is_single_user_profile()` guard makes the hook move safe (still profile-tab-only, not topics/replies/edit tabs).
- Everything else (About, Artists, Concert History, Music Fan Details, social links, personal bits): **untouched.**

## Resulting profile-tab layout (top → bottom)
1. Header card (avatar, name, rank, social links)
2. **Contribution Heatmap** (NEW — hero)
3. **Recent Activity** feed (moved up — detail under the chart)
4. Concert History card (unchanged)
5. Music Fan Details card (unchanged, if legacy data exists)
6. 2-column grid: About | Community Activity (slimmed) | Artists

## Decisions worth flagging

### Timezone approach
WordPress stores `post_date` in the site's configured timezone — `America/New_York` here (confirmed via `get_option('timezone_string')`). Users perceive "today" in that same zone, so `DATE(post_date)` yields correct local day boundaries with **no off-by-one** at day edges and **no GMT conversion** needed. Both the community and main blogs share the timezone, so the two per-day maps merge on the same basis. The window endpoints are anchored with `wp_timezone()` so "today" is local, not UTC. This matches how the existing display code (e.g. profile join date) already treats stored dates.

### Shade palette
On-brand EC accent ramp rather than GitHub-green: `--accent` (`#53940b`, the EC green) blended over `--card-background` via `color-mix(in srgb, ...)` at 30% / 55% / 78% / 100% for levels 1–4, with `level-0` = `--border-color`. This respects the design system and adapts to dark mode automatically. `color-mix` is supported in all evergreen browsers (Chrome 111+, Safari 16.2+, Firefox 113+, all 2023+); if older-browser support is ever needed, swap to fixed `rgba()` steps as a follow-up.

### Streak semantics
Current streak counts consecutive contributed days ending today, with GitHub's grace rule (if today has no contribution yet, the streak still counts up to the most recent contributed day). Longest streak is the longest run anywhere in the window.

## Verification
- `php -l` clean on all 4 edited/created PHP files.
- No build step (CSS is enqueued raw from `inc/assets/css/user-profile.css` via `inc/core/assets.php`; no JS added; no `src/`/`build/` touched).
- Validated the underlying query shapes against real data: user 1 returns both community (blog 2) topics/replies and main-site (blog 1) posts within the 365-day window; counts are cheap (~1,900 total topics+replies network-wide).
- Empty-grid path confirmed: a brand-new user (zero contributions) yields a valid payload with `max_day_count = 0`, and every cell resolves to `level-0` — the grid renders fully, intentionally.

## Non-goals respected
- No points-per-day / XP coloring (would need a new event-log table — rejected).
- No upvote-per-day squares (no timestamp trail).
- No new DB tables of any kind.
- No wrapping of the points scalar.

\`php -l\` clean. No CHANGELOG edits, no version bumps (homeboy owns both). No merge/release/deploy in this PR.