### PR TITLE
feat: add default event market setting

### DIFF
--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -21,10 +21,22 @@ import type {
 const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
 const LOCATION_SEARCH_DEBOUNCE_MS = 250;
 
-interface LocationTerm {
-	id: number;
+interface EventLocation {
+	term_id: number;
 	name: string;
 	slug: string;
+	archive_url: string;
+	coordinates: { lat: number; lon: number } | null;
+	hierarchy: {
+		region: string;
+		state: string;
+		label: string;
+	};
+}
+
+interface EventLocationsResponse {
+	locations: EventLocation[];
+	location: EventLocation | null;
 }
 
 const styles = {
@@ -73,17 +85,10 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 		}
 
 		locationSearchTimeout.current = window.setTimeout( () => {
-			const params = new URLSearchParams( {
-				search: trimmed,
-				per_page: '10',
-				_fields: 'id,name,slug',
-				orderby: 'count',
-				order: 'desc',
-			} );
-			apiFetch< LocationTerm[] >( { path: `/wp/v2/location?${ params.toString() }` } )
-				.then( ( terms ) => {
+			client.execute< EventLocationsResponse >( 'extrachill/events-locations', { mode: 'search', search: trimmed, limit: 10 } )
+				.then( ( result ) => {
 					if ( request === locationSearchRequest.current ) {
-						setLocationOptions( terms.map( ( term ) => ( { label: term.name, value: term.slug } ) ) );
+						setLocationOptions( result.locations.map( ( location ) => ( { label: location.hierarchy.label, value: location.slug } ) ) );
 					}
 				} )
 				.catch( () => {
@@ -103,7 +108,7 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 		setSaving( true );
 		setNotice( null );
 		try {
-			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', { first_name: firstName, last_name: lastName, display_name: displayName, default_event_location_slug: defaultEventLocationSlug } );
+			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', { first_name: firstName, last_name: lastName, display_name: displayName, default_event_location: defaultEventLocationSlug ?? '' } );
 			onUpdate( result );
 			setDefaultEventLocationSlug( result.default_event_location?.slug ?? null );
 			setNotice( { type: 'success', message: result.message || 'Account details updated.' } );

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import { createRoot } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { ComboboxControl } from '@wordpress/components';
 import { WPNativeClient } from 'wp-native-client';
 import { WpApiFetchTransport } from 'wp-native-client/wordpress';
 import { BlockShell, BlockShellInner, ResponsiveTabs, Panel, PanelHeader, ActionRow, FieldGroup, BlockShellHeader, BlockIntro } from '@extrachill/components';
@@ -18,6 +19,13 @@ import type {
 } from '../../types/users';
 
 const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
+const LOCATION_SEARCH_DEBOUNCE_MS = 250;
+
+interface LocationTerm {
+	id: number;
+	name: string;
+	slug: string;
+}
 
 const styles = {
 	button: {
@@ -46,21 +54,64 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 	const [ firstName, setFirstName ] = useState( settings.first_name );
 	const [ lastName, setLastName ] = useState( settings.last_name );
 	const [ displayName, setDisplayName ] = useState( settings.display_name );
+	const [ defaultEventLocationSlug, setDefaultEventLocationSlug ] = useState< string | null >( settings.default_event_location?.slug ?? null );
+	const [ locationOptions, setLocationOptions ] = useState< Array<{ label: string; value: string }> >( settings.default_event_location ? [ { label: settings.default_event_location.name, value: settings.default_event_location.slug } ] : [] );
 	const [ saving, setSaving ] = useState( false );
 	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
+	const locationSearchTimeout = useRef< number | null >( null );
+	const locationSearchRequest = useRef( 0 );
+
+	const searchLocations = useCallback( ( search: string ) => {
+		const request = ++locationSearchRequest.current;
+		if ( locationSearchTimeout.current !== null ) {
+			window.clearTimeout( locationSearchTimeout.current );
+		}
+		const trimmed = search.trim();
+		if ( ! trimmed ) {
+			setLocationOptions( settings.default_event_location ? [ { label: settings.default_event_location.name, value: settings.default_event_location.slug } ] : [] );
+			return;
+		}
+
+		locationSearchTimeout.current = window.setTimeout( () => {
+			const params = new URLSearchParams( {
+				search: trimmed,
+				per_page: '10',
+				_fields: 'id,name,slug',
+				orderby: 'count',
+				order: 'desc',
+			} );
+			apiFetch< LocationTerm[] >( { path: `/wp/v2/location?${ params.toString() }` } )
+				.then( ( terms ) => {
+					if ( request === locationSearchRequest.current ) {
+						setLocationOptions( terms.map( ( term ) => ( { label: term.name, value: term.slug } ) ) );
+					}
+				} )
+				.catch( () => {
+					if ( request === locationSearchRequest.current ) setLocationOptions( [] );
+				} );
+		}, LOCATION_SEARCH_DEBOUNCE_MS );
+
+	}, [ settings.default_event_location ] );
+
+	useEffect( () => () => {
+		if ( locationSearchTimeout.current !== null ) {
+			window.clearTimeout( locationSearchTimeout.current );
+		}
+	}, [] );
 
 	const handleSave = useCallback( async () => {
 		setSaving( true );
 		setNotice( null );
 		try {
-			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', { first_name: firstName, last_name: lastName, display_name: displayName } );
+			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', { first_name: firstName, last_name: lastName, display_name: displayName, default_event_location_slug: defaultEventLocationSlug } );
 			onUpdate( result );
+			setDefaultEventLocationSlug( result.default_event_location?.slug ?? null );
 			setNotice( { type: 'success', message: result.message || 'Account details updated.' } );
 		} catch ( err ) {
 			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
 		}
 		setSaving( false );
-	}, [ firstName, lastName, displayName, onUpdate ] );
+	}, [ firstName, lastName, displayName, defaultEventLocationSlug, onUpdate ] );
 
 	return (
 		<Panel>
@@ -75,6 +126,17 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 				<select id="ec-display-name" value={ displayName } onChange={ ( e ) => setDisplayName( e.target.value ) }>
 					{ settings.display_name_options.map( ( option ) => <option key={ option } value={ option }>{ option }</option> ) }
 				</select>
+			</FieldGroup>
+			<FieldGroup help="Used when you have not chosen an event location or shared your browser location. This does not change your public Local Scene.">
+				<ComboboxControl
+					label="Default Event Market"
+					value={ defaultEventLocationSlug }
+					options={ locationOptions }
+					onFilterValueChange={ searchLocations }
+					onChange={ ( slug ) => setDefaultEventLocationSlug( slug ?? null ) }
+					allowReset={ true }
+					placeholder="Search event markets"
+				/>
 			</FieldGroup>
 			<ActionRow>
 				<button className="button-1 button-small" style={ saving ? styles.button : undefined } onClick={ handleSave } disabled={ saving }>{ saving ? 'Saving...' : 'Save Account Details' }</button>

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -53,6 +53,14 @@ export interface LeaderboardResponse {
 
 // ─── User Settings ──────────────────────────────────────────────────────────
 
+export interface EventLocation {
+	term_id: number;
+	name: string;
+	slug: string;
+	url: string;
+	coordinates: { lat: number; lon: number } | null;
+}
+
 export interface UserSettings {
 	user_id: number;
 	first_name: string;
@@ -61,6 +69,7 @@ export interface UserSettings {
 	display_name_options: string[];
 	email: string;
 	pending_email: string | null;
+	default_event_location: EventLocation | null;
 }
 
 export interface ChangeEmailResponse {


### PR DESCRIPTION
## Summary
- add an explicit searchable and clearable Default Event Market control to authenticated account settings
- search canonical markets through the merged `extrachill/events-locations` Ability and its Events-site taxonomy context
- persist the selected canonical slug through `extrachill/update-user-settings` without reading or changing public `local_city`

## UX behavior
The Account Details tab initializes from the resolved account setting, searches after a short debounce, and allows the selection to be reset. Search results use the Ability's `hierarchy.label` value so duplicate city names remain state-qualified. Help text explicitly states that this fallback preference does not change the public Local Scene field.

## API contracts
Canonical search follows Extra-Chill/extrachill-events#234 exactly:

```json
{
  "ability": "extrachill/events-locations",
  "input": { "mode": "search", "search": "charl", "limit": 10 },
  "output": {
    "locations": [
      {
        "term_id": 1618,
        "name": "Charleston",
        "slug": "charleston",
        "archive_url": "https://events.extrachill.com/location/charleston/",
        "coordinates": { "lat": 32.7765, "lon": -79.9311 },
        "hierarchy": {
          "region": "USA",
          "state": "South Carolina",
          "label": "Charleston, South Carolina"
        }
      }
    ],
    "location": null
  }
}
```

Account persistence follows Extra-Chill/extrachill-users#179:

- `extrachill/get-user-settings` returns `default_event_location` as its resolved object or `null`
- `extrachill/update-user-settings` accepts `default_event_location` as the canonical slug
- an empty string explicitly clears the preference; omitting the property leaves it unchanged
- a location update returns the complete refreshed settings payload

No Community-site `/wp/v2/location` request, location registry, geocoder, or custom persistence layer is introduced.

## Accessibility
The selector uses WordPress `ComboboxControl`, providing the established keyboard-accessible combobox/listbox interaction, associated label, searchable options, and reset control. Free text cannot become a saved location; only canonical Ability results can be selected.

## Tests and build
- rebased/verified against current `main` (already up to date)
- `npm run build` passes
- `git diff --check` passes
- source audit confirms `/wp/v2/location` is absent from the settings consumer and `local_city` remains in the separate edit-profile flow
- repository-wide `npm run lint:js` and `npm run lint:css` remain blocked by pre-existing lint/configuration failures in untouched files
- generated build output is not tracked by this repository

Closes #155