### PR TITLE
feat: add festival-tagged community discussions

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -33,6 +33,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/assets.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/bbpress-templates.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-location.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-festival.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-artist.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/breadcrumb-filter.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/page-templates.php';

--- a/inc/abilities/community-taxonomy-counts.php
+++ b/inc/abilities/community-taxonomy-counts.php
@@ -2,10 +2,10 @@
 /**
  * Ability: extrachill/community-taxonomy-counts
  *
- * Return forum URL and topic count for a taxonomy term.
- * Used by cross-site linking — community forums are location hubs.
- * Canonical implementation — the REST route in extrachill-api refactors
- * to a thin shim that delegates here.
+ * Return a topic archive URL and topic count for a taxonomy term.
+ *
+ * Kept for existing consumers. Network cross-site linking uses the generic
+ * extrachill/taxonomy-post-counts ability, which has the same topic semantics.
  *
  * @package ExtraChillCommunity
  */
@@ -25,7 +25,7 @@ function extrachill_community_register_community_taxonomy_counts_ability(): void
 		'extrachill/community-taxonomy-counts',
 		array(
 			'label'               => __( 'Community Taxonomy Counts', 'extra-chill-community' ),
-			'description'         => __( 'Return forum URL and topic count for a taxonomy term (cross-site linking).', 'extra-chill-community' ),
+			'description'         => __( 'Return topic archive URL and topic count for a taxonomy term.', 'extra-chill-community' ),
 			'category'            => 'extrachill-community',
 			'input_schema'        => array(
 				'type'       => 'object',
@@ -72,13 +72,10 @@ function extrachill_community_register_community_taxonomy_counts_ability(): void
 // ─── Execute callback ──────────────────────────────────────────────────────────
 
 /**
- * Return forum data for a taxonomy term.
- *
- * Forums are location hubs, so we return the forum permalink and topic count
- * rather than a taxonomy archive URL.
+ * Return topic archive data for a taxonomy term.
  *
  * @param array $input Ability input with 'taxonomy' and 'slug'.
- * @return array|null|WP_Error Forum data or null if not found.
+ * @return array|null|WP_Error Topic archive data or null if not found.
  */
 function extrachill_community_ability_community_taxonomy_counts( array $input ): array|null|WP_Error {
 	$taxonomy = isset( $input['taxonomy'] ) ? sanitize_text_field( (string) $input['taxonomy'] ) : '';
@@ -97,11 +94,13 @@ function extrachill_community_ability_community_taxonomy_counts( array $input ):
 		return null;
 	}
 
-	$forums = get_posts(
+	$topic_query = new WP_Query(
 		array(
-			'post_type'      => 'forum',
+			'post_type'      => 'topic',
 			'post_status'    => 'publish',
 			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => false,
 			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				array(
 					'taxonomy' => $taxonomy,
@@ -111,29 +110,19 @@ function extrachill_community_ability_community_taxonomy_counts( array $input ):
 			),
 		)
 	);
-
-	if ( empty( $forums ) ) {
+	if ( $topic_query->found_posts < 1 ) {
 		return null;
 	}
 
-	$forum = $forums[0];
-
-	$topic_query = new WP_Query(
-		array(
-			'post_type'      => 'topic',
-			'post_status'    => 'publish',
-			'post_parent'    => $forum->ID,
-			'posts_per_page' => 1,
-			'fields'         => 'ids',
-			'no_found_rows'  => false,
-		)
-	);
-	$topic_count = $topic_query->found_posts;
+	$url = get_term_link( $term );
+	if ( is_wp_error( $url ) ) {
+		return null;
+	}
 
 	return array(
 		'slug'  => $term->slug,
 		'name'  => $term->name,
-		'count' => (int) $topic_count,
-		'url'   => get_permalink( $forum ),
+		'count' => (int) $topic_query->found_posts,
+		'url'   => $url,
 	);
 }

--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -5,7 +5,7 @@
  * Curated, pick-from-existing taxonomy tagging for the bbPress topic composer.
  *
  * Users tag their post with EXISTING curated network taxonomy terms (location
- * today; artist/festival/venue later) via an autocomplete React picker. The
+ * and festival today; artist/venue later) via an autocomplete React picker. The
  * picker searches terms through the WP REST API (NO AJAX, per the system-wide
  * rule) and submits the chosen term IDs as a hidden `${field}[]` array that the
  * server-side save handler assigns on bbp_new_topic / bbp_edit_topic.
@@ -14,8 +14,8 @@
  * mints nothing, so the network's shared taxonomy tree never drifts.
  *
  * Taxonomy-parameterized: the picker is driven by a config array (one entry per
- * taxonomy). Enabling artist/festival/venue later is a config addition here, not
- * a new component — build location only now, leave the seam.
+ * taxonomy). Enabling artist/venue later is a config addition here, not
+ * a new component.
  *
  * @package ExtraChillCommunity
  * @since 1.9.0
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Taxonomies the composer term-picker offers, in render order.
  *
- * Location-only today. To add artist/festival/venue later, append entries here
+ * Location and festival are available today. To add artist/venue later, append entries here
  * (and ensure each taxonomy is registered for `topic` and REST-enabled). No
  * React change required.
  *
@@ -50,12 +50,19 @@ function extrachill_community_term_picker_taxonomies() {
 			'placeholder' => __( 'Search locations (e.g. Charleston)…', 'extra-chill-community' ),
 			'field'       => 'bbp_topic_location',
 		),
+		array(
+			'taxonomy'    => 'festival',
+			'rest_base'   => 'festival',
+			'label'       => __( 'Festival', 'extra-chill-community' ),
+			'placeholder' => __( 'Search festivals (e.g. Bonnaroo)…', 'extra-chill-community' ),
+			'field'       => 'bbp_topic_festival',
+		),
 	);
 
 	/**
 	 * Filter the taxonomies offered by the composer term-picker.
 	 *
-	 * This is the generalization seam: artist/festival/venue can be enabled
+	 * This is the generalization seam: artist/venue can be enabled
 	 * later purely by extending this config (each must be registered for the
 	 * `topic` post type and REST-enabled).
 	 *

--- a/inc/core/taxonomy-festival.php
+++ b/inc/core/taxonomy-festival.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Festival Taxonomy Integration for bbPress Topics.
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+/**
+ * Attach the theme-owned festival taxonomy to bbPress topics.
+ *
+ * The theme registers the shared taxonomy with REST support. Community only
+ * adds its topic post type so terms retain the same network-wide identity.
+ */
+function extrachill_community_register_festival_for_topics() {
+	if ( taxonomy_exists( 'festival' ) ) {
+		register_taxonomy_for_object_type( 'festival', 'topic' );
+	}
+}
+add_action( 'init', 'extrachill_community_register_festival_for_topics', 20 );
+
+/**
+ * Persist existing festival terms selected in the bbPress topic composer.
+ *
+ * @param int $topic_id The topic ID.
+ */
+function extrachill_community_save_topic_festival( $topic_id ) {
+	if ( ! taxonomy_exists( 'festival' ) ) {
+		return;
+	}
+
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
+	$has_picker = isset( $_POST['bbp_topic_festival_submitted'] );
+	if ( ! $has_picker ) {
+		return;
+	}
+
+	$raw       = isset( $_POST['bbp_topic_festival'] ) ? wp_unslash( $_POST['bbp_topic_festival'] ) : array();
+	$submitted = is_array( $raw ) ? array_map( 'absint', $raw ) : array( absint( $raw ) );
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+	$term_ids = array();
+	foreach ( array_unique( array_filter( $submitted ) ) as $term_id ) {
+		$term = get_term( $term_id, 'festival' );
+		if ( $term && ! is_wp_error( $term ) ) {
+			$term_ids[] = (int) $term->term_id;
+		}
+	}
+
+	// Empty (or all-invalid) selection clears the festival.
+	wp_set_object_terms( $topic_id, $term_ids, 'festival' );
+}
+add_action( 'bbp_new_topic', 'extrachill_community_save_topic_festival', 20 );
+add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_festival', 20 );
+
+/**
+ * Make native festival archives list festival-tagged discussions.
+ *
+ * The shared taxonomy owns the stable /festival/<slug>/ URL. Community
+ * constrains its local archive query to the topic post type so the generic
+ * network taxonomy count ability and the destination describe the same terms.
+ *
+ * @param WP_Query $query The query being prepared.
+ */
+function extrachill_community_festival_archive_include_topics( $query ) {
+	if ( is_admin() || ! $query->is_main_query() || ! $query->is_tax( 'festival' ) ) {
+		return;
+	}
+
+	$query->set( 'post_type', array( 'topic' ) );
+	// bbPress topics are publish or closed; include both in the discussion view.
+	$query->set( 'post_status', array( 'publish', 'closed' ) );
+}
+add_action( 'pre_get_posts', 'extrachill_community_festival_archive_include_topics' );


### PR DESCRIPTION
## Summary
- Attach the shared REST-enabled `festival` taxonomy to bbPress topics and expose it in the existing curated composer term picker.
- Persist only existing festival term IDs and render the native `/festival/<slug>/` archive as the matching Community discussion listing, including closed topics.
- Replace the legacy forum-hub taxonomy count lookup with direct published-topic counts and the canonical term archive URL; topic subscriptions remain unchanged.

## Architecture
- Reuses WordPress taxonomy registration, term REST endpoints, `wp_set_object_terms()`, native taxonomy archives, and bbPress topic lifecycle hooks.
- The network's `extrachill/taxonomy-post-counts` primitive already resolves Community `topic` counts and native term URLs; no new cross-site API or search path was added.

## Validation
- `php -l` passed for all changed PHP files.
- `git diff --check` passed.
- `homeboy review audit extrachill-community --path . --changed-since origin/main --json-summary` passed with zero findings.
- `homeboy review test extrachill-community --path . --changed-since origin/main --json-summary` passed; this repository has no impacted tests for the changed scope.
- Homeboy PHPCS passed. PHPStan could not run because the installed Homeboy PHPStan PHAR exceeds its manifest limit; the validation `bbpress` checkout is also one commit stale. Local `npm run lint:js` cannot start because this worktree lacks `wp-scripts` in `node_modules`.

## Follow-up
- Add `community` to the `festival` entry in `extrachill-network`'s `extrachill_get_taxonomy_site_map()` after this destination ships, so festival pillars can render the Community discussion route. This PR intentionally does not modify that repository.

Closes #161