### PR TITLE
feat: bridge bbPress topic subscriptions into notification system

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -79,6 +79,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notification-card.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-replies.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-mentions.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-subscriptions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/contribution-heatmap.php';

--- a/inc/social/notifications/capture-subscriptions.php
+++ b/inc/social/notifications/capture-subscriptions.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Subscription Notification Capture
+ *
+ * Bridges bbPress topic subscriptions into the Extra Chill notification system.
+ *
+ * - Auto-subscribes a reply author to the topic (gated on the user preference
+ *   provided by extrachill-users).
+ * - Notifies all other topic subscribers when a new reply lands, routed through
+ *   the shared extrachill_notify action into the network notification substrate.
+ * - Disables bbPress's parallel subscription emails so all email flows through
+ *   the existing extrachill-users digest sweep.
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined('ABSPATH') ) {
+	exit;
+}
+
+/**
+ * Capture subscription notifications on a new reply.
+ *
+ * Runs at priority 11 on `bbp_new_reply`, between the reply-capture handler
+ * (priority 10) and the mention-capture handler (priority 12).
+ *
+ * - Auto-subscribes the reply author to the topic when the
+ *   `ec_users_auto_subscribe_enabled` preference is ON (default ON). bbPress's
+ *   `bbp_add_user_subscription` has an internal duplicate guard, so the call is
+ *   safe to repeat.
+ * - Notifies every topic subscriber except the topic author (already covered by
+ *   the `reply` notification in capture-replies.php) and the reply author
+ *   (mirrors bbPress's own recipient shaping in bbp_notify_topic_subscribers).
+ *
+ * @param int   $reply_id       Reply post ID.
+ * @param int   $topic_id       Topic post ID.
+ * @param int   $forum_id       Forum ID.
+ * @param array $anonymous_data Anonymous user data.
+ * @param int   $reply_author   Reply author user ID.
+ */
+function extrachill_capture_subscription_notifications( $reply_id, $topic_id, $forum_id, $anonymous_data, $reply_author ) {
+	// Bail if bbPress subscriptions are disabled site-wide.
+	if ( ! function_exists( 'bbp_is_subscriptions_active' ) || ! bbp_is_subscriptions_active() ) {
+		return;
+	}
+
+	$reply_id     = (int) $reply_id;
+	$topic_id     = (int) $topic_id;
+	$reply_author = (int) $reply_author;
+
+	if ( ! $reply_id || ! $topic_id || ! $reply_author ) {
+		return;
+	}
+
+	// Auto-subscribe the reply author when the preference is enabled. Default
+	// is ON once extrachill-users ships the getter; before then the guard skips.
+	if ( function_exists( 'ec_users_auto_subscribe_enabled' ) && ec_users_auto_subscribe_enabled( $reply_author ) ) {
+		bbp_add_user_subscription( $reply_author, $topic_id );
+	}
+
+	// Recipients: topic subscribers minus the topic author (already gets the
+	// `reply` notification from capture-replies.php) and the reply author
+	// (mirrors bbPress's own recipient shaping in bbp_notify_topic_subscribers).
+	$topic_author = (int) get_post_field( 'post_author', $topic_id );
+
+	$subscribers = bbp_get_subscribers( $topic_id );
+	if ( empty( $subscribers ) ) {
+		return;
+	}
+
+	$excluded   = array( $reply_author, $topic_author );
+	$recipients = array();
+
+	foreach ( $subscribers as $subscriber_id ) {
+		$subscriber_id = (int) $subscriber_id;
+
+		if ( $subscriber_id <= 0 ) {
+			continue;
+		}
+
+		if ( in_array( $subscriber_id, $excluded, true ) ) {
+			continue;
+		}
+
+		$recipients[] = $subscriber_id;
+	}
+
+	if ( empty( $recipients ) ) {
+		return;
+	}
+
+	$topic_title = get_the_title( $topic_id );
+	$reply_link  = bbp_get_reply_url( $reply_id );
+
+	// Fire through the shared action; the extrachill-users substrate accepts a
+	// recipient array and inserts one notification row per user. Payload keys
+	// follow the legacy shape used by capture-replies/capture-mentions; the
+	// substrate reads topic_title/post_id with item_id as the canonical key.
+	do_action( 'extrachill_notify', $recipients, array(
+		'actor_id'    => $reply_author,
+		'type'        => 'subscription',
+		'topic_title' => $topic_title,
+		'link'        => $reply_link,
+		'item_id'     => $topic_id,
+		'post_id'     => $topic_id,
+	) );
+}
+
+// Hook into bbPress actions (priority 11 - between reply@10 and mention@12).
+add_action( 'bbp_new_reply', 'extrachill_capture_subscription_notifications', 11, 5 );
+
+/**
+ * Disable bbPress's native subscription/forum emails.
+ *
+ * Ensures all notification email flows exclusively through the
+ * extrachill-users digest sweep, which is type-agnostic and picks up the new
+ * `subscription` notification type automatically.
+ *
+ * bbPress registers its `bbp_notify_*` callbacks at priority 11 during plugin
+ * load. Running the removal on `bbp_init` (priority 99) guarantees it executes
+ * after registration, and well before any `bbp_new_reply`/`bbp_new_topic` fire
+ * on a front-end POST request.
+ */
+function extrachill_community_disable_bbp_subscription_emails() {
+	remove_action( 'bbp_new_reply', 'bbp_notify_topic_subscribers', 11 );
+	remove_action( 'bbp_new_topic', 'bbp_notify_forum_subscribers', 11 );
+}
+add_action( 'bbp_init', 'extrachill_community_disable_bbp_subscription_emails', 99 );


### PR DESCRIPTION
## Summary

Backend producer for #151 — bridges bbPress topic subscriptions into the Extra Chill notification system, auto-subscribes users who reply to a topic, and kills bbPress's parallel subscription emails so all email flows through the existing extrachill-users digest. Backend PHP only; the settings React tab is #152.

## What changed

- **New producer `inc/social/notifications/capture-subscriptions.php`** hooked on `bbp_new_reply` at **priority 11** (between reply-capture@10 and mention-capture@12), 5 args. On a new reply it:
  - **Auto-subscribes the reply author** to the topic via `bbp_add_user_subscription( $reply_author, $topic_id )`, gated on `ec_users_auto_subscribe_enabled( $reply_author )` from extrachill-users. Guarded with `function_exists` so it no-ops gracefully until that getter ships (merged upstream, default ON); `bbp_add_user_subscription` has an internal dedupe so repeated calls are safe.
  - **Notifies all topic subscribers** via `do_action( 'extrachill_notify', $recipients, ... )` with `type => 'subscription'`, `topic_title`, `link => bbp_get_reply_url( $reply_id )`, `item_id => $topic_id`, `actor_id => $reply_author`. Recipients come from `bbp_get_subscribers( $topic_id )` (non-deprecated) and **exclude** the topic author (already gets the `reply` notification from `capture-replies.php`) and the reply author (mirrors bbPress's own shaping in `bbp_notify_topic_subscribers`). No bespoke digest label — generic grouping, as specified.
  - Bails early when subscriptions are disabled site-wide or no recipients remain.
- **Disables bbPress's parallel subscription emails** via a `bbp_init` (priority 99) callback that runs `remove_action` for both `bbp_new_reply`/bbp_notify_topic_subscribers` and `bbp_new_topic`/`bbp_notify_forum_subscribers` at priority 11, guaranteeing email flows only through the type-agnostic extrachill-users digest sweep.
- **Registered** the new producer in `extrachill-community.php` next to the `capture-replies`/`capture-mentions` requires.

## Notes

- Does **not** touch `extrachill-users/inc/notifications/email.php` (the digest sweep is type-agnostic and picks up the new `subscription` type automatically), does **not** invent any email sending, and does **not** touch `src/blocks` or `build/blocks` (#152).
- Payload keys follow the legacy `topic_title`/`post_id` shape used by the sibling producers, with `item_id` as the canonical key — consistent with `capture-mentions.php`.

## Verify

- `php -l` clean on `inc/social/notifications/capture-subscriptions.php` and `extrachill-community.php`.

Closes #151.