### PR TITLE
feat: notify artist subscribers of new discussions

### DIFF
--- a/inc/social/notifications/capture-festival-topics.php
+++ b/inc/social/notifications/capture-festival-topics.php
@@ -10,20 +10,21 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Community's stable entity-subscription producer identifier.
  */
-const EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-community';
+const EXTRACHILL_COMMUNITY_TOPIC_NOTIFICATION_PRODUCER    = 'extrachill-community';
 const EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META   = '_extrachill_community_festival_topic_notified';
+const EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META     = '_extrachill_community_artist_topic_notified';
 
 /**
- * Authorize Community to resolve its festival notification recipients.
+ * Authorize Community to resolve private entity notification recipients.
  *
  * @param bool   $authorized Whether the producer is authorized.
  * @param string $producer   Producer identifier.
  * @return bool
  */
-function extrachill_community_authorize_festival_notification_producer( $authorized, $producer ) {
-	return $authorized || EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER === $producer;
+function extrachill_community_authorize_topic_notification_producer( $authorized, $producer ) {
+	return $authorized || EXTRACHILL_COMMUNITY_TOPIC_NOTIFICATION_PRODUCER === $producer;
 }
-add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_community_authorize_festival_notification_producer', 10, 2 );
+add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_community_authorize_topic_notification_producer', 10, 2 );
 
 /**
  * Notify festival subscribers when a new festival-tagged topic is published.
@@ -55,7 +56,7 @@ function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
 	$recipients = array();
 	foreach ( $terms as $term ) {
 		$ids = extrachill_users_entity_subscription_recipients(
-			EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER,
+			EXTRACHILL_COMMUNITY_TOPIC_NOTIFICATION_PRODUCER,
 			'festival',
 			'festival',
 			$term->slug,
@@ -95,3 +96,73 @@ function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
 	update_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META, current_time( 'mysql', true ) );
 }
 add_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscribers', 30 );
+
+/**
+ * Notify artist subscribers when a new artist-tagged topic is published.
+ *
+ * This runs after the topic composer persists its artist terms. It intentionally
+ * observes only `bbp_new_topic`; replies and topic edits are handled separately.
+ *
+ * @param int $topic_id Topic post ID.
+ * @return void
+ */
+function extrachill_community_notify_artist_topic_subscribers( $topic_id ) {
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+		return;
+	}
+
+	$topic_id = (int) $topic_id;
+	if ( $topic_id <= 0 ) {
+		return;
+	}
+	if ( bbp_get_public_status_id() !== get_post_status( $topic_id ) || get_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META, true ) ) {
+		return;
+	}
+
+	$terms = get_the_terms( $topic_id, 'artist' );
+	if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		return;
+	}
+
+	$recipients = array();
+	foreach ( $terms as $term ) {
+		$ids = extrachill_users_entity_subscription_recipients(
+			EXTRACHILL_COMMUNITY_TOPIC_NOTIFICATION_PRODUCER,
+			'artist',
+			'artist',
+			$term->slug
+		);
+
+		if ( is_wp_error( $ids ) ) {
+			continue;
+		}
+
+		$recipients = array_merge( $recipients, $ids );
+	}
+
+	$author_id  = (int) get_post_field( 'post_author', $topic_id );
+	$recipients = array_values(
+		array_diff(
+			array_unique( array_map( 'absint', $recipients ) ),
+			array( $author_id, 0 )
+		)
+	);
+	if ( empty( $recipients ) ) {
+		return;
+	}
+
+	ec_users_notify(
+		$recipients,
+		array(
+			'actor_id' => $author_id,
+			'type'     => 'artist_discussion',
+			'title'    => get_the_title( $topic_id ),
+			'link'     => function_exists( 'bbp_get_topic_permalink' ) ? bbp_get_topic_permalink( $topic_id ) : get_permalink( $topic_id ),
+			'item_id'  => $topic_id,
+		)
+	);
+
+	// Keep a repeated bbPress new-topic action from creating duplicate notices.
+	update_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META, current_time( 'mysql', true ) );
+}
+add_action( 'bbp_new_topic', 'extrachill_community_notify_artist_topic_subscribers', 30 );

--- a/scripts/smoke-festival-topic-notifications.php
+++ b/scripts/smoke-festival-topic-notifications.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Verify festival topic notification hooks without mutating site data.
+ * Verify festival and artist topic notification hooks without mutating site data.
  *
  * Run with: wp eval-file scripts/smoke-festival-topic-notifications.php
  *
@@ -27,12 +27,36 @@ if ( ! $authorized ) {
 	WP_CLI::error( 'Community festival notification producer is not authorized.' );
 }
 
+$artist_authorized = apply_filters(
+	'extrachill_users_entity_subscription_producer_authorized',
+	false,
+	'extrachill-community',
+	array(
+		'entity_type' => 'artist',
+		'taxonomy'    => 'artist',
+		'slug'        => 'smoke-test',
+	),
+	'notification'
+);
+
+if ( ! $artist_authorized ) {
+	WP_CLI::error( 'Community artist notification producer is not authorized.' );
+}
+
 if ( 30 !== has_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscribers' ) ) {
 	WP_CLI::error( 'Festival topic notification capture is not registered.' );
+}
+
+if ( 30 !== has_action( 'bbp_new_topic', 'extrachill_community_notify_artist_topic_subscribers' ) ) {
+	WP_CLI::error( 'Artist topic notification capture is not registered.' );
 }
 
 if ( has_action( 'bbp_new_reply', 'extrachill_community_notify_festival_topic_subscribers' ) || has_action( 'bbp_edit_topic', 'extrachill_community_notify_festival_topic_subscribers' ) ) {
 	WP_CLI::error( 'Festival topic notification capture must only observe new topics.' );
 }
 
-WP_CLI::success( 'Festival topic notification smoke check passed.' );
+if ( has_action( 'bbp_new_reply', 'extrachill_community_notify_artist_topic_subscribers' ) || has_action( 'bbp_edit_topic', 'extrachill_community_notify_artist_topic_subscribers' ) ) {
+	WP_CLI::error( 'Artist topic notification capture must only observe new topics.' );
+}
+
+WP_CLI::success( 'Festival and artist topic notification smoke checks passed.' );


### PR DESCRIPTION
## Summary
- resolve private artist subscribers through Extra Chill Users for explicitly artist-tagged new topics
- create deduplicated native Community notifications while excluding the topic author
- preserve the existing festival path and extend its deterministic smoke check

## Verification
- `php -l inc/social/notifications/capture-festival-topics.php`
- `php -l scripts/smoke-festival-topic-notifications.php`
- deterministic hook-registration PHP smoke check
- `npm run lint:js` *(blocked: `wp-scripts` is not installed in this worktree)*
- `npm run lint:css` *(blocked: `wp-scripts` is not installed in this worktree)*

Closes #184