### PR TITLE
refactor: convert community to points-engine consumer, contribute bbPress sources

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -72,6 +72,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/upvote-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/forum-badges.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/point-calculation.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/points-sources.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/chill-forums-rank.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/rank-abilities.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notification-card.php';

--- a/inc/social/rank-system/point-calculation.php
+++ b/inc/social/rank-system/point-calculation.php
@@ -1,126 +1,29 @@
 <?php
 /**
- * User Rank Point Calculation
+ * Rank Points — community-side display, queue, and leaderboard helpers.
  *
- * Calculates user ranking points from multiple sources with cross-site aggregation.
+ * The points ENGINE (the full compute + cache path) has been PROMOTED to
+ * extrachill-users (inc/rank-system/points-engine.php) as the network-wide
+ * single source of truth — see Extra-Chill/extrachill-users#165. This file now
+ * holds only the community-side concerns:
  *
- * Point Values:
- * - Topics: 2 points (bbp_get_user_topic_count)
- * - Replies: 2 points (bbp_get_user_reply_count)
- * - Upvotes received: 0.5 points per upvote
- * - Main site posts: 10 points each (from main site blog ID)
- * - External sources: additive points via the `ec_rank_extra_points` filter
+ *   - `extrachill_display_user_points()`  — read wrapper with lazy recompute
+ *     (calls the users-owned engine, guarded for graceful degradation)
+ *   - `extrachill_increment_user_points()` — real-time upvote delta on the
+ *     `extrachill_total_points` meta convention
+ *   - `extrachill_queue_points_recalculation()` / process queue — bbPress-
+ *     triggered deferred recompute
+ *   - `extrachill_get_leaderboard_users()` / total — leaderboard user queries
  *
- * Performance:
- * - 1-hour transient caching per user
- * - Cross-site queries use canonical blog ID provider for main site access
- * - Always restores blog context with restore_current_blog()
+ * Community's bbPress point SOURCES are contributed to the engine via
+ * inc/social/rank-system/points-sources.php (hooks `ec_points_sources`).
  *
- * Used by leaderboard page template and user profile display.
+ * Storage conventions (owned by the engine, unchanged):
+ *   - User meta key: `extrachill_total_points`
+ *   - Total transient: `user_points_{id}` (1-hour TTL)
  *
  * @package ExtraChillCommunity
  */
-
-/**
- * Calculate total points for user across multiple point sources with caching
- *
- * Implements 1-hour caching to optimize performance.
- *
- * @param int $user_id WordPress user ID
- * @return float Total calculated points for the user
- */
-function extrachill_get_user_total_points($user_id) {
-	// Check if total points are cached
-	$cached_total_points = get_transient('user_points_' . $user_id);
-	if ( false !== $cached_total_points ) {
-		// Update user meta just in case it was missed, but return cached value
-		update_user_meta($user_id, 'extrachill_total_points', $cached_total_points);
-		return $cached_total_points;
-	}
-
-	// --- Calculate points if not cached ---
-
-	// Get topic count (cached)
-	$topic_count = false; // Initialize
-	$topic_count = get_transient('user_topic_count_' . $user_id);
-	if ( false === $topic_count ) {
-		$topic_count = intval(bbp_get_user_topic_count($user_id) ?? 0);
-		set_transient('user_topic_count_' . $user_id, $topic_count, HOUR_IN_SECONDS); // Cache for 1 hour
-	}
-
-	// Get reply count (cached)
-	$reply_count = false; // Initialize
-	$reply_count = get_transient('user_reply_count_' . $user_id);
-	if ( false === $reply_count ) {
-		$reply_count = intval(bbp_get_user_reply_count($user_id) ?? 0);
-		set_transient('user_reply_count_' . $user_id, $reply_count, HOUR_IN_SECONDS); // Cache for 1 hour
-	}
-
-	$bbpress_points = ( $topic_count + $reply_count ) * 2;
-
-	// Total upvotes received is read from an incrementally-maintained counter
-	// (extrachill_upvotes_received user meta), so this is O(1) after the
-	// one-time lazy backfill. See extrachill_get_user_total_upvotes().
-	$total_upvotes = extrachill_get_user_total_upvotes($user_id) ?? 0;
-	$upvote_points = floatval($total_upvotes) * 0.5;
-
-	// Get main site post count for points calculation
-	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-	if ( $main_blog_id ) {
-		switch_to_blog( $main_blog_id );
-		try {
-			$main_site_post_count = count_user_posts($user_id, 'post', true);
-		} finally {
-			// Always restore blog context, even if count_user_posts() throws,
-			// to avoid leaking the switched context into the rest of the request.
-			restore_current_blog();
-		}
-	} else {
-		$main_site_post_count = 0;
-	}
-	$main_site_post_points = $main_site_post_count * 10;
-
-	/**
-	 * Filter additional rank points contributed by external point sources.
-	 *
-	 * The community rank/points system computes points from a fixed set of
-	 * built-in sources (bbPress activity, upvotes, main-site posts). This filter
-	 * is the extensibility seam that lets any other plugin contribute additional
-	 * points toward a user's total rank without the community plugin needing to
-	 * know about that feature.
-	 *
-	 * Contributions are ADDITIVE: a consumer receives the running extra-points
-	 * value plus the user ID, and returns the running value with its own points
-	 * added. Always return a float.
-	 *
-	 * Example:
-	 *
-	 *     add_filter( 'ec_rank_extra_points', function ( $points, $user_id ) {
-	 *         return $points + ( my_feature_count( $user_id ) * 3 );
-	 *     }, 10, 2 );
-	 *
-	 * Caching note: the TOTAL points value (including this filter's contribution)
-	 * is cached in the `user_points_{id}` transient for one hour. If an external
-	 * source changes its contribution mid-cache, the new value is not reflected
-	 * until the transient expires or is invalidated. This delay is acceptable for
-	 * rank display; sources needing immediacy should bust the transient.
-	 *
-	 * @param float $extra_points Running total of externally contributed points. Default 0.0.
-	 * @param int   $user_id      WordPress user ID the points are being calculated for.
-	 */
-	$extra_points = (float) apply_filters( 'ec_rank_extra_points', 0.0, $user_id );
-
-	// Calculate total points
-	$total_points = $bbpress_points + $upvote_points + $main_site_post_points + $extra_points;
-
-	// Cache the total points in a transient for 1 hour
-	set_transient('user_points_' . $user_id, $total_points, HOUR_IN_SECONDS);
-	// Store the total points as user meta for leaderboard sorting / persistent storage
-	update_user_meta($user_id, 'extrachill_total_points', $total_points);
-
-	return $total_points;
-}
-
 
 /**
  * Queue user for points recalculation after bbPress activity
@@ -218,6 +121,12 @@ add_action('extrachill_hourly_points_recalculation', 'extrachill_process_points_
  * Triggered hourly by WP Cron event 'extrachill_daily_points_recalculation'.
  */
 function extrachill_process_points_recalculation_queue() {
+	// The engine (extrachill_get_user_total_points) lives in extrachill-users.
+	// Guard so the queue no-ops gracefully if that plugin is not loaded.
+	if ( ! function_exists( 'extrachill_get_user_total_points' ) ) {
+		return;
+	}
+
 	$queue = get_option('extrachill_points_recalculation_queue', array());
 
 	foreach ( array_keys($queue) as $user_id ) {
@@ -268,10 +177,17 @@ function extrachill_display_user_points($user_id) {
 	// Retrieve the total points from user meta
 	$total_points = get_user_meta($user_id, 'extrachill_total_points', true);
 
-	// If total points is not set or empty, calculate and update it
+	// If total points is not set or empty, calculate and update it via the
+	// users-owned engine. Guard so the profile renders cleanly (returns 0) if
+	// the engine is not loaded — matches the function_exists() pattern used
+	// for ec_get_last_seen() / ec_get_rank_progress() in bbpress/user-details.php.
 	if ( empty($total_points) ) {
-		$total_points = extrachill_get_user_total_points($user_id);
-		update_user_meta($user_id, 'extrachill_total_points', $total_points);
+		if ( function_exists( 'extrachill_get_user_total_points' ) ) {
+			$total_points = extrachill_get_user_total_points($user_id);
+			update_user_meta($user_id, 'extrachill_total_points', $total_points);
+		} else {
+			$total_points = 0;
+		}
 	}
 
 	return $total_points;

--- a/inc/social/rank-system/points-sources.php
+++ b/inc/social/rank-system/points-sources.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Community → Rank Engine source contributions.
+ *
+ * extrachill-community is now a CONSUMER of the points engine owned by
+ * extrachill-users (inc/rank-system/points-engine.php). This file is where
+ * community registers its bbPress-specific sources with the engine:
+ *
+ *   - SCALAR points (via `ec_points_sources`):
+ *       forum topics   (x2 each)
+ *       forum replies  (x2 each)
+ *       upvotes received (x0.5 each)
+ *
+ *   - DATED events (via `ec_contribution_events`):
+ *       forum topics + replies aggregated by post_date
+ *       (upvotes are EXCLUDED — they are a scalar counter with no per-day
+ *       timestamp trail; see extrachill-community#147 non-goals)
+ *
+ * The sub-source count transients (`user_topic_count_{id}`,
+ * `user_reply_count_{id}`) are preserved here so the cache-busting contract
+ * with inc/core/cache-invalidation.php stays intact.
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// ─── Scalar point sources ────────────────────────────────────────────────────
+
+/**
+ * Contribute bbPress forum engagement points to the rank engine.
+ *
+ * Hooks the engine's `ec_points_sources` filter. Topic and reply counts are
+ * cached in the existing per-user sub-transients so cache-invalidation.php can
+ * continue busting them on bbPress lifecycle events. Upvotes read the
+ * incrementally-maintained `extrachill_upvotes_received` counter.
+ *
+ * @param array $sources Source-id => points map.
+ * @param int   $user_id WordPress user ID.
+ * @return array
+ */
+function extrachill_community_forum_points_sources( $sources, $user_id ) {
+	// Topic count (cached sub-transient, busted by cache-invalidation.php).
+	$topic_count = get_transient( 'user_topic_count_' . $user_id );
+	if ( false === $topic_count ) {
+		$topic_count = intval( bbp_get_user_topic_count( $user_id ) ?? 0 );
+		set_transient( 'user_topic_count_' . $user_id, $topic_count, HOUR_IN_SECONDS );
+	}
+
+	// Reply count (cached sub-transient, busted by cache-invalidation.php).
+	$reply_count = get_transient( 'user_reply_count_' . $user_id );
+	if ( false === $reply_count ) {
+		$reply_count = intval( bbp_get_user_reply_count( $user_id ) ?? 0 );
+		set_transient( 'user_reply_count_' . $user_id, $reply_count, HOUR_IN_SECONDS );
+	}
+
+	$sources['forum_topics']  = (float) ( $topic_count * 2 );
+	$sources['forum_replies'] = (float) ( $reply_count * 2 );
+
+	if ( function_exists( 'extrachill_get_user_total_upvotes' ) ) {
+		$sources['forum_upvotes'] = floatval( extrachill_get_user_total_upvotes( $user_id ) ) * 0.5;
+	}
+
+	return $sources;
+}
+add_filter( 'ec_points_sources', 'extrachill_community_forum_points_sources', 10, 2 );
+
+// ─── Dated contribution events ───────────────────────────────────────────────
+
+/**
+ * Contribute dated forum activity events to the contribution seam.
+ *
+ * Aggregates the user's published topics + replies by post_date (site-local
+ * calendar day) on the community blog. Upvotes are excluded — they have no
+ * per-day timestamp trail (see extrachill-community#147).
+ *
+ * This contributor runs in the community blog context (community is active on
+ * community.extrachill.com where bbPress content lives), so $wpdb->posts is the
+ * community blog's posts table. No switch_to_blog needed.
+ *
+ * @param array  $events    Running event list.
+ * @param int    $user_id   WordPress user ID.
+ * @param string $since_ymd Inclusive start date (YYYY-MM-DD), or '' for all.
+ * @return array
+ */
+function extrachill_community_forum_contribution_events( $events, $user_id, $since_ymd ) {
+	global $wpdb;
+
+	$topic_type = bbp_get_topic_post_type();
+	$reply_type = bbp_get_reply_post_type();
+
+	// bbPress post-type slugs are sanitize_key'd; safe for a direct IN list.
+	$types_csv = "'" . implode( "','", array_map( 'esc_sql', array( $topic_type, $reply_type ) ) ) . "'";
+
+	if ( '' !== $since_ymd ) {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $types_csv is esc_sql'd from trusted bbPress post-type slugs.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DATE(post_date) AS d, COUNT(*) AS c
+				 FROM {$wpdb->posts}
+				 WHERE post_author = %d AND post_type IN ({$types_csv})
+				   AND post_status = 'publish' AND DATE(post_date) >= %s
+				 GROUP BY d",
+				$user_id,
+				$since_ymd
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	} else {
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $types_csv is esc_sql'd from trusted bbPress post-type slugs.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DATE(post_date) AS d, COUNT(*) AS c
+				 FROM {$wpdb->posts}
+				 WHERE post_author = %d AND post_type IN ({$types_csv})
+				   AND post_status = 'publish'
+				 GROUP BY d",
+				$user_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	if ( is_array( $rows ) ) {
+		foreach ( $rows as $row ) {
+			$events[] = array(
+				'date'  => (string) $row['d'],
+				'type'  => 'forum',
+				'count' => (int) $row['c'],
+			);
+		}
+	}
+
+	return $events;
+}
+add_filter( 'ec_contribution_events', 'extrachill_community_forum_contribution_events', 10, 3 );

--- a/inc/social/rank-system/points-sources.php
+++ b/inc/social/rank-system/points-sources.php
@@ -72,13 +72,19 @@ add_filter( 'ec_points_sources', 'extrachill_community_forum_points_sources', 10
 /**
  * Contribute dated forum activity events to the contribution seam.
  *
- * Aggregates the user's published topics + replies by post_date (site-local
- * calendar day) on the community blog. Upvotes are excluded — they have no
- * per-day timestamp trail (see extrachill-community#147).
+ * SELECTs the UTC-authoritative `post_date_gmt` column for the user's published
+ * topics + replies, then delegates day computation to the shared
+ * ec_bucket_utc_events_by_local_day() helper in extrachill-users. Upvotes are
+ * excluded — they have no per-day timestamp trail (see
+ * extrachill-community#147).
  *
  * This contributor runs in the community blog context (community is active on
  * community.extrachill.com where bbPress content lives), so $wpdb->posts is the
  * community blog's posts table. No switch_to_blog needed.
+ *
+ * The helper lives in extrachill-users; if that plugin is not loaded, this
+ * contributor returns $events unchanged (graceful-guard pattern, consistent
+ * with the engine-call guards elsewhere).
  *
  * @param array  $events    Running event list.
  * @param int    $user_id   WordPress user ID.
@@ -86,6 +92,12 @@ add_filter( 'ec_points_sources', 'extrachill_community_forum_points_sources', 10
  * @return array
  */
 function extrachill_community_forum_contribution_events( $events, $user_id, $since_ymd ) {
+	// The shared day-bucketing helper lives in extrachill-users. Guard so the
+	// contributor no-ops gracefully if the engine is not loaded.
+	if ( ! function_exists( 'ec_bucket_utc_events_by_local_day' ) ) {
+		return $events;
+	}
+
 	global $wpdb;
 
 	$topic_type = bbp_get_topic_post_type();
@@ -94,47 +106,27 @@ function extrachill_community_forum_contribution_events( $events, $user_id, $sin
 	// bbPress post-type slugs are sanitize_key'd; safe for a direct IN list.
 	$types_csv = "'" . implode( "','", array_map( 'esc_sql', array( $topic_type, $reply_type ) ) ) . "'";
 
-	if ( '' !== $since_ymd ) {
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $types_csv is esc_sql'd from trusted bbPress post-type slugs.
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT DATE(post_date) AS d, COUNT(*) AS c
-				 FROM {$wpdb->posts}
-				 WHERE post_author = %d AND post_type IN ({$types_csv})
-				   AND post_status = 'publish' AND DATE(post_date) >= %s
-				 GROUP BY d",
-				$user_id,
-				$since_ymd
-			),
-			ARRAY_A
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	} else {
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $types_csv is esc_sql'd from trusted bbPress post-type slugs.
-		$rows = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT DATE(post_date) AS d, COUNT(*) AS c
-				 FROM {$wpdb->posts}
-				 WHERE post_author = %d AND post_type IN ({$types_csv})
-				   AND post_status = 'publish'
-				 GROUP BY d",
-				$user_id
-			),
-			ARRAY_A
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// SELECT the UTC-authoritative column; day computation is centralized in
+	// ec_bucket_utc_events_by_local_day().
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $types_csv is esc_sql'd from trusted bbPress post-type slugs.
+	$utc_timestamps = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT post_date_gmt
+			 FROM {$wpdb->posts}
+			 WHERE post_author = %d AND post_type IN ({$types_csv})
+			   AND post_status = 'publish'",
+			$user_id
+		)
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+	if ( ! is_array( $utc_timestamps ) || empty( $utc_timestamps ) ) {
+		return $events;
 	}
 
-	if ( is_array( $rows ) ) {
-		foreach ( $rows as $row ) {
-			$events[] = array(
-				'date'  => (string) $row['d'],
-				'type'  => 'forum',
-				'count' => (int) $row['c'],
-			);
-		}
-	}
-
-	return $events;
+	return array_merge(
+		$events,
+		ec_bucket_utc_events_by_local_day( $utc_timestamps, 'forum', $since_ymd )
+	);
 }
 add_filter( 'ec_contribution_events', 'extrachill_community_forum_contribution_events', 10, 3 );


### PR DESCRIPTION
## Summary

extrachill-community is now a **CONSUMER** of the points engine owned by **extrachill-users** ([Extra-Chill/extrachill-users#166](https://github.com/Extra-Chill/extrachill-users/pull/166)). The full compute path has been promoted out; community keeps display, leaderboard queries, upvote logic, and the bbPress-triggered recalc queue.

**Coordinated two-repo change.** The companion users PR is [Extra-Chill/extrachill-users#166](https://github.com/Extra-Chill/extrachill-users/pull/166). Both deploy together on community.extrachill.com — merge them together.

Reference: [Extra-Chill/extrachill-users#165](https://github.com/Extra-Chill/extrachill-users/issues/165)

## What moved out
- **`extrachill_get_user_total_points()`** (the full compute + cache engine) → now lives in `extrachill-users/inc/rank-system/points-engine.php`. Community's copy has been **deleted** (no dead duplicate left behind, per site RULES).

## What stayed in community
- `extrachill_display_user_points()` — read wrapper with lazy recompute (calls the users-owned engine, guarded by `function_exists`)
- `extrachill_display_user_rank()` / `extrachill_determine_rank_by_points()` — display
- `extrachill_get_leaderboard_users()` / `extrachill_get_leaderboard_total_users()` — leaderboard queries
- `extrachill_increment_user_points()` — real-time upvote delta
- `extrachill_get_user_total_upvotes()` + `upvote.php` — upvote counter (bbPress-specific)
- Rank abilities, cache invalidation, spam adjustments — all unchanged

## What's new
**`inc/social/rank-system/points-sources.php`** — community's bbPress source contributions to the engine:

**Scalar points** (hooks `ec_points_sources`):
| Source id | Points | Notes |
|-----------|--------|-------|
| `forum_topics` | topic count × 2 | cached in `user_topic_count_{id}` sub-transient |
| `forum_replies` | reply count × 2 | cached in `user_reply_count_{id}` sub-transient |
| `forum_upvotes` | upvotes × 0.5 | reads `extrachill_upvotes_received` counter |

**Dated events** (hooks `ec_contribution_events`):
- Forum topics + replies aggregated by `DATE(post_date)` per day → foundation for heatmap (#147)
- **Upvotes excluded** from the dated seam — scalar counter, no per-day timestamp trail

## Graceful degradation
Community does not declare a hard dependency on users. All engine calls are guarded with `function_exists('extrachill_get_user_total_points')`, matching the existing guard pattern for `ec_get_last_seen()` / `ec_get_rank_progress()` in `bbpress/user-details.php`. If the engine isn't loaded yet, points display falls back to stored meta (or 0), and the recalc queue no-ops.

## Cache contract preserved
The sub-source count transients (`user_topic_count_{id}`, `user_reply_count_{id}`) are still written by the new contributor and still busted by `inc/core/cache-invalidation.php` on bbPress lifecycle events. The `user_points_{id}` total transient is owned by the engine and busted by the same cache-invalidation path.

## Timezone handling (v2) — single-helper contract
The forum dated contributor now SELECTs the **UTC-authoritative** `post_date_gmt` column (not the drift-prone local `post_date`) and delegates day computation to `ec_bucket_utc_events_by_local_day()` — the one shared helper in extrachill-users. All three dated sources (forum, main-posts, concert) now route through the same UTC→site-local-day conversion, making day boundaries provably consistent. Guarded with `function_exists('ec_bucket_utc_events_by_local_day')` — if the users engine isn't loaded, the contributor returns `$events` unchanged (graceful-guard pattern).

## Verification
- [x] `php -l` clean on every edited/created file
- [x] Engine definition deleted from community (grep confirmed: `function extrachill_get_user_total_points` not found)
- [x] All callers resolve their functions (display in community, engine in users)
- [x] Point totals mathematically identical before/after
- [x] No new DB tables; no changed weights

## Do NOT merge without the companion users PR
[Extra-Chill/extrachill-users#166](https://github.com/Extra-Chill/extrachill-users/pull/166) must merge together with this PR.
