### PR TITLE
feat: add Notifications tab to user-settings block + link from notifications page

### DIFF
--- a/inc/social/notifications/notifications-content.php
+++ b/inc/social/notifications/notifications-content.php
@@ -32,6 +32,15 @@ function extrachill_display_notifications() {
 		? $result['notifications']
 		: array();
 
+	// Always-on link to the notification-preferences tab of /settings, so a
+	// user can manage digests and auto-subscribe even with an empty inbox.
+	$settings_url = home_url( '/settings/#tab-notifications' );
+	printf(
+		'<p class="extrachill-notifications-settings-link"><a href="%s">%s</a></p>',
+		esc_url( $settings_url ),
+		esc_html__( 'Manage notification settings', 'extrachill-community' )
+	);
+
 	if ( empty( $notifications ) ) {
 		echo '<p>No notifications found.</p>';
 		return;

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -14,6 +14,7 @@ import type {
 	UserSubscriptions,
 	FollowedArtist,
 	RequestArtistAccessResponse,
+	NotificationPreferences,
 } from '../../types/users';
 
 const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
@@ -200,6 +201,60 @@ function SubscriptionsTab() {
 	);
 }
 
+function NotificationsTab() {
+	const [ loading, setLoading ] = useState( true );
+	const [ saving, setSaving ] = useState( false );
+	const [ emailsEnabled, setEmailsEnabled ] = useState( true );
+	const [ autoSubscribe, setAutoSubscribe ] = useState( true );
+	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
+
+	useEffect( () => {
+		client.execute< NotificationPreferences >( 'extrachill/get-notification-preferences' ).then( ( result ) => {
+			setEmailsEnabled( result.emails_enabled );
+			setAutoSubscribe( result.auto_subscribe_replies );
+			setLoading( false );
+		} ).catch( () => setLoading( false ) );
+	}, [] );
+
+	const handleSave = useCallback( async () => {
+		setSaving( true );
+		setNotice( null );
+		try {
+			await client.execute( 'extrachill/update-notification-preferences', { emails_enabled: emailsEnabled, auto_subscribe_replies: autoSubscribe } );
+			setNotice( { type: 'success', message: 'Notification preferences updated.' } );
+		} catch ( err ) {
+			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
+		}
+		setSaving( false );
+	}, [ emailsEnabled, autoSubscribe ] );
+
+	if ( loading ) return <div className="notice notice-info"><p>Loading notification preferences...</p></div>;
+
+	return (
+		<Panel>
+			<PanelHeader description="Control how Extra Chill keeps you in the loop." />
+			{ notice && <Notice type={ notice.type } message={ notice.message } /> }
+			<ul style={ styles.checkboxList }>
+				<li style={ styles.checkboxItem }>
+					<input type="checkbox" id="ec-notif-emails" checked={ emailsEnabled } onChange={ ( e ) => setEmailsEnabled( e.target.checked ) } />
+					<label htmlFor="ec-notif-emails" style={ { fontWeight: 'normal', cursor: 'pointer' } }>
+						<strong>Email notifications</strong>
+						<div style={ styles.mutedText }>Receive email digests for your notifications.</div>
+					</label>
+				</li>
+				<li style={ styles.checkboxItem }>
+					<input type="checkbox" id="ec-notif-auto-subscribe" checked={ autoSubscribe } onChange={ ( e ) => setAutoSubscribe( e.target.checked ) } />
+					<label htmlFor="ec-notif-auto-subscribe" style={ { fontWeight: 'normal', cursor: 'pointer' } }>
+						<strong>Auto-subscribe to replies</strong>
+						<div style={ styles.mutedText }>Automatically follow topics you reply to.</div>
+					</label>
+				</li>
+			</ul>
+			<ActionRow><button className="button-1 button-small" style={ saving ? styles.button : undefined } onClick={ handleSave } disabled={ saving }>{ saving ? 'Saving...' : 'Save Preferences' }</button></ActionRow>
+		</Panel>
+	);
+}
+
 function ArtistPlatformTab( { artistAccess, artistSiteUrl, hasArtists, canCreateArtists }: { artistAccess: { status: string; type: string; request_type?: string; requested_at?: number }; artistSiteUrl: string; hasArtists: boolean; canCreateArtists: boolean } ) {
 	const [ accessType, setAccessType ] = useState<'artist' | 'professional'>( 'artist' );
 	const [ submitting, setSubmitting ] = useState( false );
@@ -229,7 +284,7 @@ function ArtistPlatformTab( { artistAccess, artistSiteUrl, hasArtists, canCreate
 	);
 }
 
-type TabId = 'account-details' | 'security' | 'subscriptions' | 'artist-platform';
+type TabId = 'account-details' | 'security' | 'subscriptions' | 'notifications' | 'artist-platform';
 
 function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId }: { artistSiteUrl: string; hasArtists: boolean; canCreateArtists: boolean; userId: number } ) {
 	const [ activeTab, setActiveTab ] = useState<TabId>( 'account-details' );
@@ -260,6 +315,7 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId 
 		{ id: 'account-details', label: 'Account Details' },
 		{ id: 'security', label: 'Security' },
 		{ id: 'subscriptions', label: 'Subscriptions' },
+		{ id: 'notifications', label: 'Notifications' },
 		{ id: 'artist-platform', label: 'Artist Platform' },
 	];
 
@@ -271,6 +327,8 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId 
 				return <SecurityTab settings={ settings } onSettingsChange={ setSettings } />;
 			case 'subscriptions':
 				return <SubscriptionsTab />;
+			case 'notifications':
+				return <NotificationsTab />;
 			case 'artist-platform':
 				return <ArtistPlatformTab artistAccess={ artistAccess } artistSiteUrl={ artistSiteUrl } hasArtists={ hasArtists } canCreateArtists={ canCreateArtists } />;
 			default:
@@ -281,7 +339,7 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId 
 	return (
 		<BlockShell>
 			<BlockShellInner maxWidth="narrow">
-				<BlockShellHeader title="Settings" description="Manage your account, security, subscriptions, and artist platform access." />
+				<BlockShellHeader title="Settings" description="Manage your account, security, subscriptions, notifications, and artist platform access." />
 				<ResponsiveTabs
 					tabs={ tabs }
 					active={ activeTab }

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -13,6 +13,7 @@
  *   - extrachill/get-user-settings, update-user-settings,
  *     change-user-email, change-user-password
  *   - extrachill/get-subscriptions, update-subscriptions
+ *   - extrachill/get-notification-preferences, update-notification-preferences
  *   - extrachill/request-artist-access
  */
 
@@ -113,6 +114,18 @@ export interface FollowedArtist {
 export interface UserSubscriptions {
 	user_id: number;
 	followed_artists: FollowedArtist[];
+}
+
+// ─── Notification Preferences ────────────────────────────────────────────────
+//
+// Mirrors extrachill/get-notification-preferences and
+// extrachill/update-notification-preferences (extrachill-users). Both abilities
+// expose the same two boolean toggles; update accepts the same shape it returns.
+
+export interface NotificationPreferences {
+	user_id: number;
+	emails_enabled: boolean;
+	auto_subscribe_replies: boolean;
 }
 
 // ─── Artist Access Request ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #152.

## Summary

Adds a **Notifications** tab to the user-settings React block, surfacing the two notification-preference toggles exposed by `extrachill-users` (`extrachill/get-notification-preferences` / `extrachill/update-notification-preferences`), and links to that tab from the notifications page.

## Changes

### `src/blocks/user-settings/view.tsx`
- New `NotificationsTab` component, mirroring the `SubscriptionsTab` pattern (loading/notice/saving state, `client.execute`, `Panel`/`PanelHeader`/`Notice`). On mount it loads `{ emails_enabled, auto_subscribe_replies }` via `extrachill/get-notification-preferences`; on save it persists both via `extrachill/update-notification-preferences`.
  - **Email notifications** (`emails_enabled`) — "Receive email digests for your notifications."
  - **Auto-subscribe to replies** (`auto_subscribe_replies`) — "Automatically follow topics you reply to."
- Wired the tab in (three edit points): added `'notifications'` to the `TabId` union, added `{ id: 'notifications', label: 'Notifications' }` to the `tabs` array, and added `case 'notifications': return <NotificationsTab />;` to `renderTabPanel`.
- Header description updated to mention notifications.

### `src/types/users.ts`
- Added `NotificationPreferences` interface mirroring the ability output shape, plus a doc reference under the file's ability-source header.

### `inc/social/notifications/notifications-content.php`
- Added an always-on "Manage notification settings" link near the top of the notifications page, targeting `/settings/#tab-notifications` (matches the `ResponsiveTabs` `syncWithHash` format with default `tab-` prefix). Placed before the empty-state check so it's visible even with an empty inbox.

## Verification
- `npm install` + `npm run build` (`wp-scripts build --webpack-copy-php`): **webpack 5.108.4 compiled successfully**. TS compiles clean; `build/blocks/user-settings/*` regenerated locally.
- `php -l inc/social/notifications/notifications-content.php`: **No syntax errors detected**.

## Note on `build/` artifacts

The issue spec asked to commit the regenerated `build/blocks/user-settings/*` artifacts. This repo does **not** track `build/` in git:

- `.gitignore:12` ignores `build/`.
- `git ls-files build/` returns 0 — `build/` has never been tracked.
- The release pipeline generates build artifacts via `homeboy build` at release time (the `build.sh` symlink redirects to `homeboy build`).

So this PR ships the source changes only, and `homeboy build` will produce the deployed `build/` artifacts during release as usual. Forcing `build/` into git would violate the repo contract and conflict with the homeboy release flow.

## Upstream dependency

Relies on `extrachill-users` PR #169 (`feat: add auto-subscribe-to-replies notification preference`, commit `b56b156`), merged to `main` on Jul 6. Both `extrachill/get-notification-preferences` and `extrachill/update-notification-preferences` now expose `emails_enabled` + `auto_subscribe_replies`. (Note: the production install of `extrachill-users` is still on the pre-#169 version at the time of this PR, so end-to-end verification on prod requires the `extrachill-users` release to deploy first.)

## Constraints
- Conventional commit (`feat:`). No CHANGELOG edit, no version bump (homeboy owns both).
- PR only — no merge/release/deploy.