### PR TITLE
Heatmap year navigation back to the user's join year

### DIFF
--- a/inc/assets/css/user-profile.css
+++ b/inc/assets/css/user-profile.css
@@ -549,6 +549,36 @@
 	background-color: var(--accent);
 }
 
+/* Year navigation: trailing-window default + one tab per calendar year back
+   to the user's join year. */
+.ec-heatmap-years {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	margin-bottom: 0.75rem;
+}
+
+.ec-heatmap-year {
+	font-size: var(--font-size-xs);
+	padding: 2px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm);
+	color: var(--muted-text);
+	text-decoration: none;
+}
+
+.ec-heatmap-year:hover {
+	border-color: var(--accent);
+	color: var(--text-color);
+}
+
+.ec-heatmap-year.is-active {
+	background: var(--accent);
+	border-color: var(--accent);
+	color: var(--background-color, #fff);
+	pointer-events: none;
+}
+
 /* Hover/focus affordance on day cells. */
 .ec-heatmap-cells .ec-heat-cell {
 	cursor: default;

--- a/inc/social/rank-system/contribution-calendar-ability.php
+++ b/inc/social/rank-system/contribution-calendar-ability.php
@@ -54,23 +54,57 @@ const EC_CONTRIB_CALENDAR_CACHE_TTL = HOUR_IN_SECONDS;
  *                     bypass the cache (the card always uses the default).
  * @return array Calendar payload.
  */
-function extrachill_community_get_contribution_calendar( $user_id, $days = 365 ) {
+function extrachill_community_get_contribution_calendar( $user_id, $days = 365, $year = 0 ) {
 	$user_id = (int) $user_id;
 	$days    = max( 1, (int) $days );
+	$year    = (int) $year;
 
-	// Grid columns: full weeks needed to cover the window, capped at one year.
-	$weeks = (int) ceil( $days / 7 );
-	if ( $weeks > 53 ) {
-		$weeks = 53;
-	}
-	if ( $weeks < 1 ) {
-		$weeks = 1;
+	try {
+		$today = current_datetime(); // DateTimeImmutable in site timezone.
+	} catch ( Exception $e ) {
+		$today = new DateTimeImmutable( 'now', wp_timezone() );
 	}
 
-	// Only the canonical one-year window is cached; custom windows compute live
-	// so a transient keyed by user_id can never serve a stale window size.
-	$use_cache = ( 365 === $days );
-	$cache_key = 'ec_contrib_calendar_' . $user_id;
+	$current_year = (int) $today->format( 'Y' );
+
+	// A $year at or beyond the current year is the trailing-window view.
+	if ( $year >= $current_year ) {
+		$year = 0;
+	}
+
+	if ( $year > 0 ) {
+		// Calendar-year mode (Jan 1 – Dec 31 of a past year, GitHub's year
+		// tabs). Grid runs from the Sunday on/before Jan 1 through Dec 31.
+		$tz         = wp_timezone();
+		$jan_first  = new DateTimeImmutable( sprintf( '%d-01-01', $year ), $tz );
+		$dec_last   = new DateTimeImmutable( sprintf( '%d-12-31', $year ), $tz );
+		$start_dow  = (int) $jan_first->format( 'w' );
+		$first_sunday = $jan_first->modify( '-' . $start_dow . ' days' );
+		$grid_end     = $dec_last;
+
+		$weeks = (int) ceil( ( $first_sunday->diff( $dec_last )->days + 1 ) / 7 );
+	} else {
+		// Trailing-window mode (default): last $days ending today.
+		$weeks = (int) ceil( $days / 7 );
+		if ( $weeks > 53 ) {
+			$weeks = 53;
+		}
+		if ( $weeks < 1 ) {
+			$weeks = 1;
+		}
+
+		$dow          = (int) $today->format( 'w' ); // 0 = Sunday … 6 = Saturday.
+		$last_sunday  = $today->modify( '-' . $dow . ' days' );
+		$first_sunday = $last_sunday->modify( '-' . ( ( $weeks - 1 ) * 7 ) . ' days' );
+		$grid_end     = $today;
+	}
+
+	// Cache the canonical trailing-year view and past calendar years (which
+	// are immutable outside backfills). Custom day windows compute live.
+	$use_cache = ( $year > 0 ) || ( 365 === $days );
+	$cache_key = $year > 0
+		? 'ec_contrib_calendar_' . $user_id . '_y' . $year
+		: 'ec_contrib_calendar_' . $user_id;
 
 	if ( $use_cache ) {
 		$cached = get_transient( $cache_key );
@@ -79,18 +113,8 @@ function extrachill_community_get_contribution_calendar( $user_id, $days = 365 )
 		}
 	}
 
-	try {
-		$today = current_datetime(); // DateTimeImmutable in site timezone.
-	} catch ( Exception $e ) {
-		$today = new DateTimeImmutable( 'now', wp_timezone() );
-	}
-
-	$dow          = (int) $today->format( 'w' ); // 0 = Sunday … 6 = Saturday.
-	$last_sunday  = $today->modify( '-' . $dow . ' days' );
-	$first_sunday = $last_sunday->modify( '-' . ( ( $weeks - 1 ) * 7 ) . ' days' );
-
 	$window_start = $first_sunday->format( 'Y-m-d' );
-	$window_end   = $today->format( 'Y-m-d' );
+	$window_end   = $grid_end->format( 'Y-m-d' );
 
 	// Consume the dated-contributions seam. The seam merges every registered
 	// source (forum, main posts, concerts) and converts UTC → site-local day.
@@ -117,18 +141,33 @@ function extrachill_community_get_contribution_calendar( $user_id, $days = 365 )
 		}
 	}
 
+	// Calendar-year mode: trim events that belong to the year window's leading
+	// pre-January Sunday padding or trail past Dec 31 (the seam only filters
+	// by the lower bound).
+	if ( $year > 0 ) {
+		$year_start = sprintf( '%d-01-01', $year );
+		foreach ( array_keys( $counts ) as $day ) {
+			if ( $day < $year_start ) {
+				unset( $counts[ $day ] );
+			}
+		}
+	}
+
 	ksort( $counts );
 
 	$total        = array_sum( $counts );
 	$max_day_count = $counts ? (int) max( $counts ) : 0;
 
-	$current_streak = extrachill_community_count_current_streak( $counts, $today );
-	$longest_streak = extrachill_community_count_longest_streak( $counts, $first_sunday, $today );
+	// Streaks are relative to the displayed window. The "current" streak only
+	// makes sense in the trailing view; a past year shows longest only.
+	$current_streak = ( $year > 0 ) ? 0 : extrachill_community_count_current_streak( $counts, $today );
+	$longest_streak = extrachill_community_count_longest_streak( $counts, $first_sunday, $grid_end );
 
 	$payload = array(
 		'user_id'             => $user_id,
 		'days'                => $days,
 		'weeks'               => $weeks,
+		'year'                => $year,
 		'first_sunday'        => $window_start,
 		'window_start'        => $window_start,
 		'window_end'          => $window_end,
@@ -220,7 +259,11 @@ function extrachill_community_register_contribution_calendar_ability() {
 					),
 					'days'    => array(
 						'type'        => 'integer',
-						'description' => __( 'Window length in days (default 365).', 'extra-chill-community' ),
+						'description' => __( 'Window length in days (default 365). Ignored when year is set.', 'extra-chill-community' ),
+					),
+					'year'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Past calendar year (Jan 1 – Dec 31). Omit or 0 for the trailing window.', 'extra-chill-community' ),
 					),
 				),
 				'required'   => array( 'user_id' ),
@@ -231,6 +274,7 @@ function extrachill_community_register_contribution_calendar_ability() {
 					'user_id'             => array( 'type' => 'integer' ),
 					'days'                => array( 'type' => 'integer' ),
 					'weeks'               => array( 'type' => 'integer' ),
+					'year'                => array( 'type' => 'integer' ),
 					'first_sunday'        => array( 'type' => 'string' ),
 					'window_start'        => array( 'type' => 'string' ),
 					'window_end'          => array( 'type' => 'string' ),
@@ -280,6 +324,7 @@ function extrachill_community_ability_get_contribution_calendar( $input ) {
 	}
 
 	$days = isset( $input['days'] ) ? (int) $input['days'] : 365;
+	$year = isset( $input['year'] ) ? (int) $input['year'] : 0;
 
-	return extrachill_community_get_contribution_calendar( $user_id, $days );
+	return extrachill_community_get_contribution_calendar( $user_id, $days, $year );
 }

--- a/inc/user-profiles/contribution-heatmap.php
+++ b/inc/user-profiles/contribution-heatmap.php
@@ -90,7 +90,26 @@ function ec_community_display_contribution_heatmap() {
 		return;
 	}
 
-	$calendar = extrachill_community_get_contribution_calendar( (int) $user_id );
+	try {
+		$now = current_datetime();
+	} catch ( Exception $e ) {
+		$now = new DateTimeImmutable( 'now', wp_timezone() );
+	}
+	$current_year = (int) $now->format( 'Y' );
+
+	// Year navigation: ?contrib_year=YYYY selects a past calendar year.
+	// Valid years span the user's registration year through last year; the
+	// default (no param / invalid) is the trailing 12-month view.
+	$join_year = 0;
+	$user_data = get_userdata( (int) $user_id );
+	if ( $user_data && ! empty( $user_data->user_registered ) ) {
+		$join_year = (int) get_date_from_gmt( $user_data->user_registered, 'Y' );
+	}
+
+	$requested_year = isset( $_GET['contrib_year'] ) ? (int) $_GET['contrib_year'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only view selector on a public profile.
+	$selected_year  = ( $requested_year >= $join_year && $join_year > 0 && $requested_year < $current_year ) ? $requested_year : 0;
+
+	$calendar = extrachill_community_get_contribution_calendar( (int) $user_id, 365, $selected_year );
 	if ( ! is_array( $calendar ) ) {
 		return;
 	}
@@ -109,8 +128,11 @@ function ec_community_display_contribution_heatmap() {
 		return;
 	}
 
+	// Cell emission stops at the window end: today for the trailing view,
+	// Dec 31 for a selected past year.
+	$window_end_ymd = isset( $calendar['window_end'] ) ? (string) $calendar['window_end'] : '';
 	try {
-		$today = current_datetime();
+		$today = '' !== $window_end_ymd ? new DateTimeImmutable( $window_end_ymd, wp_timezone() ) : current_datetime();
 	} catch ( Exception $e ) {
 		$today = new DateTimeImmutable( 'now', wp_timezone() );
 	}
@@ -139,24 +161,37 @@ function ec_community_display_contribution_heatmap() {
 			<span class="ec-heatmap-total">
 				<strong><?php echo esc_html( number_format_i18n( $total ) ); ?></strong>
 				<?php
-				echo esc_html(
-					sprintf(
-						/* translators: %s: localized description of the window. */
-						_n( 'contribution in the last year', 'contributions in the last year', $total, 'extra-chill-community' ),
-						''
-					)
-				);
+				if ( $selected_year > 0 ) {
+					echo esc_html(
+						sprintf(
+							/* translators: 1: contribution count context, 2: year. */
+							_n( 'contribution in %2$d', 'contributions in %2$d', $total, 'extra-chill-community' ),
+							'',
+							$selected_year
+						)
+					);
+				} else {
+					echo esc_html(
+						sprintf(
+							/* translators: %s: localized description of the window. */
+							_n( 'contribution in the last year', 'contributions in the last year', $total, 'extra-chill-community' ),
+							''
+						)
+					);
+				}
 				?>
 			</span>
 			<span class="ec-heatmap-streaks">
-				<?php
-				printf(
-					/* translators: %d: day count. */
-					esc_html__( 'Current streak: %d days', 'extra-chill-community' ),
-					(int) $current
-				);
-				?>
-				<span class="ec-heatmap-streak-sep" aria-hidden="true">·</span>
+				<?php if ( 0 === $selected_year ) : ?>
+					<?php
+					printf(
+						/* translators: %d: day count. */
+						esc_html__( 'Current streak: %d days', 'extra-chill-community' ),
+						(int) $current
+					);
+					?>
+					<span class="ec-heatmap-streak-sep" aria-hidden="true">·</span>
+				<?php endif; ?>
 				<?php
 				printf(
 					/* translators: %d: day count. */
@@ -167,8 +202,27 @@ function ec_community_display_contribution_heatmap() {
 			</span>
 		</div>
 
+		<?php
+		// Year navigation: only when the user has history beyond the trailing
+		// window (joined before the current year).
+		if ( $join_year > 0 && $join_year < $current_year ) :
+			$profile_url = bbp_get_user_profile_url( (int) $user_id );
+			?>
+			<nav class="ec-heatmap-years" aria-label="<?php esc_attr_e( 'Contribution activity by year', 'extra-chill-community' ); ?>">
+				<a href="<?php echo esc_url( $profile_url ); ?>" class="ec-heatmap-year<?php echo 0 === $selected_year ? ' is-active' : ''; ?>"<?php echo 0 === $selected_year ? ' aria-current="true"' : ''; ?>><?php esc_html_e( 'Last year', 'extra-chill-community' ); ?></a>
+				<?php for ( $y = $current_year - 1; $y >= $join_year; $y-- ) : ?>
+					<a href="<?php echo esc_url( add_query_arg( 'contrib_year', $y, $profile_url ) ); ?>" class="ec-heatmap-year<?php echo $y === $selected_year ? ' is-active' : ''; ?>"<?php echo $y === $selected_year ? ' aria-current="true"' : ''; ?>><?php echo esc_html( (string) $y ); ?></a>
+				<?php endfor; ?>
+			</nav>
+		<?php endif; ?>
+
 		<div class="ec-heatmap-scroll">
-			<div class="ec-heatmap" role="img" style="--ec-heat-weeks:<?php echo (int) $weeks; ?>;" aria-label="<?php echo esc_attr( sprintf( /* translators: %d: total contribution count. */ __( '%d contributions in the last year', 'extra-chill-community' ), $total ) ); ?>">
+			<?php
+			$grid_aria_label = $selected_year > 0
+				? sprintf( /* translators: 1: total contribution count, 2: year. */ __( '%1$d contributions in %2$d', 'extra-chill-community' ), $total, $selected_year )
+				: sprintf( /* translators: %d: total contribution count. */ __( '%d contributions in the last year', 'extra-chill-community' ), $total );
+			?>
+			<div class="ec-heatmap" role="img" style="--ec-heat-weeks:<?php echo (int) $weeks; ?>;" aria-label="<?php echo esc_attr( $grid_aria_label ); ?>">
 				<div class="ec-heatmap-corner" aria-hidden="true"></div>
 
 				<div class="ec-heatmap-months" style="grid-template-columns:repeat(<?php echo (int) $weeks; ?>,var(--ec-heat-cell));">


### PR DESCRIPTION
## Summary
- Adds GitHub-style year tabs to the profile contribution heatmap: **Last year** (trailing 53-week default) plus one tab per calendar year back to the user's registration year, via `?contrib_year=YYYY`.
- Calendar builder gains a calendar-year mode: Sunday-aligned Jan 1 – Dec 31 grid, leading-padding events trimmed, cell emission stops at Dec 31, current streak suppressed for past years (longest only), summary/aria text adapts.
- Past-year payloads cached under `ec_contrib_calendar_{user}_y{year}` keys; `extrachill/get-user-contribution-calendar` ability schema exposes the new `year` input.
- Nav only renders for users who joined before the current year; years outside join-year..last-year clamp to the trailing view.

## Verified
- 2023: `start=2023-01-01 end=2023-12-31`, 288 contributions, streaks correct
- Trailing view unchanged; future/pre-join years clamp safely