### PR TITLE
feat: adopt canonical Local Scene

### DIFF
--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -27,8 +27,8 @@ do_action('bbp_template_before_user_profile');
 // there is actually something to show (avoids an empty bordered box for users
 // with no description and no local scene).
 $about_description = bbp_get_displayed_user_field('description');
-$about_local_city  = get_user_meta( bbp_get_displayed_user_id(), 'local_city', true );
-$has_about_content = ! empty( $about_description ) || ! empty( $about_local_city );
+$about_local_scene = extrachill_community_get_public_local_scene( bbp_get_displayed_user_id() );
+$has_about_content = ! empty( $about_description ) || ! empty( $about_local_scene['name'] );
 ?>
 <div class="bbp-user-profile-cards-container"> <?php // Start Flex Grid Container ?>
 <?php if ( $has_about_content ) : ?>
@@ -38,8 +38,8 @@ $has_about_content = ! empty( $about_description ) || ! empty( $about_local_city
 		<p class="bbp-user-description"><?php echo wp_kses_post( bbp_rel_nofollow( $about_description ) ); ?></p>
 			<?php endif; ?>
 
-			<?php if ( $about_local_city ) : ?>
-		<p class="bbp-user-local-scene-inline"><strong><?php esc_html_e( 'Local Scene:', 'extra-chill-community' ); ?></strong> <?php echo esc_html( $about_local_city ); ?></p>
+			<?php if ( ! empty( $about_local_scene['name'] ) ) : ?>
+		<p class="bbp-user-local-scene-inline"><strong><?php esc_html_e( 'Local Scene:', 'extra-chill-community' ); ?></strong> <?php echo esc_html( $about_local_scene['name'] ); ?></p>
 			<?php endif; ?>
 </div>
 <?php endif; // End has_about_content ?>

--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -83,6 +83,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/contribution-heatmap.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/public-profile.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/concert-history.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/custom-user-profile.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/profile-activity-feed.php';

--- a/inc/social/rank-system/chill-forums-rank.php
+++ b/inc/social/rank-system/chill-forums-rank.php
@@ -24,10 +24,10 @@ function extrachill_add_rank_and_points_to_reply() {
 
 	echo '<div class="rankpoints">';
 
-	$local_city = get_user_meta( $reply_author_id, 'local_city', true );
-	if ( ! empty( $local_city ) ) {
+	$local_scene = extrachill_community_get_public_local_scene( $reply_author_id );
+	if ( ! empty( $local_scene['name'] ) ) {
 		echo '<div class="reply-author-local-scene">';
-		echo '<span>Local Scene:</span> ' . esc_html( $local_city );
+		echo '<span>Local Scene:</span> ' . esc_html( $local_scene['name'] );
 		echo '</div>';
 	}
 

--- a/inc/user-profiles/public-profile.php
+++ b/inc/user-profiles/public-profile.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Visibility-filtered public profile helpers.
+ *
+ * @package ExtraChill\Community
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get a user's public Local Scene through the Users-owned profile contract.
+ *
+ * @param int $user_id User ID.
+ * @return array|null Resolved public Local Scene, or null when private/unavailable.
+ */
+function extrachill_community_get_public_local_scene( $user_id ) {
+	static $scenes = array();
+
+	$user_id = absint( $user_id );
+	if ( ! $user_id || ! function_exists( 'wp_get_ability' ) ) {
+		return null;
+	}
+
+	if ( array_key_exists( $user_id, $scenes ) ) {
+		return $scenes[ $user_id ];
+	}
+
+	$ability = wp_get_ability( 'extrachill/get-user-profile' );
+	if ( ! $ability ) {
+		$scenes[ $user_id ] = null;
+		return null;
+	}
+
+	$profile = $ability->execute( array( 'user_id' => $user_id ) );
+	$scene   = ! is_wp_error( $profile ) && is_array( $profile ) && isset( $profile['local_scene'] ) && is_array( $profile['local_scene'] )
+		? $profile['local_scene']
+		: null;
+
+	$scenes[ $user_id ] = $scene;
+	return $scene;
+}

--- a/src/blocks/edit-profile/view.tsx
+++ b/src/blocks/edit-profile/view.tsx
@@ -223,7 +223,6 @@ function EditProfileApp( {
 	const [ notice, setNotice ] = useState<{ type: 'success' | 'error'; message: string } | null>( null );
 	const [ customTitle, setCustomTitle ] = useState( '' );
 	const [ bio, setBio ] = useState( '' );
-	const [ localCity, setLocalCity ] = useState( '' );
 	const [ links, setLinks ] = useState<UserLink[]>( [] );
 	const [ avatarUrl, setAvatarUrl ] = useState( '' );
 
@@ -232,7 +231,6 @@ function EditProfileApp( {
 			setProfile( data );
 			setCustomTitle( data.custom_title || '' );
 			setBio( data.bio || '' );
-			setLocalCity( data.local_city || '' );
 			setLinks( data.links || [] );
 			setAvatarUrl( data.avatar_url || '' );
 			setLoading( false );
@@ -262,7 +260,6 @@ function EditProfileApp( {
 				client.execute< UserProfile >( 'extrachill/update-user-profile', {
 					custom_title: customTitle,
 					bio,
-					local_city: localCity,
 				} ),
 				client.execute( 'extrachill/update-user-links', { links } ),
 			] );
@@ -274,7 +271,7 @@ function EditProfileApp( {
 		}
 
 		setSaving( false );
-	}, [ customTitle, bio, localCity, links ] );
+	}, [ customTitle, bio, links ] );
 
 	if ( loading ) {
 		return (
@@ -338,15 +335,6 @@ function EditProfileApp( {
 												id="ec-bio"
 												value={ bio }
 												onChange={ ( e ) => setBio( e.target.value ) }
-											/>
-										</FieldGroup>
-										<FieldGroup label="Local Scene (City/Region)" htmlFor="ec-local-city">
-											<input
-												id="ec-local-city"
-												type="text"
-												value={ localCity }
-												onChange={ ( e ) => setLocalCity( e.target.value ) }
-												placeholder="Your local city/region..."
 											/>
 										</FieldGroup>
 									</Panel>

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -21,7 +21,7 @@ import type {
 const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
 const LOCATION_SEARCH_DEBOUNCE_MS = 250;
 
-interface EventLocation {
+interface LocalScene {
 	term_id: number;
 	name: string;
 	slug: string;
@@ -35,8 +35,8 @@ interface EventLocation {
 }
 
 interface EventLocationsResponse {
-	locations: EventLocation[];
-	location: EventLocation | null;
+	locations: LocalScene[];
+	location: LocalScene | null;
 }
 
 const styles = {
@@ -66,8 +66,10 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 	const [ firstName, setFirstName ] = useState( settings.first_name );
 	const [ lastName, setLastName ] = useState( settings.last_name );
 	const [ displayName, setDisplayName ] = useState( settings.display_name );
-	const [ defaultEventLocationSlug, setDefaultEventLocationSlug ] = useState< string | null >( settings.default_event_location?.slug ?? null );
-	const [ locationOptions, setLocationOptions ] = useState< Array<{ label: string; value: string }> >( settings.default_event_location ? [ { label: settings.default_event_location.name, value: settings.default_event_location.slug } ] : [] );
+	const [ localSceneSlug, setLocalSceneSlug ] = useState< string | null >( settings.local_scene?.slug ?? null );
+	const [ localSceneVisibility, setLocalSceneVisibility ] = useState( settings.local_scene_visibility );
+	const [ localSceneChanged, setLocalSceneChanged ] = useState( false );
+	const [ locationOptions, setLocationOptions ] = useState< Array<{ label: string; value: string }> >( settings.local_scene ? [ { label: settings.local_scene.hierarchy?.label ?? settings.local_scene.name, value: settings.local_scene.slug } ] : [] );
 	const [ locationSearchError, setLocationSearchError ] = useState( false );
 	const [ saving, setSaving ] = useState( false );
 	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
@@ -82,7 +84,7 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 		const trimmed = search.trim();
 		if ( ! trimmed ) {
 			setLocationSearchError( false );
-			setLocationOptions( settings.default_event_location ? [ { label: settings.default_event_location.name, value: settings.default_event_location.slug } ] : [] );
+			setLocationOptions( settings.local_scene ? [ { label: settings.local_scene.hierarchy?.label ?? settings.local_scene.name, value: settings.local_scene.slug } ] : [] );
 			return;
 		}
 
@@ -102,7 +104,7 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 				} );
 		}, LOCATION_SEARCH_DEBOUNCE_MS );
 
-	}, [ settings.default_event_location ] );
+	}, [ settings.local_scene ] );
 
 	useEffect( () => () => {
 		if ( locationSearchTimeout.current !== null ) {
@@ -114,15 +116,21 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 		setSaving( true );
 		setNotice( null );
 		try {
-			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', { first_name: firstName, last_name: lastName, display_name: displayName, default_event_location: defaultEventLocationSlug ?? '' } );
+			const input: Record<string, string> = { first_name: firstName, last_name: lastName, display_name: displayName, local_scene_visibility: localSceneVisibility };
+			if ( localSceneChanged ) {
+				input.local_scene = localSceneSlug ?? '';
+			}
+			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', input );
 			onUpdate( result );
-			setDefaultEventLocationSlug( result.default_event_location?.slug ?? null );
+			setLocalSceneSlug( result.local_scene?.slug ?? null );
+			setLocalSceneVisibility( result.local_scene_visibility );
+			setLocalSceneChanged( false );
 			setNotice( { type: 'success', message: result.message || 'Account details updated.' } );
 		} catch ( err ) {
 			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
 		}
 		setSaving( false );
-	}, [ firstName, lastName, displayName, defaultEventLocationSlug, onUpdate ] );
+	}, [ firstName, lastName, displayName, localSceneSlug, localSceneVisibility, localSceneChanged, onUpdate ] );
 
 	return (
 		<Panel>
@@ -138,17 +146,26 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 					{ settings.display_name_options.map( ( option ) => <option key={ option } value={ option }>{ option }</option> ) }
 				</select>
 			</FieldGroup>
-			<FieldGroup help="Used when you have not chosen an event location or shared your browser location. This does not change your public Local Scene.">
-				{ locationSearchError && <Notice type="error" message="Event market search is temporarily unavailable." /> }
+			<FieldGroup help="Choose the city or region that anchors your local music scene.">
+				{ locationSearchError && <Notice type="error" message="Local Scene search is temporarily unavailable." /> }
 				<ComboboxControl
-					label="Default Event Market"
-					value={ defaultEventLocationSlug }
+					label="Local Scene"
+					value={ localSceneSlug }
 					options={ locationOptions }
 					onFilterValueChange={ searchLocations }
-					onChange={ ( slug ) => setDefaultEventLocationSlug( slug ?? null ) }
+					onChange={ ( slug ) => {
+						setLocalSceneSlug( slug ?? null );
+						setLocalSceneChanged( true );
+					} }
 					allowReset={ true }
-					placeholder="Search event markets"
+					placeholder="Search cities and regions"
 				/>
+			</FieldGroup>
+			<FieldGroup help="Private scenes still personalize your event experience but do not appear on your public profile or forum posts.">
+				<label>
+					<input type="checkbox" checked={ localSceneVisibility === 'public' } onChange={ ( event ) => setLocalSceneVisibility( event.target.checked ? 'public' : 'private' ) } />
+					Show my Local Scene publicly
+				</label>
 			</FieldGroup>
 			<ActionRow>
 				<button className="button-1 button-small" style={ saving ? styles.button : undefined } onClick={ handleSave } disabled={ saving }>{ saving ? 'Saving...' : 'Save Account Details' }</button>

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -53,12 +53,17 @@ export interface LeaderboardResponse {
 
 // ─── User Settings ──────────────────────────────────────────────────────────
 
-export interface EventLocation {
+export interface LocalScene {
 	term_id: number;
 	name: string;
 	slug: string;
 	url: string;
 	coordinates: { lat: number; lon: number } | null;
+	hierarchy?: {
+		region: string;
+		state: string;
+		label: string;
+	};
 }
 
 export interface UserSettings {
@@ -69,7 +74,8 @@ export interface UserSettings {
 	display_name_options: string[];
 	email: string;
 	pending_email: string | null;
-	default_event_location: EventLocation | null;
+	local_scene: LocalScene | null;
+	local_scene_visibility: 'public' | 'private';
 }
 
 export interface ChangeEmailResponse {
@@ -105,7 +111,7 @@ export interface UserProfile {
 	avatar_url: string;
 	custom_title: string;
 	bio: string;
-	local_city: string;
+	local_scene?: LocalScene | null;
 	links: UserLink[];
 	link_types: Record<string, string>;
 	artist_access: ArtistAccessStatus;


### PR DESCRIPTION
## Summary
- replace free-text/default-market UI with the canonical Local Scene selector
- add a public visibility control independent of personalization
- remove duplicate Local Scene editing from Edit Profile
- route profile and forum displays through the visibility-filtered Users profile contract
- eliminate direct Community reads of `local_city`

## Verification
- `npm run build`
- changed PHP files pass `php -l`
- `git diff --check`
- repository-wide JS lint remains blocked by pre-existing parser/configuration failures

Depends on Extra-Chill/extrachill-users#184.
Fixes #162