### PR TITLE
feat: add Local Scene member archives

### DIFF
--- a/bbpress/user-profile.php
+++ b/bbpress/user-profile.php
@@ -40,7 +40,6 @@ $has_about_content = ! empty( $about_description ) || ! empty( $about_local_scen
 
 			<?php if ( ! empty( $about_local_scene['name'] ) ) : ?>
 		<div class="bbp-user-local-scene-inline">
-			<strong><?php esc_html_e( 'Local Scene', 'extra-chill-community' ); ?></strong>
 			<div class="taxonomy-badges"><?php extrachill_community_render_local_scene_badge( $about_local_scene ); ?></div>
 		</div>
 			<?php endif; ?>

--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -37,6 +37,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-artist.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/breadcrumb-filter.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/page-templates.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/local-scene-archives.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/bbpress-spam-adjustments.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/sidebar.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/nav.php';

--- a/inc/assets/css/local-scene.css
+++ b/inc/assets/css/local-scene.css
@@ -1,0 +1,42 @@
+.local-scene-archive {
+    max-width: var(--content-width);
+    margin: 0 auto;
+}
+
+.local-scene-header {
+    margin-bottom: var(--spacing-lg);
+}
+
+.local-scene-members {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--spacing-lg);
+}
+
+.local-scene-member-card {
+    display: flex;
+    gap: var(--spacing-md);
+    width: 100%;
+    margin: 0;
+}
+
+.local-scene-member-avatar img {
+    border-radius: var(--border-radius-circle);
+    display: block;
+    object-fit: cover;
+}
+
+.local-scene-member-details h2,
+.local-scene-member-details p {
+    margin-top: 0;
+}
+
+.local-scene-empty {
+    color: var(--muted-text);
+}
+
+@media (max-width: 768px) {
+    .local-scene-members {
+        grid-template-columns: 1fr;
+    }
+}

--- a/inc/core/assets.php
+++ b/inc/core/assets.php
@@ -41,6 +41,20 @@ function extrachill_enqueue_leaderboard_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'extrachill_enqueue_leaderboard_styles' );
 
+function extrachill_community_enqueue_local_scene_styles() {
+	if ( ! extrachill_community_is_local_scene_archive() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'extrachill-local-scene',
+		EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/css/local-scene.css',
+		array( 'extrachill-community-global' ),
+		filemtime( EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/css/local-scene.css' )
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_community_enqueue_local_scene_styles' );
+
 function enqueue_bbpress_global_styles() {
 	wp_register_style(
 		'extrachill-bbpress',

--- a/inc/core/local-scene-archives.php
+++ b/inc/core/local-scene-archives.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Virtual Local Scene member archives.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_COMMUNITY_LOCAL_SCENE_REWRITE_VERSION = '1';
+
+/**
+ * Limit the route to the Community site.
+ */
+function extrachill_community_is_community_site(): bool {
+	$community_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'community' ) : 2;
+	return (int) get_current_blog_id() === (int) $community_blog_id;
+}
+
+/**
+ * Register Local Scene archive rewrites.
+ */
+function extrachill_community_register_local_scene_rewrites(): void {
+	if ( ! extrachill_community_is_community_site() ) {
+		return;
+	}
+
+	add_rewrite_rule( '^local-scene/([^/]+)/?$', 'index.php?ec_local_scene=$matches[1]', 'top' );
+	add_rewrite_rule( '^local-scene/([^/]+)/page/([0-9]+)/?$', 'index.php?ec_local_scene=$matches[1]&paged=$matches[2]', 'top' );
+
+	if ( EXTRACHILL_COMMUNITY_LOCAL_SCENE_REWRITE_VERSION !== get_option( 'extrachill_community_local_scene_rewrite_version' ) ) {
+		flush_rewrite_rules( false );
+		update_option( 'extrachill_community_local_scene_rewrite_version', EXTRACHILL_COMMUNITY_LOCAL_SCENE_REWRITE_VERSION );
+	}
+}
+add_action( 'init', 'extrachill_community_register_local_scene_rewrites' );
+
+/**
+ * Register the route query variable.
+ *
+ * @param string[] $vars Public query variables.
+ * @return string[]
+ */
+function extrachill_community_local_scene_query_vars( array $vars ): array {
+	$vars[] = 'ec_local_scene';
+	return $vars;
+}
+add_filter( 'query_vars', 'extrachill_community_local_scene_query_vars' );
+
+function extrachill_community_is_local_scene_archive(): bool {
+	return extrachill_community_is_community_site() && '' !== (string) get_query_var( 'ec_local_scene', '' );
+}
+
+/**
+ * Make the virtual route a successful archive request.
+ *
+ * @param WP_Query $query Main query.
+ */
+function extrachill_community_local_scene_query( $query ): void {
+	if ( is_admin() || ! $query->is_main_query() || ! $query->get( 'ec_local_scene' ) ) {
+		return;
+	}
+
+	$query->is_404     = false;
+	$query->is_home    = false;
+	$query->is_archive = true;
+	status_header( 200 );
+}
+add_action( 'pre_get_posts', 'extrachill_community_local_scene_query' );
+
+/**
+ * Prevent core from turning a valid virtual archive into a 404.
+ *
+ * Invalid canonical scene slugs retain normal 404 handling.
+ *
+ * @param bool|null $preempt Existing preemption result.
+ * @param WP_Query  $query   Main query.
+ * @return bool|null
+ */
+function extrachill_community_local_scene_pre_handle_404( $preempt, $query ) {
+	if ( ! $query->get( 'ec_local_scene' ) ) {
+		return $preempt;
+	}
+
+	$data = extrachill_community_get_local_scene_archive_data();
+	if ( is_wp_error( $data ) ) {
+		return $preempt;
+	}
+
+	status_header( 200 );
+	return true;
+}
+add_filter( 'pre_handle_404', 'extrachill_community_local_scene_pre_handle_404', 10, 2 );
+
+/**
+ * Execute the Users-owned public member query once per request.
+ *
+ * @return array|WP_Error
+ */
+function extrachill_community_get_local_scene_archive_data() {
+	static $data;
+	static $loaded = false;
+
+	if ( $loaded ) {
+		return $data;
+	}
+	$loaded = true;
+
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		$data = new WP_Error( 'ability_unavailable', __( 'Local Scene members are temporarily unavailable.', 'extra-chill-community' ) );
+		return $data;
+	}
+
+	$ability = wp_get_ability( 'extrachill/local-scene-members' );
+	if ( ! $ability ) {
+		$data = new WP_Error( 'ability_unavailable', __( 'Local Scene members are temporarily unavailable.', 'extra-chill-community' ) );
+		return $data;
+	}
+
+	$data = $ability->execute(
+		array(
+			'slug'     => sanitize_title( get_query_var( 'ec_local_scene' ) ),
+			'page'     => max( 1, absint( get_query_var( 'paged', 1 ) ) ),
+			'per_page' => 24,
+		)
+	);
+
+	return $data;
+}
+
+function extrachill_community_get_local_scene_url( string $slug, int $page = 1 ): string {
+	$base = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url( '/' );
+	$url  = trailingslashit( $base ) . 'local-scene/' . sanitize_title( $slug ) . '/';
+	return $page > 1 ? $url . 'page/' . $page . '/' : $url;
+}
+
+/**
+ * Load the Community-owned presentation template.
+ */
+function extrachill_community_local_scene_template( string $template ): string {
+	return extrachill_community_is_local_scene_archive()
+		? EXTRACHILL_COMMUNITY_PLUGIN_DIR . 'page-templates/local-scene-archive.php'
+		: $template;
+}
+add_filter( 'extrachill_template_archive', 'extrachill_community_local_scene_template' );
+
+/**
+ * Use the canonical hierarchy label in the document title.
+ *
+ * @param array $parts Document title parts.
+ * @return array
+ */
+function extrachill_community_local_scene_title( array $parts ): array {
+	if ( ! extrachill_community_is_local_scene_archive() ) {
+		return $parts;
+	}
+
+	$data  = extrachill_community_get_local_scene_archive_data();
+	$scene = is_array( $data ) && is_array( $data['scene'] ?? null ) ? $data['scene'] : array();
+	$label = sanitize_text_field( $scene['hierarchy']['label'] ?? $scene['name'] ?? '' );
+	if ( '' !== $label ) {
+		/* translators: %s: canonical Local Scene hierarchy label. */
+		$parts['title'] = sprintf( __( 'People in %s', 'extra-chill-community' ), $label );
+	}
+
+	return $parts;
+}
+add_filter( 'document_title_parts', 'extrachill_community_local_scene_title', 1000 );
+
+function extrachill_community_local_scene_canonical( string $canonical ): string {
+	if ( ! extrachill_community_is_local_scene_archive() ) {
+		return $canonical;
+	}
+
+	return extrachill_community_get_local_scene_url(
+		sanitize_title( get_query_var( 'ec_local_scene' ) ),
+		max( 1, absint( get_query_var( 'paged', 1 ) ) )
+	);
+}
+add_filter( 'extrachill_seo_canonical_url', 'extrachill_community_local_scene_canonical' );
+
+function extrachill_community_local_scene_redirect_canonical( $redirect_url ) {
+	return extrachill_community_is_local_scene_archive() ? false : $redirect_url;
+}
+add_filter( 'redirect_canonical', 'extrachill_community_local_scene_redirect_canonical' );

--- a/inc/social/rank-system/chill-forums-rank.php
+++ b/inc/social/rank-system/chill-forums-rank.php
@@ -27,7 +27,6 @@ function extrachill_add_rank_and_points_to_reply() {
 	$local_scene = extrachill_community_get_public_local_scene( $reply_author_id );
 	if ( ! empty( $local_scene['name'] ) ) {
 		echo '<div class="reply-author-local-scene">';
-		echo '<span>' . esc_html__( 'Local Scene:', 'extra-chill-community' ) . '</span> ';
 		extrachill_community_render_local_scene_badge( $local_scene, true );
 		echo '</div>';
 	}

--- a/inc/user-profiles/public-profile.php
+++ b/inc/user-profiles/public-profile.php
@@ -50,8 +50,9 @@ function extrachill_community_render_local_scene_badge( array $scene, bool $comp
 	$name      = sanitize_text_field( $scene['name'] ?? '' );
 	$hierarchy = is_array( $scene['hierarchy'] ?? null ) ? $scene['hierarchy'] : array();
 	$label     = $compact ? $name : sanitize_text_field( $hierarchy['label'] ?? $name );
-	$url       = esc_url( $scene['url'] ?? '' );
 	$slug      = sanitize_title( $scene['slug'] ?? '' );
+	$url       = '' !== $slug ? extrachill_community_get_local_scene_url( $slug ) : '';
+	$aria      = sprintf( 'Local Scene: %s', $label );
 
 	if ( '' === $label ) {
 		return;
@@ -63,9 +64,9 @@ function extrachill_community_render_local_scene_badge( array $scene, bool $comp
 	}
 
 	if ( '' !== $url ) {
-		printf( '<a class="%1$s" href="%2$s">%3$s</a>', esc_attr( $classes ), $url, esc_html( $label ) );
+		printf( '<a class="%1$s" href="%2$s" aria-label="%3$s">%4$s</a>', esc_attr( $classes ), esc_url( $url ), esc_attr( $aria ), esc_html( $label ) );
 		return;
 	}
 
-	printf( '<span class="%1$s">%2$s</span>', esc_attr( $classes ), esc_html( $label ) );
+	printf( '<span class="%1$s" aria-label="%2$s">%3$s</span>', esc_attr( $classes ), esc_attr( $aria ), esc_html( $label ) );
 }

--- a/page-templates/local-scene-archive.php
+++ b/page-templates/local-scene-archive.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Local Scene member archive template.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$data       = extrachill_community_get_local_scene_archive_data();
+$scene      = is_array( $data ) && is_array( $data['scene'] ?? null ) ? $data['scene'] : array();
+$members    = is_array( $data ) && is_array( $data['members'] ?? null ) ? $data['members'] : array();
+$pagination = is_array( $data ) && is_array( $data['pagination'] ?? null ) ? $data['pagination'] : array();
+$label      = sanitize_text_field( $scene['hierarchy']['label'] ?? $scene['name'] ?? get_query_var( 'ec_local_scene' ) );
+$events_url = esc_url( $scene['url'] ?? '' );
+
+get_header();
+do_action( 'extrachill_before_body_content' );
+extrachill_breadcrumbs();
+?>
+<main class="local-scene-archive ec-mobile-full-width-panel">
+	<header class="local-scene-header">
+		<?php /* translators: %s: canonical Local Scene hierarchy label. */ ?>
+		<h1><?php echo esc_html( sprintf( __( 'People in %s', 'extra-chill-community' ), $label ) ); ?></h1>
+		<?php if ( $events_url ) : ?>
+			<?php /* translators: %s: Local Scene city name. */ ?>
+			<a href="<?php echo esc_url( $events_url ); ?>"><?php echo esc_html( sprintf( __( 'Live music in %s', 'extra-chill-community' ), $scene['name'] ?? $label ) ); ?></a>
+		<?php endif; ?>
+	</header>
+
+	<?php if ( is_wp_error( $data ) ) : ?>
+		<p class="local-scene-empty"><?php echo esc_html( $data->get_error_message() ); ?></p>
+	<?php elseif ( empty( $members ) ) : ?>
+		<p class="local-scene-empty"><?php esc_html_e( 'No public members have joined this Local Scene yet.', 'extra-chill-community' ); ?></p>
+	<?php else : ?>
+		<div class="local-scene-members">
+			<?php
+			foreach ( $members as $member ) :
+				$name         = sanitize_text_field( $member['display_name'] ?? '' );
+				$profile_url  = esc_url( $member['profile_url'] ?? '' );
+				$member_title = sanitize_text_field( $member['custom_title'] ?? '' );
+				if ( '' === $member_title ) {
+					$member_title = sanitize_text_field( $member['rank'] ?? '' );
+				}
+				$bio = sanitize_textarea_field( $member['bio'] ?? '' );
+				?>
+				<article class="bbp-user-profile-card local-scene-member-card">
+					<a class="local-scene-member-avatar" href="<?php echo esc_url( $profile_url ); ?>">
+						<img src="<?php echo esc_url( $member['avatar_url'] ?? '' ); ?>" alt="" width="96" height="96" loading="lazy">
+					</a>
+					<div class="local-scene-member-details">
+						<h2><a href="<?php echo esc_url( $profile_url ); ?>"><?php echo esc_html( $name ); ?></a></h2>
+						<?php if ( $member_title ) : ?>
+							<p class="user-custom-title"><?php echo esc_html( $member_title ); ?></p>
+						<?php endif; ?>
+						<?php if ( $bio ) : ?>
+							<p><?php echo esc_html( wp_trim_words( $bio, 28 ) ); ?></p>
+						<?php endif; ?>
+					</div>
+				</article>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
+
+	<?php
+	if ( ! empty( $pagination ) && function_exists( 'extrachill_pagination' ) ) {
+		extrachill_pagination(
+			array(
+				'current_page' => absint( $pagination['page'] ?? 1 ),
+				'total_pages'  => absint( $pagination['total_pages'] ?? 1 ),
+				'total_items'  => absint( $pagination['total'] ?? 0 ),
+				'per_page'     => absint( $pagination['per_page'] ?? 24 ),
+			),
+			'local-scene',
+			'member'
+		);
+	}
+	?>
+</main>
+<?php
+get_footer();


### PR DESCRIPTION
Adds privacy-filtered `/local-scene/{slug}/` member archives backed exclusively by the Users Ability. Includes paginated member cards, canonical titles/URLs, Events links, accessible badge routing, and removes redundant visible Local Scene labels. Fixes #170.