### PR TITLE
fix: consume corrected ability client

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@wordpress/element": "^6.0.0",
     "@wordpress/i18n": "^5.0.0",
     "@wordpress/icons": "^10.0.0",
-    "wp-native-client": "^0.0.1"
+    "wp-native-client": "^0.0.2"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- require `wp-native-client` 0.0.2 for the Community settings bundle
- consume the upstream fix for namespaced Ability routes, readonly GET execution, nested input serialization, and direct run responses
- keep user settings and location search on the canonical Abilities API rather than adding duplicate `extrachill-api` routes

## Verification
- `npm install --no-package-lock`
- `npm run build`
- webpack compiled successfully
- `git diff --check`

Depends on chubes4/wp-native#61.
Fixes #159