### PR TITLE
fix: use Users-owned event market search

### DIFF
--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -25,7 +25,7 @@ interface EventLocation {
 	term_id: number;
 	name: string;
 	slug: string;
-	archive_url: string;
+	url: string;
 	coordinates: { lat: number; lon: number } | null;
 	hierarchy: {
 		region: string;
@@ -68,6 +68,7 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 	const [ displayName, setDisplayName ] = useState( settings.display_name );
 	const [ defaultEventLocationSlug, setDefaultEventLocationSlug ] = useState< string | null >( settings.default_event_location?.slug ?? null );
 	const [ locationOptions, setLocationOptions ] = useState< Array<{ label: string; value: string }> >( settings.default_event_location ? [ { label: settings.default_event_location.name, value: settings.default_event_location.slug } ] : [] );
+	const [ locationSearchError, setLocationSearchError ] = useState( false );
 	const [ saving, setSaving ] = useState( false );
 	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
 	const locationSearchTimeout = useRef< number | null >( null );
@@ -80,19 +81,24 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 		}
 		const trimmed = search.trim();
 		if ( ! trimmed ) {
+			setLocationSearchError( false );
 			setLocationOptions( settings.default_event_location ? [ { label: settings.default_event_location.name, value: settings.default_event_location.slug } ] : [] );
 			return;
 		}
 
 		locationSearchTimeout.current = window.setTimeout( () => {
-			client.execute< EventLocationsResponse >( 'extrachill/events-locations', { mode: 'search', search: trimmed, limit: 10 } )
+			client.execute< EventLocationsResponse >( 'extrachill/user-event-locations', { mode: 'search', search: trimmed, limit: 10 } )
 				.then( ( result ) => {
 					if ( request === locationSearchRequest.current ) {
+						setLocationSearchError( false );
 						setLocationOptions( result.locations.map( ( location ) => ( { label: location.hierarchy.label, value: location.slug } ) ) );
 					}
 				} )
 				.catch( () => {
-					if ( request === locationSearchRequest.current ) setLocationOptions( [] );
+					if ( request === locationSearchRequest.current ) {
+						setLocationSearchError( true );
+						setLocationOptions( [] );
+					}
 				} );
 		}, LOCATION_SEARCH_DEBOUNCE_MS );
 
@@ -133,6 +139,7 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 				</select>
 			</FieldGroup>
 			<FieldGroup help="Used when you have not chosen an event location or shared your browser location. This does not change your public Local Scene.">
+				{ locationSearchError && <Notice type="error" message="Event market search is temporarily unavailable." /> }
 				<ComboboxControl
 					label="Default Event Market"
 					value={ defaultEventLocationSlug }


### PR DESCRIPTION
## Summary
- replace the Community selector's site-scoped `extrachill/events-locations` dependency with the network-wide Users-owned `extrachill/user-event-locations` Ability from Extra-Chill/extrachill-users#180
- preserve the searchable, clearable `ComboboxControl`, canonical `hierarchy.label` options, debounce/race protection, empty-string clearing through `extrachill/update-user-settings`, and the separation from public Local Scene
- show a graceful inline error when market search is unavailable instead of presenting a silent empty result set

## Root cause
`extrachill-events` is intentionally active only on the Events site, so its `extrachill/events-locations` Ability is not registered during Community requests. `extrachill-users` owns the network-wide account preference and now provides the matching search contract through `extrachill/user-event-locations`.

## Verification
- `npm run build` passes
- scoped TypeScript check for `src/blocks/user-settings/view.tsx` passes with TypeScript 5.9.3
- `git diff --check` passes
- no test suite is present
- repository-wide TypeScript remains blocked by existing errors in unrelated block registrations and missing `@wordpress/block-editor` declarations
- `wp-scripts lint-js` misparses the existing TypeScript file; repository formatting would rewrite the full legacy file, so formatting was kept consistent with its current style

Closes #157