### PR TITLE
feat: notify festival subscribers about discussions

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -81,6 +81,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-replies.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-mentions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-subscriptions.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/capture-festival-topics.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/social/notifications/notifications-content.php';
 
 	require_once plugin_dir_path( __FILE__ ) . 'inc/user-profiles/contribution-heatmap.php';

--- a/inc/social/notifications/capture-festival-topics.php
+++ b/inc/social/notifications/capture-festival-topics.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Festival Topic Notification Capture.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Community's stable entity-subscription producer identifier.
+ */
+const EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-community';
+const EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META   = '_extrachill_community_festival_topic_notified';
+
+/**
+ * Authorize Community to resolve its festival notification recipients.
+ *
+ * @param bool   $authorized Whether the producer is authorized.
+ * @param string $producer   Producer identifier.
+ * @return bool
+ */
+function extrachill_community_authorize_festival_notification_producer( $authorized, $producer ) {
+	return $authorized || EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER === $producer;
+}
+add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_community_authorize_festival_notification_producer', 10, 2 );
+
+/**
+ * Notify festival subscribers when a new festival-tagged topic is published.
+ *
+ * This runs after the topic composer persists its festival terms. It intentionally
+ * observes only `bbp_new_topic`; replies and topic edits are handled separately.
+ *
+ * @param int $topic_id Topic post ID.
+ * @return void
+ */
+function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+		return;
+	}
+
+	$topic_id = (int) $topic_id;
+	if ( $topic_id <= 0 ) {
+		return;
+	}
+	if ( bbp_get_public_status_id() !== get_post_status( $topic_id ) || get_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META, true ) ) {
+		return;
+	}
+
+	$terms = get_the_terms( $topic_id, 'festival' );
+	if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		return;
+	}
+
+	$recipients = array();
+	foreach ( $terms as $term ) {
+		$ids = extrachill_users_entity_subscription_recipients(
+			EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER,
+			'festival',
+			'festival',
+			$term->slug,
+			'email'
+		);
+
+		if ( is_wp_error( $ids ) ) {
+			continue;
+		}
+
+		$recipients = array_merge( $recipients, $ids );
+	}
+
+	$author_id  = (int) get_post_field( 'post_author', $topic_id );
+	$recipients = array_values(
+		array_diff(
+			array_unique( array_map( 'absint', $recipients ) ),
+			array( $author_id, 0 )
+		)
+	);
+	if ( empty( $recipients ) ) {
+		return;
+	}
+
+	ec_users_notify(
+		$recipients,
+		array(
+			'actor_id' => $author_id,
+			'type'     => 'festival_discussion',
+			'title'    => get_the_title( $topic_id ),
+			'link'     => function_exists( 'bbp_get_topic_permalink' ) ? bbp_get_topic_permalink( $topic_id ) : get_permalink( $topic_id ),
+			'item_id'  => $topic_id,
+		)
+	);
+
+	// Keep a repeated bbPress new-topic action from creating duplicate notices.
+	update_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META, current_time( 'mysql', true ) );
+}
+add_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscribers', 30 );

--- a/scripts/smoke-festival-topic-notifications.php
+++ b/scripts/smoke-festival-topic-notifications.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Verify festival topic notification hooks without mutating site data.
+ *
+ * Run with: wp eval-file scripts/smoke-festival-topic-notifications.php
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	exit( 1 );
+}
+
+$authorized = apply_filters(
+	'extrachill_users_entity_subscription_producer_authorized',
+	false,
+	'extrachill-community',
+	array(
+		'entity_type' => 'festival',
+		'taxonomy'    => 'festival',
+		'slug'        => 'smoke-test',
+	),
+	'email'
+);
+
+if ( ! $authorized ) {
+	WP_CLI::error( 'Community festival notification producer is not authorized.' );
+}
+
+if ( 30 !== has_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscribers' ) ) {
+	WP_CLI::error( 'Festival topic notification capture is not registered.' );
+}
+
+if ( has_action( 'bbp_new_reply', 'extrachill_community_notify_festival_topic_subscribers' ) || has_action( 'bbp_edit_topic', 'extrachill_community_notify_festival_topic_subscribers' ) ) {
+	WP_CLI::error( 'Festival topic notification capture must only observe new topics.' );
+}
+
+WP_CLI::success( 'Festival topic notification smoke check passed.' );


### PR DESCRIPTION
## Summary
- authorize Community as a private entity-subscription producer and notify festival subscribers when a festival-tagged topic is first published
- resolve email-eligible recipients per festival slug, deduplicate them without exposing counts, and keep topic replies and edits out of this flow
- add a non-mutating WP-CLI smoke check for producer authorization and new-topic-only registration

## Verification
- `php -l inc/social/notifications/capture-festival-topics.php`
- `php -l scripts/smoke-festival-topic-notifications.php`
- `homeboy review extrachill-community audit --changed-since origin/main --path /var/lib/datamachine/workspace/extrachill-community@feat-festival-notifications-165`
- `homeboy review extrachill-community lint --changed-since origin/main --path /var/lib/datamachine/workspace/extrachill-community@feat-festival-notifications-165`
- `homeboy review extrachill-community test --changed-since origin/main --path /var/lib/datamachine/workspace/extrachill-community@feat-festival-notifications-165` (no impacted automated tests discovered)