### PR TITLE
fix: style Local Scene member cards

### DIFF
--- a/inc/assets/css/local-scene.css
+++ b/inc/assets/css/local-scene.css
@@ -15,20 +15,52 @@
 
 .local-scene-member-card {
     display: flex;
+    align-items: center;
     gap: var(--spacing-md);
     width: 100%;
-    margin: 0;
+    min-width: 0;
+    padding: var(--spacing-md);
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-sm);
+    box-shadow: var(--card-shadow);
+    box-sizing: border-box;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.local-scene-member-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--card-hover-shadow);
 }
 
 .local-scene-member-avatar img {
-    border-radius: var(--border-radius-circle);
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
     display: block;
     object-fit: cover;
 }
 
-.local-scene-member-details h2,
-.local-scene-member-details p {
-    margin-top: 0;
+.local-scene-member-details {
+    min-width: 0;
+}
+
+.local-scene-member-name {
+    margin: 0;
+    font-size: var(--font-size-lg);
+    line-height: 1.25;
+}
+
+.local-scene-member-name a {
+    color: var(--accent-2);
+    text-decoration: none;
+}
+
+.local-scene-member-title {
+    margin: var(--spacing-xs) 0 0;
+    color: var(--muted-text);
+    font-size: var(--font-size-sm);
+    line-height: 1.3;
 }
 
 .local-scene-empty {

--- a/page-templates/local-scene-archive.php
+++ b/page-templates/local-scene-archive.php
@@ -42,19 +42,15 @@ extrachill_breadcrumbs();
 				if ( '' === $member_title ) {
 					$member_title = sanitize_text_field( $member['rank'] ?? '' );
 				}
-				$bio = sanitize_textarea_field( $member['bio'] ?? '' );
 				?>
-				<article class="bbp-user-profile-card local-scene-member-card">
+				<article class="local-scene-member-card">
 					<a class="local-scene-member-avatar" href="<?php echo esc_url( $profile_url ); ?>">
 						<img src="<?php echo esc_url( $member['avatar_url'] ?? '' ); ?>" alt="" width="96" height="96" loading="lazy">
 					</a>
 					<div class="local-scene-member-details">
-						<h2><a href="<?php echo esc_url( $profile_url ); ?>"><?php echo esc_html( $name ); ?></a></h2>
+						<h2 class="local-scene-member-name"><a href="<?php echo esc_url( $profile_url ); ?>"><?php echo esc_html( $name ); ?></a></h2>
 						<?php if ( $member_title ) : ?>
-							<p class="user-custom-title"><?php echo esc_html( $member_title ); ?></p>
-						<?php endif; ?>
-						<?php if ( $bio ) : ?>
-							<p><?php echo esc_html( wp_trim_words( $bio, 28 ) ); ?></p>
+							<p class="local-scene-member-title"><?php echo esc_html( $member_title ); ?></p>
 						<?php endif; ?>
 					</div>
 				</article>


### PR DESCRIPTION
Makes Local Scene member cards self-contained instead of depending on profile-only `bbp-user-profile-card` CSS. Adds visible card surfaces, borders, shadows, compact avatars, names, and titles/ranks while removing uneven directory bios. Fixes #172.