### PR TITLE
feat: GitHub-style contribution heatmap on user profiles

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -75,11 +75,13 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/points-sources.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/chill-forums-rank.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/rank-abilities.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/social/rank-system/contribution-calendar-ability.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notification-card.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-replies.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-mentions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
+	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/contribution-heatmap.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/concert-history.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/custom-user-profile.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/profile-activity-feed.php';

--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -361,13 +361,14 @@
     width: 100%;
 }
 
-/* Concert History + legacy Music Fan cards render via the
-   bbp_template_after_user_details hook (see user-details.php), which places
+/* Concert History, Contribution heatmap, and legacy Music Fan cards render via
+   the bbp_template_after_user_details hook (see user-details.php), which places
    them outside .bbp-user-profile-cards-container — directly under the header
    card, not inside the 2-column flex grid. Keep them full-width so the desktop
    half-width card rule above doesn't shrink them. */
 .bbp-user-profile-card.ec-concert-history-card,
-.bbp-user-profile-card.ec-music-fan-details-card {
+.bbp-user-profile-card.ec-music-fan-details-card,
+.bbp-user-profile-card.ec-contribution-heatmap-card {
     width: 100%;
 }
 
@@ -456,4 +457,166 @@
 
 .ec-music-fan-details-card .ec-music-fan-nudge em {
 	opacity: 0.7;
+}
+
+/* ==================================================
+   Contribution Activity heatmap (GitHub-style grid)
+   ================================================== */
+
+.ec-contribution-heatmap-card {
+	--ec-heat-cell: 11px;       /* square size */
+	--ec-heat-gap: 3px;         /* space between squares */
+	--ec-heat-weekday-col: 1.6rem;
+}
+
+.ec-heatmap-summary {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 0.5rem 1rem;
+	margin-bottom: 0.75rem;
+	font-size: var(--font-size-sm);
+}
+
+.ec-heatmap-summary .ec-heatmap-total strong {
+	font-size: var(--font-size-base);
+}
+
+.ec-heatmap-streaks {
+	color: var(--muted-text);
+}
+
+.ec-heatmap-streak-sep {
+	margin: 0 0.35rem;
+	opacity: 0.6;
+}
+
+/* Horizontal scroll on narrow viewports so the 53-week grid never overflows
+   the profile column. Touch users swipe; the fade is a subtle affordance. */
+.ec-heatmap-scroll {
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	padding-bottom: 2px;
+}
+
+.ec-heatmap {
+	display: grid;
+	/* [weekday-col] [graph]  ×  [months-row] [graph-row] */
+	grid-template-columns: var(--ec-heat-weekday-col) max-content;
+	grid-template-rows: 1rem auto;
+	column-gap: var(--ec-heat-gap);
+	row-gap: var(--ec-heat-gap);
+	width: max-content;
+}
+
+.ec-heatmap-corner {
+	/* top-left empty cell (row1/col1) — corners the layout. */
+	grid-row: 1;
+	grid-column: 1;
+}
+
+.ec-heatmap-months {
+	grid-row: 1;
+	grid-column: 2;
+	display: grid;
+	/* column count is set inline (weeks) so it tracks the data exactly. */
+	gap: var(--ec-heat-gap);
+	font-size: var(--font-size-xs);
+	color: var(--muted-text);
+	line-height: 1rem;
+}
+
+.ec-heat-month.is-empty {
+	visibility: hidden;
+}
+
+.ec-heatmap-weekdays {
+	grid-row: 2;
+	grid-column: 1;
+	display: grid;
+	grid-template-rows: repeat(7, var(--ec-heat-cell));
+	gap: var(--ec-heat-gap);
+	font-size: var(--font-size-xs);
+	color: var(--muted-text);
+}
+
+.ec-heat-weekday {
+	display: block;
+	line-height: var(--ec-heat-cell);
+	white-space: nowrap;
+}
+
+.ec-heat-weekday.is-empty {
+	visibility: hidden;
+}
+
+/* The graph itself. grid-auto-flow:column fills each week top-to-bottom (Sun→Sat)
+   before advancing, so cells can be emitted in column-major order. */
+.ec-heatmap-cells {
+	grid-row: 2;
+	grid-column: 2;
+	display: grid;
+	grid-template-rows: repeat(7, var(--ec-heat-cell));
+	grid-auto-flow: column;
+	grid-auto-columns: var(--ec-heat-cell);
+	gap: var(--ec-heat-gap);
+}
+
+.ec-heat-cell {
+	width: var(--ec-heat-cell);
+	height: var(--ec-heat-cell);
+	border-radius: 2px;
+	display: inline-block;
+	background-color: var(--ec-heat-empty, #ebedf0);
+}
+
+/* Shade ramp: built from --accent (green) via color-mix over the card
+   background, so it respects the EC palette AND flips correctly in dark mode.
+   level-0 = empty day; 1→4 = increasing intensity relative to the busiest day. */
+.ec-heat-cell.level-0 {
+	background-color: color-mix(in srgb, var(--border-color) 55%, var(--card-background));
+}
+.ec-heat-cell.level-1 {
+	background-color: color-mix(in srgb, var(--accent) 28%, var(--card-background));
+}
+.ec-heat-cell.level-2 {
+	background-color: color-mix(in srgb, var(--accent) 50%, var(--card-background));
+}
+.ec-heat-cell.level-3 {
+	background-color: color-mix(in srgb, var(--accent) 72%, var(--card-background));
+}
+.ec-heat-cell.level-4 {
+	background-color: var(--accent);
+}
+
+/* Legend */
+.ec-heatmap-legend {
+	display: flex;
+	align-items: center;
+	gap: var(--ec-heat-gap);
+	margin-top: 0.6rem;
+	justify-content: flex-end;
+	font-size: var(--font-size-xs);
+	color: var(--muted-text);
+}
+
+.ec-heatmap-legend .ec-heat-cell {
+	border-radius: 2px;
+}
+
+/* Slightly larger squares on roomier screens for readability. */
+@media (min-width: 900px) {
+	.ec-contribution-heatmap-card {
+		--ec-heat-cell: 12px;
+	}
+}
+
+/* On very narrow screens, shrink squares so more of the year is visible
+   without scrolling, but keep it scrollable as a fallback. */
+@media (max-width: 480px) {
+	.ec-contribution-heatmap-card {
+		--ec-heat-cell: 9px;
+		--ec-heat-gap: 2px;
+		--ec-heat-weekday-col: 1.3rem;
+	}
 }

--- a/inc/core/cache-invalidation.php
+++ b/inc/core/cache-invalidation.php
@@ -119,6 +119,9 @@ function extrachill_clear_user_points_cache($user_ids) {
 		delete_transient('user_topic_count_' . $user_id);
 		delete_transient('user_reply_count_' . $user_id);
 		delete_transient('user_points_' . $user_id);
+		// Bust the contribution-calendar cache so the heatmap + streaks stay
+		// fresh on new forum activity (see contribution-calendar-ability.php).
+		delete_transient('ec_contrib_calendar_' . $user_id);
 	}
 
 	extrachill_queue_user_points_recalculation($user_ids);

--- a/inc/social/rank-system/contribution-calendar-ability.php
+++ b/inc/social/rank-system/contribution-calendar-ability.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Contribution Calendar Ability
+ *
+ * Ability-first data layer for the GitHub-style contribution heatmap
+ * (extrachill-community#147). Assembles a per-day contribution calendar by
+ * CONSUMING the dated-contributions seam owned by extrachill-users
+ * (`ec_get_contribution_events`). Community owns the calendar assembly +
+ * rendering; users owns the underlying dated data.
+ *
+ * This file does NOT re-query posts or re-aggregate cross-site data. It calls
+ * the seam, which already merges forum topics+replies, main-site posts, and
+ * concert check-ins (each source hooks `ec_contribution_events`), and central
+ * timezone conversion is handled in `ec_bucket_utc_events_by_local_day()`.
+ *
+ * Output payload (returned by the ability and consumed by the profile card):
+ *   - user_id, days, weeks (column count)
+ *   - first_sunday / window_start / window_end (site-local Y-m-d)
+ *   - total_contributions, max_day_count (for shade scaling)
+ *   - current_streak, longest_streak (consecutive-day runs)
+ *   - counts: sparse map { 'YYYY-MM-DD': int } of days with >=1 contribution
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Cache TTL for the per-user contribution calendar (seconds).
+ *
+ * Busts on bbPress lifecycle events via extrachill_clear_user_points_cache().
+ */
+const EC_CONTRIB_CALENDAR_CACHE_TTL = HOUR_IN_SECONDS;
+
+/**
+ * Assemble a user's contribution calendar over the trailing window.
+ *
+ * Calls the users-owned dated-contributions seam and projects the result onto
+ * a GitHub-style 53-week grid (weeks × 7 days, aligned to Sunday). The grid
+ * always ends on the current site-local day; `weeks` is derived from `$days`
+ * and capped at one year (53 columns) so the layout matches GitHub exactly.
+ *
+ * Sparse counts: only days with >=1 contribution appear in `counts`; every
+ * other day in the grid range is implicitly zero. Consumers fill the gaps.
+ *
+ * Graceful degradation: if the seam function (`ec_get_contribution_events`)
+ * is absent — e.g. extrachill-users is not yet deployed with #166 — the
+ * calendar resolves to an all-zero grid with zero totals, never a fatal.
+ *
+ * @param int $user_id WordPress user ID.
+ * @param int $days    Window length in days (default 365). Non-default windows
+ *                     bypass the cache (the card always uses the default).
+ * @return array Calendar payload.
+ */
+function extrachill_community_get_contribution_calendar( $user_id, $days = 365 ) {
+	$user_id = (int) $user_id;
+	$days    = max( 1, (int) $days );
+
+	// Grid columns: full weeks needed to cover the window, capped at one year.
+	$weeks = (int) ceil( $days / 7 );
+	if ( $weeks > 53 ) {
+		$weeks = 53;
+	}
+	if ( $weeks < 1 ) {
+		$weeks = 1;
+	}
+
+	// Only the canonical one-year window is cached; custom windows compute live
+	// so a transient keyed by user_id can never serve a stale window size.
+	$use_cache = ( 365 === $days );
+	$cache_key = 'ec_contrib_calendar_' . $user_id;
+
+	if ( $use_cache ) {
+		$cached = get_transient( $cache_key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+	}
+
+	try {
+		$today = current_datetime(); // DateTimeImmutable in site timezone.
+	} catch ( Exception $e ) {
+		$today = new DateTimeImmutable( 'now', wp_timezone() );
+	}
+
+	$dow          = (int) $today->format( 'w' ); // 0 = Sunday … 6 = Saturday.
+	$last_sunday  = $today->modify( '-' . $dow . ' days' );
+	$first_sunday = $last_sunday->modify( '-' . ( ( $weeks - 1 ) * 7 ) . ' days' );
+
+	$window_start = $first_sunday->format( 'Y-m-d' );
+	$window_end   = $today->format( 'Y-m-d' );
+
+	// Consume the dated-contributions seam. The seam merges every registered
+	// source (forum, main posts, concerts) and converts UTC → site-local day.
+	$counts = array();
+	if ( function_exists( 'ec_get_contribution_events' ) ) {
+		$events = ec_get_contribution_events( $user_id, $window_start );
+		if ( is_array( $events ) ) {
+			foreach ( $events as $event ) {
+				if ( ! is_array( $event ) ) {
+					continue;
+				}
+				$date  = isset( $event['date'] ) ? (string) $event['date'] : '';
+				$count = isset( $event['count'] ) ? (int) $event['count'] : 0;
+				if ( '' === $date || $count < 1 ) {
+					continue;
+				}
+				// Guard the upper bound (no future days) even though sources
+				// should not emit any.
+				if ( $date > $window_end ) {
+					continue;
+				}
+				$counts[ $date ] = ( $counts[ $date ] ?? 0 ) + $count;
+			}
+		}
+	}
+
+	ksort( $counts );
+
+	$total        = array_sum( $counts );
+	$max_day_count = $counts ? (int) max( $counts ) : 0;
+
+	$current_streak = extrachill_community_count_current_streak( $counts, $today );
+	$longest_streak = extrachill_community_count_longest_streak( $counts, $first_sunday, $today );
+
+	$payload = array(
+		'user_id'             => $user_id,
+		'days'                => $days,
+		'weeks'               => $weeks,
+		'first_sunday'        => $window_start,
+		'window_start'        => $window_start,
+		'window_end'          => $window_end,
+		'total_contributions' => (int) $total,
+		'max_day_count'       => $max_day_count,
+		'current_streak'      => $current_streak,
+		'longest_streak'      => $longest_streak,
+		'counts'              => $counts,
+	);
+
+	if ( $use_cache ) {
+		set_transient( $cache_key, $payload, EC_CONTRIB_CALENDAR_CACHE_TTL );
+	}
+
+	return $payload;
+}
+
+/**
+ * Current streak: consecutive days with >=1 contribution, counting back from
+ * today. If today has no contributions the streak is 0 (matches GitHub).
+ *
+ * @param array             $counts Sparse day => count map.
+ * @param DateTimeImmutable $today  Current site-local day.
+ * @return int
+ */
+function extrachill_community_count_current_streak( array $counts, $today ) {
+	$streak = 0;
+	$cursor = $today;
+	while ( isset( $counts[ $cursor->format( 'Y-m-d' ) ] ) && $counts[ $cursor->format( 'Y-m-d' ) ] >= 1 ) {
+		++$streak;
+		$cursor = $cursor->modify( '-1 day' );
+	}
+	return $streak;
+}
+
+/**
+ * Longest streak: the longest run of consecutive days with >=1 contribution
+ * anywhere in the grid window.
+ *
+ * @param array             $counts       Sparse day => count map.
+ * @param DateTimeImmutable $first_sunday Grid start date.
+ * @param DateTimeImmutable $today        Grid end date (today).
+ * @return int
+ */
+function extrachill_community_count_longest_streak( array $counts, $first_sunday, $today ) {
+	$longest = 0;
+	$run     = 0;
+	$cursor  = $first_sunday;
+
+	while ( $cursor <= $today ) {
+		$ymd = $cursor->format( 'Y-m-d' );
+		if ( isset( $counts[ $ymd ] ) && $counts[ $ymd ] >= 1 ) {
+			++$run;
+			if ( $run > $longest ) {
+				$longest = $run;
+			}
+		} else {
+			$run = 0;
+		}
+		$cursor = $cursor->modify( '+1 day' );
+	}
+
+	return $longest;
+}
+
+// ─── Ability registration ────────────────────────────────────────────────────
+
+add_action( 'wp_abilities_api_init', 'extrachill_community_register_contribution_calendar_ability' );
+
+/**
+ * Register the contribution-calendar ability.
+ *
+ * Public + read-only: contribution counts are engagement signals shown on the
+ * public profile, so no auth gate (mirrors extrachill/community-get-user-points).
+ */
+function extrachill_community_register_contribution_calendar_ability() {
+	wp_register_ability(
+		'extrachill/get-user-contribution-calendar',
+		array(
+			'label'               => __( 'Get User Contribution Calendar', 'extra-chill-community' ),
+			'description'         => __( 'Get a user\'s per-day contribution counts over the trailing year, with totals and streaks (powers the profile heatmap).', 'extra-chill-community' ),
+			'category'            => 'extrachill-community',
+			'input_schema'        => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'User ID (required)', 'extra-chill-community' ),
+					),
+					'days'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Window length in days (default 365).', 'extra-chill-community' ),
+					),
+				),
+				'required'   => array( 'user_id' ),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'user_id'             => array( 'type' => 'integer' ),
+					'days'                => array( 'type' => 'integer' ),
+					'weeks'               => array( 'type' => 'integer' ),
+					'first_sunday'        => array( 'type' => 'string' ),
+					'window_start'        => array( 'type' => 'string' ),
+					'window_end'          => array( 'type' => 'string' ),
+					'total_contributions' => array( 'type' => 'integer' ),
+					'max_day_count'       => array( 'type' => 'integer' ),
+					'current_streak'      => array( 'type' => 'integer' ),
+					'longest_streak'      => array( 'type' => 'integer' ),
+					'counts'              => array(
+						'type'                 => 'object',
+						'additionalProperties' => array( 'type' => 'integer' ),
+					),
+				),
+			),
+			'execute_callback'    => 'extrachill_community_ability_get_contribution_calendar',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Ability execute callback: resolve inputs and delegate to the builder.
+ *
+ * Degrades to an empty calendar when the dated-contributions seam is absent
+ * (no fatal), so the ability remains safe to call before extrachill-users #166
+ * is deployed.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_community_ability_get_contribution_calendar( $input ) {
+	$user_id = isset( $input['user_id'] ) ? (int) $input['user_id'] : 0;
+	if ( ! $user_id ) {
+		return new WP_Error( 'missing_user', __( 'A user_id is required.', 'extra-chill-community' ) );
+	}
+
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return new WP_Error( 'user_not_found', __( 'User not found.', 'extra-chill-community' ) );
+	}
+
+	$days = isset( $input['days'] ) ? (int) $input['days'] : 365;
+
+	return extrachill_community_get_contribution_calendar( $user_id, $days );
+}

--- a/inc/user-profiles/contribution-heatmap.php
+++ b/inc/user-profiles/contribution-heatmap.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Contribution Heatmap Profile Card
+ *
+ * Renders a GitHub-style contribution heatmap on the bbPress user profile — a
+ * 53-week × 7-day grid of intensity-shaded squares, one per day, over the
+ * trailing year. It is the profile's primary at-a-glance engagement surface
+ * and a stickiness driver (people come back to watch their streak grow).
+ *
+ * This is a CONSUMER of the `extrachill/get-user-contribution-calendar`
+ * ability (inc/social/rank-system/contribution-calendar-ability.php), which in
+ * turn consumes the users-owned dated-contributions seam. This file does NO
+ * cross-site aggregation of its own — it only projects the assembled calendar
+ * onto a CSS grid.
+ *
+ * Placement: full-width card rendered via `bbp_template_after_user_details`
+ * at priority 1, directly under the header card and ABOVE the 2-column
+ * `.bbp-user-profile-cards-container` grid (same outside-the-grid placement
+ * pattern as Concert History at priority 5). The Recent Activity feed
+ * (priority 3) sits between them as the chart's detail view.
+ *
+ * Empty grid on a brand-new user is expected and rendered as-is — the "dead
+ * chart" invites the owner to fill it in. If the contribution seam is not yet
+ * deployed (extrachill-users #166 absent), the card degrades by not rendering
+ * at all rather than showing a chart that can never populate.
+ *
+ * @package ExtraChillCommunity
+ * @since 0.x
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Map a day's contribution count to a 0–4 shade level.
+ *
+ * GitHub-style: level-0 = no contributions, 1–4 are relative to the window's
+ * busiest day. When the whole window is empty, everything stays level-0.
+ *
+ * @param int $count        Contributions on the day.
+ * @param int $max_day_count The window's busiest day (0 when empty).
+ * @return int Level 0..4.
+ */
+function ec_community_heatmap_level( $count, $max_day_count ) {
+	$count = (int) $count;
+	if ( $count < 1 ) {
+		return 0;
+	}
+	$max = (int) $max_day_count;
+	if ( $max < 1 ) {
+		return 0;
+	}
+	$ratio = $count / $max;
+	if ( $ratio <= 0.25 ) {
+		return 1;
+	}
+	if ( $ratio <= 0.50 ) {
+		return 2;
+	}
+	if ( $ratio <= 0.75 ) {
+		return 3;
+	}
+	return 4;
+}
+
+/**
+ * Display the Contribution Activity heatmap on the bbPress user profile.
+ *
+ * Pulls the assembled calendar from the contribution-calendar ability builder
+ * and renders the grid + summary + legend. Renders on the profile overview
+ * tab only (bbp_is_single_user_profile), where the card grid lives.
+ */
+function ec_community_display_contribution_heatmap() {
+	// Only on the profile overview tab — the heatmap is a profile-body element,
+	// not a header chrome element repeated across the Topics/Replies/Edit tabs.
+	if ( function_exists( 'bbp_is_single_user_profile' ) && ! bbp_is_single_user_profile() ) {
+		return;
+	}
+
+	$user_id = bbp_get_displayed_user_id();
+	if ( ! $user_id ) {
+		return;
+	}
+
+	// The dated-contributions seam is owned by extrachill-users. If it is not
+	// loaded yet, skip the card entirely (graceful — no fatal, no dead chart).
+	if ( ! function_exists( 'ec_get_contribution_events' ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'extrachill_community_get_contribution_calendar' ) ) {
+		return;
+	}
+
+	$calendar = extrachill_community_get_contribution_calendar( (int) $user_id );
+	if ( ! is_array( $calendar ) ) {
+		return;
+	}
+
+	$weeks        = isset( $calendar['weeks'] ) ? (int) $calendar['weeks'] : 53;
+	$counts       = isset( $calendar['counts'] ) && is_array( $calendar['counts'] ) ? $calendar['counts'] : array();
+	$max_day      = isset( $calendar['max_day_count'] ) ? (int) $calendar['max_day_count'] : 0;
+	$total        = isset( $calendar['total_contributions'] ) ? (int) $calendar['total_contributions'] : 0;
+	$current      = isset( $calendar['current_streak'] ) ? (int) $calendar['current_streak'] : 0;
+	$longest      = isset( $calendar['longest_streak'] ) ? (int) $calendar['longest_streak'] : 0;
+	$first_ymd    = isset( $calendar['first_sunday'] ) ? (string) $calendar['first_sunday'] : '';
+
+	try {
+		$first_sunday = new DateTimeImmutable( $first_ymd, wp_timezone() );
+	} catch ( Exception $e ) {
+		return;
+	}
+
+	try {
+		$today = current_datetime();
+	} catch ( Exception $e ) {
+		$today = new DateTimeImmutable( 'now', wp_timezone() );
+	}
+
+	$is_own    = ( (int) get_current_user_id() === (int) $user_id );
+	$heading   = $is_own
+		? __( 'My Contribution Activity', 'extra-chill-community' )
+		: __( 'Contribution Activity', 'extra-chill-community' );
+
+	// Weekday labels down the left edge (GitHub shows Mon / Wed / Fri).
+	global $wp_locale;
+	$weekday_labels = array( '', '', '', '', '', '', '' );
+	if ( $wp_locale instanceof WP_Locale ) {
+		$weekday_labels[1] = $wp_locale->get_weekday_abbrev( $wp_locale->get_weekday( 1 ) ); // Mon.
+		$weekday_labels[3] = $wp_locale->get_weekday_abbrev( $wp_locale->get_weekday( 3 ) ); // Wed.
+		$weekday_labels[5] = $wp_locale->get_weekday_abbrev( $wp_locale->get_weekday( 5 ) ); // Fri.
+	}
+
+	$date_format = get_option( 'date_format' );
+	?>
+
+	<div class="bbp-user-profile-card ec-contribution-heatmap-card">
+		<h3><?php echo esc_html( $heading ); ?></h3>
+
+		<div class="ec-heatmap-summary">
+			<span class="ec-heatmap-total">
+				<strong><?php echo esc_html( number_format_i18n( $total ) ); ?></strong>
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: localized description of the window. */
+						_n( 'contribution in the last year', 'contributions in the last year', $total, 'extra-chill-community' ),
+						''
+					)
+				);
+				?>
+			</span>
+			<span class="ec-heatmap-streaks">
+				<?php
+				printf(
+					/* translators: %d: day count. */
+					esc_html__( 'Current streak: %d days', 'extra-chill-community' ),
+					(int) $current
+				);
+				?>
+				<span class="ec-heatmap-streak-sep" aria-hidden="true">·</span>
+				<?php
+				printf(
+					/* translators: %d: day count. */
+					esc_html__( 'Longest: %d days', 'extra-chill-community' ),
+					(int) $longest
+				);
+				?>
+			</span>
+		</div>
+
+		<div class="ec-heatmap-scroll">
+			<div class="ec-heatmap" role="img" aria-label="<?php echo esc_attr( sprintf( __( '%d contributions in the last year', 'extra-chill-community' ), $total ) ); ?>">
+				<div class="ec-heatmap-corner" aria-hidden="true"></div>
+
+				<div class="ec-heatmap-months" style="--ec-heat-weeks:<?php echo (int) $weeks; ?>;grid-template-columns:repeat(<?php echo (int) $weeks; ?>,var(--ec-heat-cell));">
+					<?php
+					$prev_month = '';
+					for ( $col = 0; $col < $weeks; $col++ ) {
+						$sunday = $first_sunday->modify( ( $col * 7 ) . ' days' );
+						$month  = (int) $sunday->format( 'n' );
+						$label  = '';
+						if ( $month !== $prev_month && $wp_locale instanceof WP_Locale ) {
+							$label = $wp_locale->get_month_abbrev( $wp_locale->get_month( $month ) );
+						}
+						$prev_month = $month;
+						?>
+						<span class="ec-heat-month<?php echo '' === $label ? ' is-empty' : ''; ?>"><?php echo esc_html( $label ); ?></span>
+						<?php
+					}
+					?>
+				</div>
+
+				<div class="ec-heatmap-weekdays" aria-hidden="true">
+					<?php foreach ( $weekday_labels as $label ) : ?>
+						<span class="ec-heat-weekday<?php echo '' === $label ? ' is-empty' : ''; ?>"><?php echo esc_html( $label ); ?></span>
+					<?php endforeach; ?>
+				</div>
+
+				<div class="ec-heatmap-cells">
+					<?php
+					for ( $col = 0; $col < $weeks; $col++ ) {
+						for ( $dow = 0; $dow < 7; $dow++ ) {
+							$date = $first_sunday->modify( ( $col * 7 + $dow ) . ' days' );
+
+							// Days after today are in the future — stop emitting
+							// (grid-auto-flow:column leaves the last column partial,
+							// exactly like GitHub's trailing week).
+							if ( $date > $today ) {
+								break 2;
+							}
+
+							$ymd   = $date->format( 'Y-m-d' );
+							$count = isset( $counts[ $ymd ] ) ? (int) $counts[ $ymd ] : 0;
+							$level = ec_community_heatmap_level( $count, $max_day );
+							$ts    = $date->getTimestamp();
+							$label = $count > 0
+								? sprintf(
+									/* translators: 1: contribution count, 2: localized date. */
+									_n( '%1$d contribution on %2$s', '%1$d contributions on %2$s', $count, 'extra-chill-community' ),
+									$count,
+									wp_date( $date_format, $ts )
+								)
+								: sprintf(
+									/* translators: %s: localized date. */
+									__( 'No contributions on %s', 'extra-chill-community' ),
+									wp_date( $date_format, $ts )
+								);
+							?>
+							<span
+								class="ec-heat-cell level-<?php echo (int) $level; ?>"
+								title="<?php echo esc_attr( $label ); ?>"
+							></span>
+							<?php
+						}
+					}
+					?>
+				</div>
+			</div>
+		</div>
+
+		<div class="ec-heatmap-legend">
+			<span class="ec-heatmap-legend-label"><?php esc_html_e( 'Less', 'extra-chill-community' ); ?></span>
+			<span class="ec-heat-cell level-0" aria-hidden="true"></span>
+			<span class="ec-heat-cell level-1" aria-hidden="true"></span>
+			<span class="ec-heat-cell level-2" aria-hidden="true"></span>
+			<span class="ec-heat-cell level-3" aria-hidden="true"></span>
+			<span class="ec-heat-cell level-4" aria-hidden="true"></span>
+			<span class="ec-heatmap-legend-label"><?php esc_html_e( 'More', 'extra-chill-community' ); ?></span>
+		</div>
+	</div>
+	<?php
+}
+
+// Render directly under the header card, above everything else in the profile
+// body. Priority 1 keeps it the hero element; the Recent Activity feed
+// (priority 3) and Concert History (priority 5) follow it.
+add_action( 'bbp_template_after_user_details', 'ec_community_display_contribution_heatmap', 1 );

--- a/inc/user-profiles/profile-activity-feed.php
+++ b/inc/user-profiles/profile-activity-feed.php
@@ -24,9 +24,12 @@ if ( ! defined('ABSPATH') ) {
 /**
  * Render the displayed user's activity feed below their profile.
  *
- * Hooked to bbp_template_after_user_profile so it only renders on the main
- * profile tab (bbp_is_single_user_profile()), not on the topics/replies/edit
- * sub-tabs which already have their own bbPress loops.
+ * Hooked to bbp_template_after_user_details (priority 3) so it renders as the
+ * natural detail view directly beneath the Contribution Activity heatmap
+ * (priority 1) — the flow is chart → recent items. The bbp_is_single_user_profile()
+ * guard keeps it on the main profile tab only, not on the topics/replies/edit
+ * sub-tabs which already have their own bbPress loops. Full-width via the
+ * existing .user-profile-activity-feed CSS rule.
  *
  * @return void
  */
@@ -65,4 +68,6 @@ function extrachill_render_profile_activity_feed() {
 
 	echo '</div>';
 }
-add_action( 'bbp_template_after_user_profile', 'extrachill_render_profile_activity_feed' );
+// Priority 3 places the feed directly under the heatmap (priority 1) and above
+// Concert History (priority 5), all outside the 2-column card grid.
+add_action( 'bbp_template_after_user_details', 'extrachill_render_profile_activity_feed', 3 );


### PR DESCRIPTION
Closes #147.

Adds a GitHub-style contribution heatmap — 53-week × 7-day grid of intensity-shaded squares — as the profile's primary at-a-glance engagement surface and a stickiness driver (watching your streak grow).

## Data layer: consumes the seam, does not re-aggregate

Community **renders** the card; **users owns the data**. The new ability `extrachill/get-user-contribution-calendar` assembles the calendar by calling `ec_get_contribution_events( $user_id, $since_ymd )` (the dated-contributions seam landed in extrachill-users#166). It performs **no cross-site queries of its own** — no `switch_to_blog` + `GROUP BY DATE(post_date)`, no direct `post_date` reads. The seam already merges forum topics+replies (community source), main-site posts (users source), and concert check-ins (concert-tracking source), and centralizes UTC → site-local day conversion in `ec_bucket_utc_events_by_local_day()`. This issue is a pure consumer of that seam, as the Phase-2 comment specified.

Author-honesty: counts exactly what the seam returns, with **no author special-casing** (no bot/automation filtering hacks), per the events#207 note.

New files:
- `inc/social/rank-system/contribution-calendar-ability.php` — the ability + calendar builder (`extrachill_community_get_contribution_calendar`), streak math, per-user transient cache (`ec_contrib_calendar_{user_id}`, 1h TTL for the canonical 365-day window). Public, read-only, `show_in_rest`.
- `inc/user-profiles/contribution-heatmap.php` — the card renderer (consumer).

## The card

- **Placement**: full-width `.bbp-user-profile-card` on `bbp_template_after_user_details` @ priority 1 — directly under the header card, **above** the 2-column `.bbp-user-profile-cards-container` grid (same outside-the-grid pattern as Concert History @5). Guarded to the profile-overview tab via `bbp_is_single_user_profile()`.
- **Grid**: server-rendered CSS grid, 53 cols (weeks) × 7 rows (days), Sunday-aligned, trailing-week trimmed at today. `grid-auto-flow:column` emits cells column-major. Month labels along the top (shown on month change), Mon/Wed/Fri labels down the left. Summary line (total + current/longest streak) and a Less ▢▢▢▢▢ More legend. Pure PHP+CSS, native `title` tooltips (no JS).
- **Empty grid on new users renders as-is** — the dead chart is part of the appeal.

## Shade palette

5-level ramp (level-0 empty, 1→4 increasing intensity relative to the window's busiest day) built from the EC `--accent` green via `color-mix(in srgb, var(--accent) N%, var(--card-background))`:
- `0`: empty — `color-mix(border-color 55%, card-background)`
- `1`: accent 28%, `2`: 50%, `3`: 72%, `4`: full `--accent`

`color-mix` is chosen so the ramp is **fully token-driven** (no hardcoded RGB) and **flips correctly in dark mode** — it mixes against `--card-background`, which the token set overrides under `prefers-color-scheme`. Supported in all current evergreen browsers (2023+).

## Collapse decisions (conservative — vibe preserved)

- ✅ **Recent Activity feed repositioned** to `bbp_template_after_user_details` @ priority 3, so the flow is **chart → recent items** (heatmap @1, feed @3, Concert History @5). Low-risk reorder, explicitly endorsed in #147. Kept its `bbp_is_single_user_profile()` guard so it stays on the profile tab.
- ✅ **Community Activity card: retained wholesale.** Every line (Threads Started, Total Replies, Extra Chill Articles, Main Site Comments) is **navigational** — each links to that user's list. Per #147's "Do NOT delete the navigational links" + "When unsure, leave it," no content was removed. The heatmap becomes the hero and naturally draws the eye, visually de-emphasizing this card without surgery on the brittle old template. If further slimming is wanted, it's a trivial follow-up.
- ✅ **About / Artists / Concert History / social / personal bits: untouched.**

## Streaks & timezone behavior

- **Timezone**: the grid and stats operate entirely on site-local calendar days (`America/New_York`). The seam does the UTC→local conversion centrally (it selects `post_date_gmt`/`created_at` and buckets via `wp_timezone()`); this card just consumes the resulting `YYYY-MM-DD` keys and iterates its own local-day grid from `first_sunday` to today. No off-by-one.
- **Current streak**: consecutive days with ≥1 contribution counting back from **today**; 0 if today is empty (matches GitHub). Documented for follow-up if we'd rather count up to the most recent active day.
- **Longest streak**: longest run of consecutive active days anywhere in the window.

## Cache invalidation

The calendar transient is busted alongside the points transients in `extrachill_clear_user_points_cache()` (on `bbp_new_topic`/`bbp_new_reply`/edit/trash/delete/etc.), so new activity refreshes the heatmap + streaks on the next read. Only the canonical 365-day window is cached; custom `days` params compute live (no stale-window collisions).

## Graceful degradation

If the seam (`ec_get_contribution_events`) is absent — i.e. extrachill-users #166 is not yet deployed — the **ability** returns an all-zero calendar (no fatal) and the **card** skips rendering entirely rather than showing a chart that can never populate. Both are safe before the dependency ships.

## Verified

- `php -l` clean on all touched PHP.
- Runtime-tested on the community site (loading the not-yet-deployed seam + community forum source in-process):
  - **Active user** (Chris, 84 contributions): 365-cell grid, 66 shaded days across levels 1–4, correct month labels, total 84, current streak 1, longest 4.
  - **Empty user** (0 contributions): full 365-cell level-0 grid, total 0, streak 0.
  - Heading adapts: "My Contribution Activity" (own) vs "Contribution Activity" (others).
- No build step — CSS enqueued raw via the existing `enqueue_user_profile_styles()` on `bbp_is_single_user()`.

No CHANGELOG edits, no version bumps (homeboy owns both).