### PR TITLE
feat: add artist-tagged community discussions

### DIFF
--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -5,7 +5,7 @@
  * Curated, pick-from-existing taxonomy tagging for the bbPress topic composer.
  *
  * Users tag their post with EXISTING curated network taxonomy terms (location
- * and festival today; artist/venue later) via an autocomplete React picker. The
+ * festival, and artist) via an autocomplete React picker. The
  * picker searches terms through the WP REST API (NO AJAX, per the system-wide
  * rule) and submits the chosen term IDs as a hidden `${field}[]` array that the
  * server-side save handler assigns on bbp_new_topic / bbp_edit_topic.
@@ -14,8 +14,8 @@
  * mints nothing, so the network's shared taxonomy tree never drifts.
  *
  * Taxonomy-parameterized: the picker is driven by a config array (one entry per
- * taxonomy). Enabling artist/venue later is a config addition here, not
- * a new component.
+ * taxonomy). Enabling another taxonomy is a config addition here, not a new
+ * component.
  *
  * @package ExtraChillCommunity
  * @since 1.9.0
@@ -28,9 +28,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Taxonomies the composer term-picker offers, in render order.
  *
- * Location and festival are available today. To add artist/venue later, append entries here
- * (and ensure each taxonomy is registered for `topic` and REST-enabled). No
- * React change required.
+ * Each taxonomy must be registered for `topic` and REST-enabled. No React
+ * change is required to add a future taxonomy.
  *
  * Each entry:
  * - taxonomy     Taxonomy slug.
@@ -57,14 +56,21 @@ function extrachill_community_term_picker_taxonomies() {
 			'placeholder' => __( 'Search festivals (e.g. Bonnaroo)…', 'extra-chill-community' ),
 			'field'       => 'bbp_topic_festival',
 		),
+		array(
+			'taxonomy'    => 'artist',
+			'rest_base'   => 'artist',
+			'label'       => __( 'Artist', 'extra-chill-community' ),
+			'placeholder' => __( 'Search artists…', 'extra-chill-community' ),
+			'field'       => 'bbp_topic_artist',
+		),
 	);
 
 	/**
 	 * Filter the taxonomies offered by the composer term-picker.
 	 *
-	 * This is the generalization seam: artist/venue can be enabled
-	 * later purely by extending this config (each must be registered for the
-	 * `topic` post type and REST-enabled).
+	 * This is the generalization seam: future taxonomies can be enabled purely
+	 * by extending this config (each must be registered for the `topic` post
+	 * type and REST-enabled).
 	 *
 	 * @param array $taxonomies Taxonomy picker config.
 	 */

--- a/inc/core/taxonomy-artist.php
+++ b/inc/core/taxonomy-artist.php
@@ -2,13 +2,11 @@
 /**
  * Artist Taxonomy Integration for bbPress
  *
- * Registers the shared 'artist' taxonomy (defined in the Extra Chill theme)
- * for bbPress topics, enabling artist-based identity on forum content. This is
- * the keystone wire for the artist/fan engagement loop (epics #53, #80).
+ * Registers the shared 'artist' taxonomy for bbPress topics, enabling
+ * explicitly selected artist context on forum content.
  *
- * The taxonomy itself is defined in the theme's custom-taxonomies.php on the
- * 'post' type at init priority 5; this file only attaches it to the community
- * 'topic' CPT, mirroring the existing 'location' integration.
+ * Community only attaches and queries the shared taxonomy. Artist Platform
+ * remains the canonical owner of artist identity and profile URLs.
  *
  * @package ExtraChillCommunity
  * @subpackage Core
@@ -22,10 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Register the artist taxonomy for the bbPress topic post type.
  *
- * The 'artist' taxonomy is defined in the Extra Chill theme (network-active on
- * all sites) and registered on the 'post' type at init priority 5. This runs at
- * priority 20 so the taxonomy already exists when we attach it, matching the
- * 'location' integration in taxonomy-location.php.
+ * This runs at priority 20 so the shared taxonomy already exists when we
+ * attach it, matching the location and festival integrations.
  *
  * Scope: topics only. Replies inherit their parent topic's artist context, so
  * tagging at the topic level is the high-value target; attaching to 'reply'
@@ -40,5 +36,58 @@ function extrachill_register_artist_for_bbpress() {
 }
 add_action( 'init', 'extrachill_register_artist_for_bbpress', 20 );
 
-// Note: theme registers the 'artist' taxonomy; this file only attaches it to
-// the bbPress 'topic' CPT.
+/**
+ * Persist existing artist terms selected in the bbPress topic composer.
+ *
+ * The picker only submits IDs for existing shared artist terms. Its marker
+ * lets an intentionally empty selection clear an edited topic while leaving
+ * programmatic topic creation untouched.
+ *
+ * @param int $topic_id The topic ID.
+ */
+function extrachill_community_save_topic_artist( $topic_id ) {
+	if ( ! taxonomy_exists( 'artist' ) ) {
+		return;
+	}
+
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- bbPress verifies its form nonce before firing bbp_new_topic/bbp_edit_topic.
+	if ( ! isset( $_POST['bbp_topic_artist_submitted'] ) ) {
+		return;
+	}
+
+	$raw       = isset( $_POST['bbp_topic_artist'] ) ? wp_unslash( $_POST['bbp_topic_artist'] ) : array();
+	$submitted = is_array( $raw ) ? array_map( 'absint', $raw ) : array( absint( $raw ) );
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+	$term_ids = array();
+	foreach ( array_unique( array_filter( $submitted ) ) as $term_id ) {
+		$term = get_term( $term_id, 'artist' );
+		if ( $term && ! is_wp_error( $term ) ) {
+			$term_ids[] = (int) $term->term_id;
+		}
+	}
+
+	// Empty (or all-invalid) selection clears the artist context.
+	wp_set_object_terms( $topic_id, $term_ids, 'artist' );
+}
+add_action( 'bbp_new_topic', 'extrachill_community_save_topic_artist', 20 );
+add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_artist', 20 );
+
+/**
+ * Make native Community artist archives list artist-tagged discussions.
+ *
+ * Artist Platform keeps canonical artist identity and profile URLs. This only
+ * makes Community's local artist taxonomy view a discussion archive.
+ *
+ * @param WP_Query $query The query being prepared.
+ */
+function extrachill_community_artist_archive_include_topics( $query ) {
+	if ( is_admin() || ! $query->is_main_query() || ! $query->is_tax( 'artist' ) ) {
+		return;
+	}
+
+	$query->set( 'post_type', array( 'topic' ) );
+	// bbPress topics are publish or closed; include both in the discussion view.
+	$query->set( 'post_status', array( 'publish', 'closed' ) );
+}
+add_action( 'pre_get_posts', 'extrachill_community_artist_archive_include_topics' );

--- a/scripts/smoke-artist-topic-taxonomy.php
+++ b/scripts/smoke-artist-topic-taxonomy.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Verify artist discussion taxonomy wiring without mutating site data.
+ *
+ * Run with: wp eval-file scripts/smoke-artist-topic-taxonomy.php
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	exit( 1 );
+}
+
+$artist_taxonomy = get_taxonomy( 'artist' );
+if ( ! $artist_taxonomy || ! in_array( 'topic', $artist_taxonomy->object_type, true ) ) {
+	WP_CLI::error( 'Artist taxonomy is not registered for bbPress topics.' );
+}
+
+$artist_picker = null;
+foreach ( extrachill_community_term_picker_taxonomies() as $picker ) {
+	if ( 'artist' === $picker['taxonomy'] ) {
+		$artist_picker = $picker;
+		break;
+	}
+}
+
+if ( ! $artist_picker || 'bbp_topic_artist' !== $artist_picker['field'] ) {
+	WP_CLI::error( 'Artist topic picker configuration is missing or invalid.' );
+}
+
+if ( 20 !== has_action( 'bbp_new_topic', 'extrachill_community_save_topic_artist' ) || 20 !== has_action( 'bbp_edit_topic', 'extrachill_community_save_topic_artist' ) ) {
+	WP_CLI::error( 'Artist topic persistence hooks are not registered.' );
+}
+
+$query                    = new WP_Query();
+$query->is_tax            = true;
+$query->queried_object    = (object) array( 'taxonomy' => 'artist' );
+$previous_wp_query        = $GLOBALS['wp_query'];
+$previous_wp_the_query    = $GLOBALS['wp_the_query'];
+$GLOBALS['wp_query']      = $query;
+$GLOBALS['wp_the_query']  = $query;
+
+extrachill_community_artist_archive_include_topics( $query );
+
+$GLOBALS['wp_query']     = $previous_wp_query;
+$GLOBALS['wp_the_query'] = $previous_wp_the_query;
+
+if ( array( 'topic' ) !== $query->get( 'post_type' ) || array( 'publish', 'closed' ) !== $query->get( 'post_status' ) ) {
+	WP_CLI::error( 'Artist archive query does not include published and closed topics.' );
+}
+
+WP_CLI::success( 'Artist topic taxonomy smoke check passed.' );


### PR DESCRIPTION
## Summary
- Extend the existing configurable topic term picker with an Artist field that accepts only explicit selections of existing shared artist terms; no title/content inference, term creation, follower behavior, or parallel picker was added.
- Persist author-confirmed artist selections through bbPress's native new/edit topic hooks, including intentional clearing when the picker marker is submitted without terms.
- Make Community's native artist taxonomy archives list matching published and closed bbPress topics while preserving Artist Platform ownership of canonical artist identity and profile URLs.

## Validation
- `php -l inc/core/taxonomy-artist.php`
- `php -l inc/content/editor/composer-term-picker.php`
- `php -l scripts/smoke-artist-topic-taxonomy.php`
- Isolated `wp eval` smoke coverage: `Artist topic taxonomy smoke check passed.`
- `homeboy review extrachill-community lint --path /var/lib/datamachine/workspace/extrachill-community@feat-artist-discussions-180 --changed-since origin/main`
- `homeboy review extrachill-community test --path /var/lib/datamachine/workspace/extrachill-community@feat-artist-discussions-180 --changed-since origin/main`

## Network Follow-up
- Extra-Chill/extrachill-network#118 must add Community to the existing artist taxonomy site map and ensure its Community count adapter queries `post_type=topic`. It must reuse generic slug-based taxonomy resolution, caching, and existing artist-profile routing without changing Artist Platform canonical ownership.

Closes #180