### PR TITLE
feat: link Local Scene profile badges

### DIFF
--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -39,7 +39,10 @@ $has_about_content = ! empty( $about_description ) || ! empty( $about_local_scen
 			<?php endif; ?>
 
 			<?php if ( ! empty( $about_local_scene['name'] ) ) : ?>
-		<p class="bbp-user-local-scene-inline"><strong><?php esc_html_e( 'Local Scene:', 'extra-chill-community' ); ?></strong> <?php echo esc_html( $about_local_scene['name'] ); ?></p>
+		<div class="bbp-user-local-scene-inline">
+			<strong><?php esc_html_e( 'Local Scene', 'extra-chill-community' ); ?></strong>
+			<div class="taxonomy-badges"><?php extrachill_community_render_local_scene_badge( $about_local_scene ); ?></div>
+		</div>
 			<?php endif; ?>
 </div>
 <?php endif; // End has_about_content ?>

--- a/inc/social/rank-system/chill-forums-rank.php
+++ b/inc/social/rank-system/chill-forums-rank.php
@@ -27,7 +27,8 @@ function extrachill_add_rank_and_points_to_reply() {
 	$local_scene = extrachill_community_get_public_local_scene( $reply_author_id );
 	if ( ! empty( $local_scene['name'] ) ) {
 		echo '<div class="reply-author-local-scene">';
-		echo '<span>Local Scene:</span> ' . esc_html( $local_scene['name'] );
+		echo '<span>' . esc_html__( 'Local Scene:', 'extra-chill-community' ) . '</span> ';
+		extrachill_community_render_local_scene_badge( $local_scene, true );
 		echo '</div>';
 	}
 

--- a/inc/user-profiles/public-profile.php
+++ b/inc/user-profiles/public-profile.php
@@ -39,3 +39,33 @@ function extrachill_community_get_public_local_scene( $user_id ) {
 	$scenes[ $user_id ] = $scene;
 	return $scene;
 }
+
+/**
+ * Render a canonical Local Scene as a linked platform location badge.
+ *
+ * @param array $scene   Visibility-filtered Local Scene data.
+ * @param bool  $compact Whether to use only the city name.
+ */
+function extrachill_community_render_local_scene_badge( array $scene, bool $compact = false ): void {
+	$name      = sanitize_text_field( $scene['name'] ?? '' );
+	$hierarchy = is_array( $scene['hierarchy'] ?? null ) ? $scene['hierarchy'] : array();
+	$label     = $compact ? $name : sanitize_text_field( $hierarchy['label'] ?? $name );
+	$url       = esc_url( $scene['url'] ?? '' );
+	$slug      = sanitize_title( $scene['slug'] ?? '' );
+
+	if ( '' === $label ) {
+		return;
+	}
+
+	$classes = 'taxonomy-badge location-badge';
+	if ( '' !== $slug ) {
+		$classes .= ' location-' . sanitize_html_class( $slug );
+	}
+
+	if ( '' !== $url ) {
+		printf( '<a class="%1$s" href="%2$s">%3$s</a>', esc_attr( $classes ), $url, esc_html( $label ) );
+		return;
+	}
+
+	printf( '<span class="%1$s">%2$s</span>', esc_attr( $classes ), esc_html( $label ) );
+}


### PR DESCRIPTION
Render visibility-filtered Local Scenes as linked platform location badges. Full profiles use the canonical hierarchy label; forum metadata keeps the compact city name. Reuses existing taxonomy badge styling and adds no counts or popularity signals. Fixes #168.