### PR TITLE
chore: clear ESLint debt blocking release lint gate

### DIFF
--- a/inc/assets/js/bbpress-blocks-mentions.js
+++ b/inc/assets/js/bbpress-blocks-mentions.js
@@ -1,5 +1,5 @@
 /**
- * @mentions autocompleter for the Blocks Everywhere (Gutenberg) bbPress editor.
+ * Autocompleter for @-mentions in the Blocks Everywhere (Gutenberg) bbPress editor.
  *
  * Registers a custom completer via the `editor.Autocomplete.completers` filter
  * that hits the canonical `extrachill/users-search` REST endpoint and inserts
@@ -9,7 +9,7 @@
  * loads the editor scripts into the iframe document) and on non-iframe BE
  * renders. Vanilla ES5-compatible — no build step.
  *
- * @package ExtraChillCommunity
+ * @package
  */
 
 ( function () {
@@ -24,15 +24,17 @@
 	}
 	window.extrachillBbpressMentionsRegistered = true;
 
-	var apiFetch = wp.apiFetch;
-	var element = wp.element;
-	var createElement = element.createElement;
-	var concatChildren = element.concatChildren;
+	const apiFetch = wp.apiFetch;
+	const element = wp.element;
+	const createElement = element.createElement;
+	const concatChildren = element.concatChildren;
 
-	var SEARCH_PATH = '/extrachill/v1/users/search';
+	const SEARCH_PATH = '/extrachill/v1/users/search';
 
 	function buildPath( term ) {
-		return SEARCH_PATH + '?context=mentions&term=' + encodeURIComponent( term );
+		return (
+			SEARCH_PATH + '?context=mentions&term=' + encodeURIComponent( term )
+		);
 	}
 
 	function normalizeUsers( users ) {
@@ -55,7 +57,7 @@
 	}
 
 	function getOptionLabel( user ) {
-		var avatar = user.avatarUrl
+		const avatar = user.avatarUrl
 			? createElement( 'img', {
 					className: 'editor-autocompleters__user-avatar',
 					alt: '',
@@ -65,38 +67,36 @@
 					className: 'editor-autocompleters__no-avatar',
 			  } );
 
-		return concatChildren(
-			[
-				avatar,
-				createElement(
-					'span',
-					{ className: 'editor-autocompleters__user-name' },
-					'@' + user.slug
-				),
-				createElement(
-					'span',
-					{ className: 'editor-autocompleters__user-slug' },
-					user.username
-				),
-			]
-		);
+		return concatChildren( [
+			avatar,
+			createElement(
+				'span',
+				{ className: 'editor-autocompleters__user-name' },
+				'@' + user.slug
+			),
+			createElement(
+				'span',
+				{ className: 'editor-autocompleters__user-slug' },
+				user.username
+			),
+		] );
 	}
 
 	function getMentionLink( user ) {
-		var href = user.profileUrl || '/u/' + user.slug;
+		const href = user.profileUrl || '/u/' + user.slug;
 		return createElement(
 			'a',
-			{ href: href, className: 'ec-mention' },
+			{ href, className: 'ec-mention' },
 			'@' + user.slug
 		);
 	}
 
-	var mentionsCompleter = {
+	const mentionsCompleter = {
 		name: 'extrachill-mentions',
 		className: 'editor-autocompleters__user',
 		triggerPrefix: '@',
 		isDebounced: true,
-		options: function ( filterValue ) {
+		options( filterValue ) {
 			if ( ! filterValue || filterValue.length < 2 ) {
 				return [];
 			}
@@ -107,14 +107,14 @@
 					return [];
 				} );
 		},
-		getOptionKeywords: function ( user ) {
-			var values = [ user.slug, user.username ].filter( Boolean );
+		getOptionKeywords( user ) {
+			const values = [ user.slug, user.username ].filter( Boolean );
 			return values.reduce( function ( acc, value ) {
 				return acc.concat( String( value ).split( /\s+/ ) );
 			}, [] );
 		},
-		getOptionLabel: getOptionLabel,
-		getOptionCompletion: function ( user ) {
+		getOptionLabel,
+		getOptionCompletion( user ) {
 			return {
 				action: 'insert-at-caret',
 				value: concatChildren( [ getMentionLink( user ), ' ' ] ),
@@ -129,7 +129,7 @@
 			completers = completers || [];
 			// Avoid double-registration if the filter fires again with our
 			// completer already present.
-			var hasOurs = completers.some( function ( c ) {
+			const hasOurs = completers.some( function ( c ) {
 				return c && c.name === 'extrachill-mentions';
 			} );
 			if ( hasOurs ) {

--- a/inc/assets/js/bbpress-ui.js
+++ b/inc/assets/js/bbpress-ui.js
@@ -21,9 +21,15 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 	// Get the bottom form wrapper (contains the Gutenberg editor)
 	const bottomForm = document.getElementById( 'new-post' );
-	const bottomFormWrapper = bottomForm ? bottomForm.closest( '.bbp-reply-form' ) : null;
-	const bottomFormLegend = bottomFormWrapper ? bottomFormWrapper.querySelector( '.bbp-form > legend' ) : null;
-	const originalLegendText = bottomFormLegend ? bottomFormLegend.textContent : null;
+	const bottomFormWrapper = bottomForm
+		? bottomForm.closest( '.bbp-reply-form' )
+		: null;
+	const bottomFormLegend = bottomFormWrapper
+		? bottomFormWrapper.querySelector( '.bbp-form > legend' )
+		: null;
+	const originalLegendText = bottomFormLegend
+		? bottomFormLegend.textContent
+		: null;
 	let originalFormLocation = null;
 	let activeReplyCard = null;
 	let activeReplyId = null;
@@ -53,7 +59,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			return;
 		}
 
-		const topicIdField = bottomForm.querySelector( 'input[name="bbp_topic_id"]' );
+		const topicIdField = bottomForm.querySelector(
+			'input[name="bbp_topic_id"]'
+		);
 		const topicId = topicIdField ? parseInt( topicIdField.value, 10 ) : 0;
 		if ( ! topicId ) {
 			return;
@@ -72,7 +80,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	}
 
 	function getReplyToFieldValue() {
-		const replyToField = bottomForm ? bottomForm.querySelector( 'input[name="bbp_reply_to"]' ) : null;
+		const replyToField = bottomForm
+			? bottomForm.querySelector( 'input[name="bbp_reply_to"]' )
+			: null;
 		if ( ! replyToField ) {
 			return 0;
 		}
@@ -97,7 +107,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		if ( ! bottomFormWrapper ) {
 			return;
 		}
-		const wrapper = bottomFormWrapper.querySelector( '.blocks-everywhere-editor' );
+		const wrapper = bottomFormWrapper.querySelector(
+			'.blocks-everywhere-editor'
+		);
 		if ( ! wrapper ) {
 			return;
 		}
@@ -125,7 +137,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		}
 
 		// Reset the reply_to field to 0 (top-level reply)
-		const replyToField = bottomForm ? bottomForm.querySelector( 'input[name="bbp_reply_to"]' ) : null;
+		const replyToField = bottomForm
+			? bottomForm.querySelector( 'input[name="bbp_reply_to"]' )
+			: null;
 		if ( replyToField ) {
 			replyToField.value = '0';
 		}
@@ -163,11 +177,16 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		}
 
 		// Mark the original location with placeholder
-		bottomFormWrapper.parentNode.insertBefore( placeholder, bottomFormWrapper );
+		bottomFormWrapper.parentNode.insertBefore(
+			placeholder,
+			bottomFormWrapper
+		);
 		originalFormLocation = placeholder;
 
 		// Set the reply_to field to the parent reply ID
-		const replyToField = bottomForm ? bottomForm.querySelector( 'input[name="bbp_reply_to"]' ) : null;
+		const replyToField = bottomForm
+			? bottomForm.querySelector( 'input[name="bbp_reply_to"]' )
+			: null;
 		if ( replyToField ) {
 			replyToField.value = String( replyId );
 		}
@@ -188,11 +207,19 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		if ( ! cancelButton ) {
 			cancelButton = createCancelButton();
 		}
-		const submitButton = bottomForm ? bottomForm.querySelector( '.bbp-submit-button' ) : null;
-		const actionsContainer = bottomForm ? bottomForm.querySelector( '.ec-reply-actions' ) : null;
+		const submitButton = bottomForm
+			? bottomForm.querySelector( '.bbp-submit-button' )
+			: null;
+		const actionsContainer = bottomForm
+			? bottomForm.querySelector( '.ec-reply-actions' )
+			: null;
 		if ( submitButton ) {
 			submitButton.classList.add( 'button-large' );
-			if ( actionsContainer && cancelButton && ! actionsContainer.contains( cancelButton ) ) {
+			if (
+				actionsContainer &&
+				cancelButton &&
+				! actionsContainer.contains( cancelButton )
+			) {
 				actionsContainer.appendChild( cancelButton );
 			}
 		}
@@ -202,7 +229,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		activeReplyId = replyId;
 
 		// Scroll to the form
-		bottomFormWrapper.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+		bottomFormWrapper.scrollIntoView( {
+			behavior: 'smooth',
+			block: 'start',
+		} );
 
 		// Focus the editor
 		setTimeout( function () {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "devDependencies": {
     "@wordpress/scripts": "^30.15.0",
-    "ajv": "^8.20.0"
+    "ajv": "^8.20.0",
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@extrachill/components": "^0.8.0",

--- a/src/blocks/contribution-heatmap/view.tsx
+++ b/src/blocks/contribution-heatmap/view.tsx
@@ -113,8 +113,8 @@ function formatDayLabel( ymd: string, count: number ): string {
 			date
 		);
 	}
-	/* translators: %s: localized date. */
 	return sprintf(
+		/* translators: %s: localized date. */
 		__( 'No contributions on %s', 'extra-chill-community' ),
 		date
 	);
@@ -134,19 +134,22 @@ function useCellTooltip() {
 		top: number;
 	} | null >( null );
 
-	const show = useCallback( ( event: React.SyntheticEvent< HTMLElement > ) => {
-		const cell = event.currentTarget;
-		const text = cell.getAttribute( 'data-ec-tip' );
-		if ( ! text ) {
-			return;
-		}
-		const rect = cell.getBoundingClientRect();
-		setTip( {
-			text,
-			left: rect.left + rect.width / 2,
-			top: rect.top,
-		} );
-	}, [] );
+	const show = useCallback(
+		( event: React.SyntheticEvent< HTMLElement > ) => {
+			const cell = event.currentTarget;
+			const text = cell.getAttribute( 'data-ec-tip' );
+			if ( ! text ) {
+				return;
+			}
+			const rect = cell.getBoundingClientRect();
+			setTip( {
+				text,
+				left: rect.left + rect.width / 2,
+				top: rect.top,
+			} );
+		},
+		[]
+	);
 
 	const hide = useCallback( () => setTip( null ), [] );
 

--- a/src/blocks/edit-profile/index.tsx
+++ b/src/blocks/edit-profile/index.tsx
@@ -9,7 +9,12 @@ function Edit() {
 
 	return (
 		<div { ...blockProps }>
-			<BlockIntro description={ __( 'Edit Profile — renders on the frontend.', 'extra-chill-community' ) } />
+			<BlockIntro
+				description={ __(
+					'Edit Profile — renders on the frontend.',
+					'extra-chill-community'
+				) }
+			/>
 		</div>
 	);
 }

--- a/src/blocks/edit-profile/view.tsx
+++ b/src/blocks/edit-profile/view.tsx
@@ -1,5 +1,9 @@
-import { useState, useEffect, useCallback } from '@wordpress/element';
-import { createRoot } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	createRoot,
+} from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { WPNativeClient } from 'wp-native-client';
 import { WpApiFetchTransport } from 'wp-native-client/wordpress';
@@ -8,7 +12,6 @@ import {
 	BlockShell,
 	BlockShellInner,
 	BlockShellHeader,
-	BlockIntro,
 	FieldGroup,
 	Panel,
 	PanelHeader,
@@ -18,7 +21,9 @@ import '@extrachill/components/styles/components.scss';
 import { cssVar, spacing, colors } from '@extrachill/tokens';
 import type { UserProfile, UserLink } from '../../types/users';
 
-const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
+const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), {
+	validateAbilityNames: false,
+} );
 
 const styles = {
 	avatarContainer: {
@@ -59,7 +64,13 @@ const styles = {
 	},
 } as const;
 
-function Notice( { type, message }: { type: 'success' | 'error'; message: string } ) {
+function Notice( {
+	type,
+	message,
+}: {
+	type: 'success' | 'error';
+	message: string;
+} ) {
 	return (
 		<div className={ `notice notice-${ type }` }>
 			<p>{ message }</p>
@@ -78,51 +89,69 @@ function AvatarUpload( {
 } ) {
 	const [ uploading, setUploading ] = useState( false );
 
-	const handleFileChange = useCallback( async ( e: React.ChangeEvent<HTMLInputElement> ) => {
-		const file = e.target.files?.[ 0 ];
-		if ( ! file ) return;
-
-		setUploading( true );
-
-		try {
-			// B1 exception: avatar upload is a multipart POST with no backing
-			// ability (the Abilities API run endpoint is JSON-only). It stays on
-			// the existing extrachill/v1/media REST route, called directly via
-			// apiFetch — mirroring the former api-client media.upload() wire.
-			const formData = new FormData();
-			formData.append( 'context', 'user_avatar' );
-			if ( userId ) {
-				formData.append( 'target_id', String( userId ) );
+	const handleFileChange = useCallback(
+		async ( e: React.ChangeEvent< HTMLInputElement > ) => {
+			const file = e.target.files?.[ 0 ];
+			if ( ! file ) {
+				return;
 			}
-			formData.append( 'file', file );
 
-			const result = await apiFetch< { url?: string } >( {
-				path: 'extrachill/v1/media',
-				method: 'POST',
-				body: formData,
-			} );
-			if ( result.url ) {
-				onAvatarChange( result.url );
-			}
-		} catch {}
+			setUploading( true );
 
-		setUploading( false );
-	}, [ onAvatarChange, userId ] );
+			try {
+				// B1 exception: avatar upload is a multipart POST with no backing
+				// ability (the Abilities API run endpoint is JSON-only). It stays on
+				// the existing extrachill/v1/media REST route, called directly via
+				// apiFetch — mirroring the former api-client media.upload() wire.
+				const formData = new FormData();
+				formData.append( 'context', 'user_avatar' );
+				if ( userId ) {
+					formData.append( 'target_id', String( userId ) );
+				}
+				formData.append( 'file', file );
+
+				const result = await apiFetch< { url?: string } >( {
+					path: 'extrachill/v1/media',
+					method: 'POST',
+					body: formData,
+				} );
+				if ( result.url ) {
+					onAvatarChange( result.url );
+				}
+			} catch {}
+
+			setUploading( false );
+		},
+		[ onAvatarChange, userId ]
+	);
 
 	return (
 		<div style={ styles.avatarContainer }>
 			<img src={ avatarUrl } alt="Avatar" style={ styles.avatar } />
 			<div>
-				<h4 style={ { margin: 0, marginBottom: '4px' } }>Current Avatar</h4>
-				<p style={ { marginTop: 0, marginBottom: '8px', color: cssVar( colors.mutedText ) } }>
-					This is the avatar you currently have set. Upload a new image to change it.
+				<h4 style={ { margin: 0, marginBottom: '4px' } }>
+					Current Avatar
+				</h4>
+				<p
+					style={ {
+						marginTop: 0,
+						marginBottom: '8px',
+						color: cssVar( colors.mutedText ),
+					} }
+				>
+					This is the avatar you currently have set. Upload a new
+					image to change it.
 				</p>
 				<label
-					className={ `button-3 button-small${ uploading ? ' is-disabled' : '' }` }
+					htmlFor="ec-edit-profile-avatar-upload"
+					className={ `button-3 button-small${
+						uploading ? ' is-disabled' : ''
+					}` }
 					style={ uploading ? styles.disabledButton : undefined }
 				>
 					{ uploading ? 'Uploading...' : 'Upload New Avatar' }
 					<input
+						id="ec-edit-profile-avatar-upload"
 						type="file"
 						accept="image/*"
 						onChange={ handleFileChange }
@@ -141,58 +170,98 @@ function LinksManager( {
 	onChange,
 }: {
 	links: UserLink[];
-	linkTypes: Record<string, string>;
+	linkTypes: Record< string, string >;
 	onChange: ( links: UserLink[] ) => void;
 } ) {
 	const addLink = useCallback( () => {
 		onChange( [ ...links, { type_key: 'website', url: '' } ] );
 	}, [ links, onChange ] );
 
-	const removeLink = useCallback( ( index: number ) => {
-		onChange( links.filter( ( _, i ) => i !== index ) );
-	}, [ links, onChange ] );
+	const removeLink = useCallback(
+		( index: number ) => {
+			onChange( links.filter( ( _, i ) => i !== index ) );
+		},
+		[ links, onChange ]
+	);
 
-	const updateLink = useCallback( ( index: number, field: keyof UserLink, value: string ) => {
-		onChange( links.map( ( link, i ) => ( i !== index ? link : { ...link, [ field ]: value } ) ) );
-	}, [ links, onChange ] );
+	const updateLink = useCallback(
+		( index: number, field: keyof UserLink, value: string ) => {
+			onChange(
+				links.map( ( link, i ) =>
+					i !== index ? link : { ...link, [ field ]: value }
+				)
+			);
+		},
+		[ links, onChange ]
+	);
 
 	return (
 		<div>
-			<p style={ styles.mutedText }>Add links to your website, social media, streaming, etc.</p>
+			<p style={ styles.mutedText }>
+				Add links to your website, social media, streaming, etc.
+			</p>
 			{ links.map( ( link, index ) => (
 				<div key={ index } style={ styles.linkRow }>
 					<select
 						style={ styles.linkSelect }
 						value={ link.type_key }
-						onChange={ ( e ) => updateLink( index, 'type_key', e.target.value ) }
+						onChange={ ( e ) =>
+							updateLink( index, 'type_key', e.target.value )
+						}
 					>
-						{ Object.entries( linkTypes ).map( ( [ key, label ] ) => (
-							<option key={ key } value={ key }>{ label }</option>
-						) ) }
+						{ Object.entries( linkTypes ).map(
+							( [ key, label ] ) => (
+								<option key={ key } value={ key }>
+									{ label }
+								</option>
+							)
+						) }
 					</select>
 					<input
 						type="url"
 						style={ styles.linkInput }
 						value={ link.url }
-						onChange={ ( e ) => updateLink( index, 'url', e.target.value ) }
+						onChange={ ( e ) =>
+							updateLink( index, 'url', e.target.value )
+						}
 						placeholder="https://..."
 					/>
 					{ link.type_key === 'other' && (
 						<input
 							type="text"
-							style={ { ...styles.linkInput, minWidth: '120px', flex: 'none', width: '140px' } }
+							style={ {
+								...styles.linkInput,
+								minWidth: '120px',
+								flex: 'none',
+								width: '140px',
+							} }
 							value={ link.custom_label || '' }
-							onChange={ ( e ) => updateLink( index, 'custom_label', e.target.value ) }
+							onChange={ ( e ) =>
+								updateLink(
+									index,
+									'custom_label',
+									e.target.value
+								)
+							}
 							placeholder="Label"
 						/>
 					) }
-					<button type="button" className="button-3 button-small" onClick={ () => removeLink( index ) } title="Remove link">
+					<button
+						type="button"
+						className="button-3 button-small"
+						onClick={ () => removeLink( index ) }
+						title="Remove link"
+					>
 						Remove
 					</button>
 				</div>
 			) ) }
 			<ActionRow>
-				<button type="button" className="button-3 button-small" onClick={ addLink }>
+				<button
+					type="button"
+					className="button-3 button-small"
+					onClick={ addLink }
+				>
 					+ Add Link
 				</button>
 			</ActionRow>
@@ -215,34 +284,50 @@ function EditProfileApp( {
 	hasArtists: boolean;
 	canCreateArtists: boolean;
 } ) {
-	const [ activeTab, setActiveTab ] = useState<TabId>( 'avatar-title' );
-	const [ profile, setProfile ] = useState<UserProfile | null>( null );
+	const [ activeTab, setActiveTab ] = useState< TabId >( 'avatar-title' );
+	const [ profile, setProfile ] = useState< UserProfile | null >( null );
 	const [ loading, setLoading ] = useState( true );
-	const [ error, setError ] = useState<string | null>( null );
+	const [ error, setError ] = useState< string | null >( null );
 	const [ saving, setSaving ] = useState( false );
-	const [ notice, setNotice ] = useState<{ type: 'success' | 'error'; message: string } | null>( null );
+	const [ , setNotice ] = useState< {
+		type: 'success' | 'error';
+		message: string;
+	} | null >( null );
 	const [ customTitle, setCustomTitle ] = useState( '' );
 	const [ bio, setBio ] = useState( '' );
-	const [ links, setLinks ] = useState<UserLink[]>( [] );
+	const [ links, setLinks ] = useState< UserLink[] >( [] );
 	const [ avatarUrl, setAvatarUrl ] = useState( '' );
 
 	useEffect( () => {
-		client.execute< UserProfile >( 'extrachill/get-user-profile', { user_id: userId } ).then( ( data ) => {
-			setProfile( data );
-			setCustomTitle( data.custom_title || '' );
-			setBio( data.bio || '' );
-			setLinks( data.links || [] );
-			setAvatarUrl( data.avatar_url || '' );
-			setLoading( false );
-		} ).catch( ( err ) => {
-			setError( err instanceof Error ? err.message : 'Failed to load profile.' );
-			setLoading( false );
-		} );
+		client
+			.execute< UserProfile >( 'extrachill/get-user-profile', {
+				user_id: userId,
+			} )
+			.then( ( data ) => {
+				setProfile( data );
+				setCustomTitle( data.custom_title || '' );
+				setBio( data.bio || '' );
+				setLinks( data.links || [] );
+				setAvatarUrl( data.avatar_url || '' );
+				setLoading( false );
+			} )
+			.catch( ( err ) => {
+				setError(
+					err instanceof Error
+						? err.message
+						: 'Failed to load profile.'
+				);
+				setLoading( false );
+			} );
 	}, [ userId ] );
 
 	useEffect( () => {
 		const hash = window.location.hash.replace( '#tab-', '' );
-		if ( [ 'avatar-title', 'about', 'links', 'artist-profiles' ].includes( hash ) ) {
+		if (
+			[ 'avatar-title', 'about', 'links', 'artist-profiles' ].includes(
+				hash
+			)
+		) {
 			setActiveTab( hash as TabId );
 		}
 	}, [] );
@@ -257,17 +342,26 @@ function EditProfileApp( {
 
 		try {
 			const [ profileResult ] = await Promise.all( [
-				client.execute< UserProfile >( 'extrachill/update-user-profile', {
-					custom_title: customTitle,
-					bio,
-				} ),
+				client.execute< UserProfile >(
+					'extrachill/update-user-profile',
+					{
+						custom_title: customTitle,
+						bio,
+					}
+				),
 				client.execute( 'extrachill/update-user-links', { links } ),
 			] );
 
 			setProfile( profileResult );
-			setNotice( { type: 'success', message: 'Profile updated successfully.' } );
+			setNotice( {
+				type: 'success',
+				message: 'Profile updated successfully.',
+			} );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
+			setNotice( {
+				type: 'error',
+				message: err instanceof Error ? err.message : 'Update failed.',
+			} );
 		}
 
 		setSaving( false );
@@ -282,7 +376,12 @@ function EditProfileApp( {
 	}
 
 	if ( error || ! profile ) {
-		return <Notice type="error" message={ error || 'Failed to load profile.' } />;
+		return (
+			<Notice
+				type="error"
+				message={ error || 'Failed to load profile.' }
+			/>
+		);
 	}
 
 	const hasArtistAccess = profile.artist_access.status === 'approved';
@@ -290,7 +389,9 @@ function EditProfileApp( {
 		{ id: 'avatar-title', label: 'Avatar & Title' },
 		{ id: 'about', label: 'About' },
 		{ id: 'links', label: 'Your Links' },
-		...( hasArtistAccess ? [ { id: 'artist-profiles', label: 'Artist Profiles' } ] : [] ),
+		...( hasArtistAccess
+			? [ { id: 'artist-profiles', label: 'Artist Profiles' } ]
+			: [] ),
 	] as const;
 
 	return (
@@ -301,28 +402,40 @@ function EditProfileApp( {
 					description="Update your public profile, links, and artist profile access."
 				/>
 				<ResponsiveTabs
-						tabs={ tabs as Array<{ id: string; label: string }> }
-						active={ activeTab }
-						onChange={ ( id ) => switchTab( id as TabId ) }
-						syncWithHash={ true }
-						showDesktopTabs={ true }
-						renderPanel={ ( id ) => {
-							switch ( id as TabId ) {
+					tabs={ tabs as Array< { id: string; label: string } > }
+					active={ activeTab }
+					onChange={ ( id ) => switchTab( id as TabId ) }
+					syncWithHash={ true }
+					showDesktopTabs={ true }
+					renderPanel={ ( id ) => {
+						switch ( id as TabId ) {
 							case 'avatar-title':
 								return (
 									<Panel>
-										<AvatarUpload avatarUrl={ avatarUrl } userId={ userId } onAvatarChange={ setAvatarUrl } />
+										<AvatarUpload
+											avatarUrl={ avatarUrl }
+											userId={ userId }
+											onAvatarChange={ setAvatarUrl }
+										/>
 										<FieldGroup
-											label={ `Custom Title${ customTitle ? ` (Current: ${ customTitle })` : '' }` }
+											label={ `Custom Title${
+												customTitle
+													? ` (Current: ${ customTitle })`
+													: ''
+											}` }
 											htmlFor="ec-custom-title"
 											help="Enter a custom title, or leave blank for default."
 										>
-										<input
-											id="ec-custom-title"
-											type="text"
-											value={ customTitle }
-											onChange={ ( e ) => setCustomTitle( e.target.value ) }
-											placeholder="Extra Chillian"
+											<input
+												id="ec-custom-title"
+												type="text"
+												value={ customTitle }
+												onChange={ ( e ) =>
+													setCustomTitle(
+														e.target.value
+													)
+												}
+												placeholder="Extra Chillian"
 											/>
 										</FieldGroup>
 									</Panel>
@@ -330,11 +443,16 @@ function EditProfileApp( {
 							case 'about':
 								return (
 									<Panel>
-										<FieldGroup label="Bio" htmlFor="ec-bio">
+										<FieldGroup
+											label="Bio"
+											htmlFor="ec-bio"
+										>
 											<textarea
 												id="ec-bio"
 												value={ bio }
-												onChange={ ( e ) => setBio( e.target.value ) }
+												onChange={ ( e ) =>
+													setBio( e.target.value )
+												}
 											/>
 										</FieldGroup>
 									</Panel>
@@ -342,47 +460,59 @@ function EditProfileApp( {
 							case 'links':
 								return (
 									<Panel>
-										<LinksManager links={ links } linkTypes={ profile.link_types } onChange={ setLinks } />
+										<LinksManager
+											links={ links }
+											linkTypes={ profile.link_types }
+											onChange={ setLinks }
+										/>
 									</Panel>
 								);
 							case 'artist-profiles':
 								return hasArtistAccess ? (
 									<Panel>
-										<PanelHeader
-											description="Manage your artist profiles and link pages."
-										/>
-										{ hasArtists ? (
+										<PanelHeader description="Manage your artist profiles and link pages." />
+										{ hasArtists && (
 											<ActionRow>
 												<a
 													href={ `${ artistSiteUrl }/manage-artist/` }
 													className="button-2 button-small"
-													style={ styles.inlineButtonLink }
+													style={
+														styles.inlineButtonLink
+													}
 												>
 													Manage Artist
 												</a>
 											</ActionRow>
-										) : canCreateArtists ? (
+										) }
+										{ ! hasArtists && canCreateArtists && (
 											<ActionRow>
 												<a
 													href={ `${ artistSiteUrl }/create-artist/` }
 													className="button-2 button-small"
-													style={ styles.inlineButtonLink }
+													style={
+														styles.inlineButtonLink
+													}
 												>
 													Create Artist Profile
 												</a>
 											</ActionRow>
-										) : (
-											<p style={ styles.mutedText }>No artist profiles available yet.</p>
 										) }
+										{ ! hasArtists &&
+											! canCreateArtists && (
+												<p style={ styles.mutedText }>
+													No artist profiles available
+													yet.
+												</p>
+											) }
 									</Panel>
 								) : null;
-								default:
-									return null;
-							}
-						} }
-					/>
-					<ActionRow>
-						<button
+							default:
+								return null;
+						}
+					} }
+				/>
+				<ActionRow>
+					<button
 						type="button"
 						className="button-1 button-small"
 						style={ saving ? styles.disabledButton : undefined }
@@ -400,35 +530,41 @@ function EditProfileApp( {
 							View Public Profile
 						</a>
 					) }
-					</ActionRow>
+				</ActionRow>
 			</BlockShellInner>
 		</BlockShell>
 	);
 }
 
 function init(): void {
-	document.querySelectorAll<HTMLElement>( '.wp-block-extrachill-edit-profile' ).forEach( ( container ) => {
-		if ( container.dataset.initialized === '1' ) return;
+	document
+		.querySelectorAll< HTMLElement >( '.wp-block-extrachill-edit-profile' )
+		.forEach( ( container ) => {
+			if ( container.dataset.initialized === '1' ) {
+				return;
+			}
 
-		container.dataset.initialized = '1';
+			container.dataset.initialized = '1';
 
-		const artistSiteUrl = container.dataset.artistSiteUrl || 'https://artist.extrachill.com';
-		const userId = Number( container.dataset.userId || '0' );
-		const profileUrl = container.dataset.profileUrl || '#';
-		const hasArtists = container.dataset.hasArtists === '1';
-		const canCreateArtists = container.dataset.canCreateArtists === '1';
-		const root = createRoot( container );
+			const artistSiteUrl =
+				container.dataset.artistSiteUrl ||
+				'https://artist.extrachill.com';
+			const userId = Number( container.dataset.userId || '0' );
+			const profileUrl = container.dataset.profileUrl || '#';
+			const hasArtists = container.dataset.hasArtists === '1';
+			const canCreateArtists = container.dataset.canCreateArtists === '1';
+			const root = createRoot( container );
 
-		root.render(
-			<EditProfileApp
-				artistSiteUrl={ artistSiteUrl }
-				userId={ userId }
-				profileUrl={ profileUrl }
-				hasArtists={ hasArtists }
-				canCreateArtists={ canCreateArtists }
-			/>
-		);
-	} );
+			root.render(
+				<EditProfileApp
+					artistSiteUrl={ artistSiteUrl }
+					userId={ userId }
+					profileUrl={ profileUrl }
+					hasArtists={ hasArtists }
+					canCreateArtists={ canCreateArtists }
+				/>
+			);
+		} );
 }
 
 if ( document.readyState === 'loading' ) {

--- a/src/blocks/leaderboard/index.tsx
+++ b/src/blocks/leaderboard/index.tsx
@@ -5,12 +5,14 @@ import { __ } from '@wordpress/i18n';
 import { BlockIntro } from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 
-
 interface Attributes {
 	perPage: number;
 }
 
-function Edit( { attributes, setAttributes }: {
+function Edit( {
+	attributes,
+	setAttributes,
+}: {
 	attributes: Attributes;
 	setAttributes: ( attrs: Partial< Attributes > ) => void;
 } ) {
@@ -25,7 +27,10 @@ function Edit( { attributes, setAttributes }: {
 				>
 					<RangeControl
 						__nextHasNoMarginBottom
-						label={ __( 'Users per page', 'extra-chill-community' ) }
+						label={ __(
+							'Users per page',
+							'extra-chill-community'
+						) }
 						value={ perPage }
 						onChange={ ( value ) =>
 							setAttributes( { perPage: value } )
@@ -36,7 +41,12 @@ function Edit( { attributes, setAttributes }: {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<BlockIntro description={ __( 'Leaderboard — renders on the frontend.', 'extra-chill-community' ) } />
+				<BlockIntro
+					description={ __(
+						'Leaderboard — renders on the frontend.',
+						'extra-chill-community'
+					) }
+				/>
 			</div>
 		</>
 	);

--- a/src/blocks/leaderboard/view.tsx
+++ b/src/blocks/leaderboard/view.tsx
@@ -1,14 +1,26 @@
-import { useState, useEffect, useCallback } from '@wordpress/element';
-import { createRoot } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	createRoot,
+} from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { WPNativeClient } from 'wp-native-client';
 import { WpApiFetchTransport } from 'wp-native-client/wordpress';
-import { ActionRow, BlockShell, BlockShellHeader, BlockShellInner, Panel, BlockIntro } from '@extrachill/components';
+import {
+	ActionRow,
+	BlockShell,
+	BlockShellHeader,
+	BlockShellInner,
+	Panel,
+} from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 import { cssVar, colors, fontSize } from '@extrachill/tokens';
 import type { LeaderboardResponse, LeaderboardEntry } from '../../types/users';
 
-const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
+const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), {
+	validateAbilityNames: false,
+} );
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
@@ -51,7 +63,8 @@ function UserCell( { item, spriteUrl }: UserCellProps ) {
 		<>{ name }</>
 	);
 
-	const hasBadges = Array.isArray( item.badges ) && item.badges.length > 0 && spriteUrl;
+	const hasBadges =
+		Array.isArray( item.badges ) && item.badges.length > 0 && spriteUrl;
 
 	return (
 		<td>
@@ -59,7 +72,11 @@ function UserCell( { item, spriteUrl }: UserCellProps ) {
 			{ hasBadges && (
 				<span className="ec-user-badges">
 					{ item.badges.map( ( badge, i ) => {
-						if ( ! badge?.icon || ! badge?.class_name || ! badge?.title ) {
+						if (
+							! badge?.icon ||
+							! badge?.class_name ||
+							! badge?.title
+						) {
 							return null;
 						}
 						return (
@@ -99,35 +116,53 @@ function Leaderboard( { perPage, spriteUrl }: LeaderboardProps ) {
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState< string | null >( null );
 
-	const load = useCallback( ( targetPage: number ) => {
-		setLoading( true );
-		setError( null );
-		client
-			.execute< LeaderboardResponse >( 'extrachill/users-leaderboard', { page: targetPage, per_page: perPage } )
-			.then( ( response ) => {
-				setData( response );
-				setLoading( false );
-			} )
-			.catch( () => {
-				setError( 'Unable to load leaderboard.' );
-				setLoading( false );
-			} );
-	}, [ perPage ] );
+	const load = useCallback(
+		( targetPage: number ) => {
+			setLoading( true );
+			setError( null );
+			client
+				.execute< LeaderboardResponse >(
+					'extrachill/users-leaderboard',
+					{ page: targetPage, per_page: perPage }
+				)
+				.then( ( response ) => {
+					setData( response );
+					setLoading( false );
+				} )
+				.catch( () => {
+					setError( 'Unable to load leaderboard.' );
+					setLoading( false );
+				} );
+		},
+		[ perPage ]
+	);
 
 	useEffect( () => {
 		load( page );
 	}, [ page, load ] );
 
 	if ( loading ) {
-		return <div className="notice notice-info"><p>Loading leaderboard…</p></div>;
+		return (
+			<div className="notice notice-info">
+				<p>Loading leaderboard…</p>
+			</div>
+		);
 	}
 
 	if ( error ) {
-		return <div className="notice notice-error"><p>{ error }</p></div>;
+		return (
+			<div className="notice notice-error">
+				<p>{ error }</p>
+			</div>
+		);
 	}
 
 	if ( ! data || ! Array.isArray( data.items ) ) {
-		return <div className="notice notice-info"><p>No leaderboard data.</p></div>;
+		return (
+			<div className="notice notice-info">
+				<p>No leaderboard data.</p>
+			</div>
+		);
 	}
 
 	const totalPages = data.pagination?.total_pages ?? 1;
@@ -155,10 +190,17 @@ function Leaderboard( { perPage, spriteUrl }: LeaderboardProps ) {
 								{ data.items.map( ( item ) => (
 									<tr key={ item.id }>
 										<td>{ item.position }</td>
-										<UserCell item={ item } spriteUrl={ spriteUrl } />
+										<UserCell
+											item={ item }
+											spriteUrl={ spriteUrl }
+										/>
 										<td>{ item.points }</td>
 										<td>{ item.rank }</td>
-										<td>{ item.registered ? formatDate( item.registered ) : '' }</td>
+										<td>
+											{ item.registered
+												? formatDate( item.registered )
+												: '' }
+										</td>
 									</tr>
 								) ) }
 							</tbody>
@@ -169,7 +211,9 @@ function Leaderboard( { perPage, spriteUrl }: LeaderboardProps ) {
 							type="button"
 							className="button-3 button-small"
 							disabled={ page <= 1 }
-							onClick={ () => setPage( ( p ) => Math.max( 1, p - 1 ) ) }
+							onClick={ () =>
+								setPage( ( p ) => Math.max( 1, p - 1 ) )
+							}
 						>
 							Previous
 						</button>
@@ -204,12 +248,17 @@ function init(): void {
 
 			const perPage = Math.max(
 				1,
-				Math.min( 100, parseInt( container.dataset.perPage || '25', 10 ) ),
+				Math.min(
+					100,
+					parseInt( container.dataset.perPage || '25', 10 )
+				)
 			);
 			const spriteUrl = container.dataset.spriteUrl || '';
 
 			const root = createRoot( container );
-			root.render( <Leaderboard perPage={ perPage } spriteUrl={ spriteUrl } /> );
+			root.render(
+				<Leaderboard perPage={ perPage } spriteUrl={ spriteUrl } />
+			);
 		} );
 }
 

--- a/src/blocks/user-settings/index.tsx
+++ b/src/blocks/user-settings/index.tsx
@@ -9,7 +9,12 @@ function Edit() {
 
 	return (
 		<div { ...blockProps }>
-			<BlockIntro description={ __( 'User Settings — renders on the frontend.', 'extra-chill-community' ) } />
+			<BlockIntro
+				description={ __(
+					'User Settings — renders on the frontend.',
+					'extra-chill-community'
+				) }
+			/>
 		</div>
 	);
 }

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -1,10 +1,24 @@
-import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
-import { createRoot } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useCallback,
+	useRef,
+	createRoot,
+} from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { ComboboxControl } from '@wordpress/components';
 import { WPNativeClient } from 'wp-native-client';
 import { WpApiFetchTransport } from 'wp-native-client/wordpress';
-import { BlockShell, BlockShellInner, ResponsiveTabs, Panel, PanelHeader, ActionRow, FieldGroup, BlockShellHeader, BlockIntro } from '@extrachill/components';
+import {
+	BlockShell,
+	BlockShellInner,
+	ResponsiveTabs,
+	Panel,
+	PanelHeader,
+	ActionRow,
+	FieldGroup,
+	BlockShellHeader,
+} from '@extrachill/components';
 import '@extrachill/components/styles/components.scss';
 import { cssVar, spacing, colors } from '@extrachill/tokens';
 import type {
@@ -18,7 +32,9 @@ import type {
 	NotificationPreferences,
 } from '../../types/users';
 
-const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), { validateAbilityNames: false } );
+const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), {
+	validateAbilityNames: false,
+} );
 const LOCATION_SEARCH_DEBOUNCE_MS = 250;
 
 interface LocalScene {
@@ -54,7 +70,13 @@ const styles = {
 	mutedText: { color: cssVar( colors.mutedText ) },
 } as const;
 
-function Notice( { type, message }: { type: 'success' | 'error'; message: string } ) {
+function Notice( {
+	type,
+	message,
+}: {
+	type: 'success' | 'error';
+	message: string;
+} ) {
 	return (
 		<div className={ `notice notice-${ type }` }>
 			<p>{ message }</p>
@@ -62,92 +84,189 @@ function Notice( { type, message }: { type: 'success' | 'error'; message: string
 	);
 }
 
-function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate: ( updated: UserSettings ) => void } ) {
+function AccountTab( {
+	settings,
+	onUpdate,
+}: {
+	settings: UserSettings;
+	onUpdate: ( updated: UserSettings ) => void;
+} ) {
 	const [ firstName, setFirstName ] = useState( settings.first_name );
 	const [ lastName, setLastName ] = useState( settings.last_name );
 	const [ displayName, setDisplayName ] = useState( settings.display_name );
-	const [ localSceneSlug, setLocalSceneSlug ] = useState< string | null >( settings.local_scene?.slug ?? null );
-	const [ localSceneVisibility, setLocalSceneVisibility ] = useState( settings.local_scene_visibility );
+	const [ localSceneSlug, setLocalSceneSlug ] = useState< string | null >(
+		settings.local_scene?.slug ?? null
+	);
+	const [ localSceneVisibility, setLocalSceneVisibility ] = useState(
+		settings.local_scene_visibility
+	);
 	const [ localSceneChanged, setLocalSceneChanged ] = useState( false );
-	const [ locationOptions, setLocationOptions ] = useState< Array<{ label: string; value: string }> >( settings.local_scene ? [ { label: settings.local_scene.hierarchy?.label ?? settings.local_scene.name, value: settings.local_scene.slug } ] : [] );
+	const [ locationOptions, setLocationOptions ] = useState<
+		Array< { label: string; value: string } >
+	>(
+		settings.local_scene
+			? [
+					{
+						label:
+							settings.local_scene.hierarchy?.label ??
+							settings.local_scene.name,
+						value: settings.local_scene.slug,
+					},
+			  ]
+			: []
+	);
 	const [ locationSearchError, setLocationSearchError ] = useState( false );
 	const [ saving, setSaving ] = useState( false );
-	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
+	const [ notice, setNotice ] = useState< {
+		type: 'success' | 'error';
+		message: string;
+	} | null >( null );
 	const locationSearchTimeout = useRef< number | null >( null );
 	const locationSearchRequest = useRef( 0 );
 
-	const searchLocations = useCallback( ( search: string ) => {
-		const request = ++locationSearchRequest.current;
-		if ( locationSearchTimeout.current !== null ) {
-			window.clearTimeout( locationSearchTimeout.current );
-		}
-		const trimmed = search.trim();
-		if ( ! trimmed ) {
-			setLocationSearchError( false );
-			setLocationOptions( settings.local_scene ? [ { label: settings.local_scene.hierarchy?.label ?? settings.local_scene.name, value: settings.local_scene.slug } ] : [] );
-			return;
-		}
+	const searchLocations = useCallback(
+		( search: string ) => {
+			const request = ++locationSearchRequest.current;
+			if ( locationSearchTimeout.current !== null ) {
+				window.clearTimeout( locationSearchTimeout.current );
+			}
+			const trimmed = search.trim();
+			if ( ! trimmed ) {
+				setLocationSearchError( false );
+				setLocationOptions(
+					settings.local_scene
+						? [
+								{
+									label:
+										settings.local_scene.hierarchy?.label ??
+										settings.local_scene.name,
+									value: settings.local_scene.slug,
+								},
+						  ]
+						: []
+				);
+				return;
+			}
 
-		locationSearchTimeout.current = window.setTimeout( () => {
-			client.execute< EventLocationsResponse >( 'extrachill/user-event-locations', { mode: 'search', search: trimmed, limit: 10 } )
-				.then( ( result ) => {
-					if ( request === locationSearchRequest.current ) {
-						setLocationSearchError( false );
-						setLocationOptions( result.locations.map( ( location ) => ( { label: location.hierarchy.label, value: location.slug } ) ) );
-					}
-				} )
-				.catch( () => {
-					if ( request === locationSearchRequest.current ) {
-						setLocationSearchError( true );
-						setLocationOptions( [] );
-					}
-				} );
-		}, LOCATION_SEARCH_DEBOUNCE_MS );
+			locationSearchTimeout.current = window.setTimeout( () => {
+				client
+					.execute< EventLocationsResponse >(
+						'extrachill/user-event-locations',
+						{ mode: 'search', search: trimmed, limit: 10 }
+					)
+					.then( ( result ) => {
+						if ( request === locationSearchRequest.current ) {
+							setLocationSearchError( false );
+							setLocationOptions(
+								result.locations.map( ( location ) => ( {
+									label: location.hierarchy.label,
+									value: location.slug,
+								} ) )
+							);
+						}
+					} )
+					.catch( () => {
+						if ( request === locationSearchRequest.current ) {
+							setLocationSearchError( true );
+							setLocationOptions( [] );
+						}
+					} );
+			}, LOCATION_SEARCH_DEBOUNCE_MS );
+		},
+		[ settings.local_scene ]
+	);
 
-	}, [ settings.local_scene ] );
-
-	useEffect( () => () => {
-		if ( locationSearchTimeout.current !== null ) {
-			window.clearTimeout( locationSearchTimeout.current );
-		}
-	}, [] );
+	useEffect(
+		() => () => {
+			if ( locationSearchTimeout.current !== null ) {
+				window.clearTimeout( locationSearchTimeout.current );
+			}
+		},
+		[]
+	);
 
 	const handleSave = useCallback( async () => {
 		setSaving( true );
 		setNotice( null );
 		try {
-			const input: Record<string, string> = { first_name: firstName, last_name: lastName, display_name: displayName, local_scene_visibility: localSceneVisibility };
+			const input: Record< string, string > = {
+				first_name: firstName,
+				last_name: lastName,
+				display_name: displayName,
+				local_scene_visibility: localSceneVisibility,
+			};
 			if ( localSceneChanged ) {
 				input.local_scene = localSceneSlug ?? '';
 			}
-			const result = await client.execute< UserSettings & { message?: string } >( 'extrachill/update-user-settings', input );
+			const result = await client.execute<
+				UserSettings & { message?: string }
+			>( 'extrachill/update-user-settings', input );
 			onUpdate( result );
 			setLocalSceneSlug( result.local_scene?.slug ?? null );
 			setLocalSceneVisibility( result.local_scene_visibility );
 			setLocalSceneChanged( false );
-			setNotice( { type: 'success', message: result.message || 'Account details updated.' } );
+			setNotice( {
+				type: 'success',
+				message: result.message || 'Account details updated.',
+			} );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
+			setNotice( {
+				type: 'error',
+				message: err instanceof Error ? err.message : 'Update failed.',
+			} );
 		}
 		setSaving( false );
-	}, [ firstName, lastName, displayName, localSceneSlug, localSceneVisibility, localSceneChanged, onUpdate ] );
+	}, [
+		firstName,
+		lastName,
+		displayName,
+		localSceneSlug,
+		localSceneVisibility,
+		localSceneChanged,
+		onUpdate,
+	] );
 
 	return (
 		<Panel>
-			{ notice && <Notice type={ notice.type } message={ notice.message } /> }
+			{ notice && (
+				<Notice type={ notice.type } message={ notice.message } />
+			) }
 			<FieldGroup label="First Name" htmlFor="ec-first-name">
-				<input id="ec-first-name" type="text" value={ firstName } onChange={ ( e ) => setFirstName( e.target.value ) } />
+				<input
+					id="ec-first-name"
+					type="text"
+					value={ firstName }
+					onChange={ ( e ) => setFirstName( e.target.value ) }
+				/>
 			</FieldGroup>
 			<FieldGroup label="Last Name" htmlFor="ec-last-name">
-				<input id="ec-last-name" type="text" value={ lastName } onChange={ ( e ) => setLastName( e.target.value ) } />
+				<input
+					id="ec-last-name"
+					type="text"
+					value={ lastName }
+					onChange={ ( e ) => setLastName( e.target.value ) }
+				/>
 			</FieldGroup>
 			<FieldGroup label="Display Name" htmlFor="ec-display-name">
-				<select id="ec-display-name" value={ displayName } onChange={ ( e ) => setDisplayName( e.target.value ) }>
-					{ settings.display_name_options.map( ( option ) => <option key={ option } value={ option }>{ option }</option> ) }
+				<select
+					id="ec-display-name"
+					value={ displayName }
+					onChange={ ( e ) => setDisplayName( e.target.value ) }
+				>
+					{ settings.display_name_options.map( ( option ) => (
+						<option key={ option } value={ option }>
+							{ option }
+						</option>
+					) ) }
 				</select>
 			</FieldGroup>
 			<FieldGroup help="Choose the city or region that anchors your local music scene.">
-				{ locationSearchError && <Notice type="error" message="Local Scene search is temporarily unavailable." /> }
+				{ locationSearchError && (
+					<Notice
+						type="error"
+						message="Local Scene search is temporarily unavailable."
+					/>
+				) }
 				<ComboboxControl
 					label="Local Scene"
 					value={ localSceneSlug }
@@ -162,37 +281,72 @@ function AccountTab( { settings, onUpdate }: { settings: UserSettings; onUpdate:
 				/>
 			</FieldGroup>
 			<FieldGroup help="Private scenes still personalize your event experience but do not appear on your public profile or forum posts.">
-				<label>
-					<input type="checkbox" checked={ localSceneVisibility === 'public' } onChange={ ( event ) => setLocalSceneVisibility( event.target.checked ? 'public' : 'private' ) } />
+				<label htmlFor="ec-local-scene-visibility">
+					<input
+						id="ec-local-scene-visibility"
+						type="checkbox"
+						checked={ localSceneVisibility === 'public' }
+						onChange={ ( event ) =>
+							setLocalSceneVisibility(
+								event.target.checked ? 'public' : 'private'
+							)
+						}
+					/>
 					Show my Local Scene publicly
 				</label>
 			</FieldGroup>
 			<ActionRow>
-				<button className="button-1 button-small" style={ saving ? styles.button : undefined } onClick={ handleSave } disabled={ saving }>{ saving ? 'Saving...' : 'Save Account Details' }</button>
+				<button
+					className="button-1 button-small"
+					style={ saving ? styles.button : undefined }
+					onClick={ handleSave }
+					disabled={ saving }
+				>
+					{ saving ? 'Saving...' : 'Save Account Details' }
+				</button>
 			</ActionRow>
 		</Panel>
 	);
 }
 
-function SecurityTab( { settings, onSettingsChange }: { settings: UserSettings; onSettingsChange: ( updated: UserSettings ) => void } ) {
+function SecurityTab( {
+	settings,
+	onSettingsChange,
+}: {
+	settings: UserSettings;
+	onSettingsChange: ( updated: UserSettings ) => void;
+} ) {
 	const [ newEmail, setNewEmail ] = useState( '' );
 	const [ currentPassword, setCurrentPassword ] = useState( '' );
 	const [ newPassword, setNewPassword ] = useState( '' );
 	const [ confirmPassword, setConfirmPassword ] = useState( '' );
 	const [ emailSaving, setEmailSaving ] = useState( false );
 	const [ passwordSaving, setPasswordSaving ] = useState( false );
-	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
+	const [ notice, setNotice ] = useState< {
+		type: 'success' | 'error';
+		message: string;
+	} | null >( null );
 
 	const handleEmailChange = useCallback( async () => {
 		setEmailSaving( true );
 		setNotice( null );
 		try {
-			const result = await client.execute< ChangeEmailResponse >( 'extrachill/change-user-email', { new_email: newEmail } );
+			const result = await client.execute< ChangeEmailResponse >(
+				'extrachill/change-user-email',
+				{ new_email: newEmail }
+			);
 			setNotice( { type: 'success', message: result.message } );
 			setNewEmail( '' );
-			onSettingsChange( { ...settings, pending_email: result.pending_email } );
+			onSettingsChange( {
+				...settings,
+				pending_email: result.pending_email,
+			} );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Email change failed.' } );
+			setNotice( {
+				type: 'error',
+				message:
+					err instanceof Error ? err.message : 'Email change failed.',
+			} );
 		}
 		setEmailSaving( false );
 	}, [ newEmail, settings, onSettingsChange ] );
@@ -201,39 +355,131 @@ function SecurityTab( { settings, onSettingsChange }: { settings: UserSettings; 
 		setPasswordSaving( true );
 		setNotice( null );
 		try {
-			const result = await client.execute< ChangePasswordResponse >( 'extrachill/change-user-password', { current_password: currentPassword, new_password: newPassword, confirm_password: confirmPassword } );
+			const result = await client.execute< ChangePasswordResponse >(
+				'extrachill/change-user-password',
+				{
+					current_password: currentPassword,
+					new_password: newPassword,
+					confirm_password: confirmPassword,
+				}
+			);
 			setNotice( { type: 'success', message: result.message } );
 			setCurrentPassword( '' );
 			setNewPassword( '' );
 			setConfirmPassword( '' );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Password change failed.' } );
+			setNotice( {
+				type: 'error',
+				message:
+					err instanceof Error
+						? err.message
+						: 'Password change failed.',
+			} );
 		}
 		setPasswordSaving( false );
 	}, [ currentPassword, newPassword, confirmPassword ] );
 
 	return (
 		<Panel>
-			{ notice && <Notice type={ notice.type } message={ notice.message } /> }
+			{ notice && (
+				<Notice type={ notice.type } message={ notice.message } />
+			) }
 			<FieldGroup label="Current Email Address">
 				<input type="email" value={ settings.email } disabled />
-				{ settings.pending_email && <div className="notice notice-info"><p>Email change pending - verification sent to <strong>{ settings.pending_email }</strong></p><p><small>Check your inbox and click the verification link.</small></p></div> }
+				{ settings.pending_email && (
+					<div className="notice notice-info">
+						<p>
+							Email change pending - verification sent to{ ' ' }
+							<strong>{ settings.pending_email }</strong>
+						</p>
+						<p>
+							<small>
+								Check your inbox and click the verification
+								link.
+							</small>
+						</p>
+					</div>
+				) }
 			</FieldGroup>
-			<FieldGroup label="New Email Address" htmlFor="ec-new-email" help="A verification email will be sent to your new address. Your current email will remain active until verification is complete.">
-				<input id="ec-new-email" type="email" value={ newEmail } onChange={ ( e ) => setNewEmail( e.target.value ) } placeholder="Enter new email address" />
+			<FieldGroup
+				label="New Email Address"
+				htmlFor="ec-new-email"
+				help="A verification email will be sent to your new address. Your current email will remain active until verification is complete."
+			>
+				<input
+					id="ec-new-email"
+					type="email"
+					value={ newEmail }
+					onChange={ ( e ) => setNewEmail( e.target.value ) }
+					placeholder="Enter new email address"
+				/>
 			</FieldGroup>
-			<ActionRow><button className="button-1 button-small" style={ emailSaving || ! newEmail ? styles.button : undefined } onClick={ handleEmailChange } disabled={ emailSaving || ! newEmail }>{ emailSaving ? 'Sending...' : 'Change Email' }</button></ActionRow>
-			<hr style={ { border: 'none', borderTop: `1px solid ${ cssVar( colors.borderColor ) }`, margin: `${ cssVar( spacing.spacingLg ) } 0` } } />
-			<FieldGroup label="Current Password" htmlFor="ec-current-pass" required>
-				<input id="ec-current-pass" type="password" value={ currentPassword } onChange={ ( e ) => setCurrentPassword( e.target.value ) } autoComplete="current-password" />
+			<ActionRow>
+				<button
+					className="button-1 button-small"
+					style={
+						emailSaving || ! newEmail ? styles.button : undefined
+					}
+					onClick={ handleEmailChange }
+					disabled={ emailSaving || ! newEmail }
+				>
+					{ emailSaving ? 'Sending...' : 'Change Email' }
+				</button>
+			</ActionRow>
+			<hr
+				style={ {
+					border: 'none',
+					borderTop: `1px solid ${ cssVar( colors.borderColor ) }`,
+					margin: `${ cssVar( spacing.spacingLg ) } 0`,
+				} }
+			/>
+			<FieldGroup
+				label="Current Password"
+				htmlFor="ec-current-pass"
+				required
+			>
+				<input
+					id="ec-current-pass"
+					type="password"
+					value={ currentPassword }
+					onChange={ ( e ) => setCurrentPassword( e.target.value ) }
+					autoComplete="current-password"
+				/>
 			</FieldGroup>
 			<FieldGroup label="New Password" htmlFor="ec-new-pass">
-				<input id="ec-new-pass" type="password" value={ newPassword } onChange={ ( e ) => setNewPassword( e.target.value ) } autoComplete="new-password" />
+				<input
+					id="ec-new-pass"
+					type="password"
+					value={ newPassword }
+					onChange={ ( e ) => setNewPassword( e.target.value ) }
+					autoComplete="new-password"
+				/>
 			</FieldGroup>
 			<FieldGroup label="Confirm New Password" htmlFor="ec-confirm-pass">
-				<input id="ec-confirm-pass" type="password" value={ confirmPassword } onChange={ ( e ) => setConfirmPassword( e.target.value ) } autoComplete="new-password" />
+				<input
+					id="ec-confirm-pass"
+					type="password"
+					value={ confirmPassword }
+					onChange={ ( e ) => setConfirmPassword( e.target.value ) }
+					autoComplete="new-password"
+				/>
 			</FieldGroup>
-			<ActionRow><button className="button-1 button-small" style={ passwordSaving || ! currentPassword || ! newPassword ? styles.button : undefined } onClick={ handlePasswordChange } disabled={ passwordSaving || ! currentPassword || ! newPassword }>{ passwordSaving ? 'Changing...' : 'Change Password' }</button></ActionRow>
+			<ActionRow>
+				<button
+					className="button-1 button-small"
+					style={
+						passwordSaving || ! currentPassword || ! newPassword
+							? styles.button
+							: undefined
+					}
+					onClick={ handlePasswordChange }
+					disabled={
+						passwordSaving || ! currentPassword || ! newPassword
+					}
+				>
+					{ passwordSaving ? 'Changing...' : 'Change Password' }
+				</button>
+			</ActionRow>
 		</Panel>
 	);
 }
@@ -242,23 +488,37 @@ function SubscriptionsTab() {
 	const [ data, setData ] = useState< UserSubscriptions | null >( null );
 	const [ loading, setLoading ] = useState( true );
 	const [ saving, setSaving ] = useState( false );
-	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
-	const [ consented, setConsented ] = useState< Set<number> >( new Set() );
+	const [ notice, setNotice ] = useState< {
+		type: 'success' | 'error';
+		message: string;
+	} | null >( null );
+	const [ consented, setConsented ] = useState< Set< number > >( new Set() );
 
 	useEffect( () => {
-		client.execute< UserSubscriptions >( 'extrachill/get-subscriptions' ).then( ( result ) => {
-			setData( result );
-			const ids = new Set<number>();
-			result.followed_artists.forEach( ( a: FollowedArtist ) => { if ( a.email_consent ) ids.add( a.artist_id ); } );
-			setConsented( ids );
-			setLoading( false );
-		} ).catch( () => setLoading( false ) );
+		client
+			.execute< UserSubscriptions >( 'extrachill/get-subscriptions' )
+			.then( ( result ) => {
+				setData( result );
+				const ids = new Set< number >();
+				result.followed_artists.forEach( ( a: FollowedArtist ) => {
+					if ( a.email_consent ) {
+						ids.add( a.artist_id );
+					}
+				} );
+				setConsented( ids );
+				setLoading( false );
+			} )
+			.catch( () => setLoading( false ) );
 	}, [] );
 
 	const toggleConsent = useCallback( ( artistId: number ) => {
 		setConsented( ( prev ) => {
 			const next = new Set( prev );
-			next.has( artistId ) ? next.delete( artistId ) : next.add( artistId );
+			if ( next.has( artistId ) ) {
+				next.delete( artistId );
+			} else {
+				next.add( artistId );
+			}
 			return next;
 		} );
 	}, [] );
@@ -267,27 +527,93 @@ function SubscriptionsTab() {
 		setSaving( true );
 		setNotice( null );
 		try {
-			await client.execute( 'extrachill/update-subscriptions', { consented_artists: Array.from( consented ) } );
-			setNotice( { type: 'success', message: 'Subscription preferences updated.' } );
+			await client.execute( 'extrachill/update-subscriptions', {
+				consented_artists: Array.from( consented ),
+			} );
+			setNotice( {
+				type: 'success',
+				message: 'Subscription preferences updated.',
+			} );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
+			setNotice( {
+				type: 'error',
+				message: err instanceof Error ? err.message : 'Update failed.',
+			} );
 		}
 		setSaving( false );
 	}, [ consented ] );
 
-	if ( loading ) return <div className="notice notice-info"><p>Loading subscriptions...</p></div>;
+	if ( loading ) {
+		return (
+			<div className="notice notice-info">
+				<p>Loading subscriptions...</p>
+			</div>
+		);
+	}
 	const artists = data?.followed_artists || [];
 
 	return (
 		<Panel>
 			<PanelHeader description="Manage email consent for bands you follow. Unchecking will prevent a band from seeing your email or including it in their exports." />
-			{ notice && <Notice type={ notice.type } message={ notice.message } /> }
-			{ artists.length === 0 ? <p style={ styles.mutedText }>You are not currently following any bands.</p> : <>
-				<ul style={ styles.checkboxList }>
-					{ artists.map( ( artist: FollowedArtist ) => <li key={ artist.artist_id } style={ styles.checkboxItem }><input type="checkbox" id={ `ec-consent-${ artist.artist_id }` } checked={ consented.has( artist.artist_id ) } onChange={ () => toggleConsent( artist.artist_id ) } /><label htmlFor={ `ec-consent-${ artist.artist_id }` } style={ { fontWeight: 'normal', cursor: 'pointer' } }>Share my email with <a href={ artist.url } target="_blank" rel="noopener noreferrer" style={ { color: cssVar( colors.linkColor ) } }>{ artist.name }</a></label></li> ) }
-				</ul>
-				<ActionRow><button className="button-1 button-small" style={ saving ? styles.button : undefined } onClick={ handleSave } disabled={ saving }>{ saving ? 'Saving...' : 'Save Preferences' }</button></ActionRow>
-			</>}
+			{ notice && (
+				<Notice type={ notice.type } message={ notice.message } />
+			) }
+			{ artists.length === 0 ? (
+				<p style={ styles.mutedText }>
+					You are not currently following any bands.
+				</p>
+			) : (
+				<>
+					<ul style={ styles.checkboxList }>
+						{ artists.map( ( artist: FollowedArtist ) => (
+							<li
+								key={ artist.artist_id }
+								style={ styles.checkboxItem }
+							>
+								<input
+									type="checkbox"
+									id={ `ec-consent-${ artist.artist_id }` }
+									checked={ consented.has(
+										artist.artist_id
+									) }
+									onChange={ () =>
+										toggleConsent( artist.artist_id )
+									}
+								/>
+								<label
+									htmlFor={ `ec-consent-${ artist.artist_id }` }
+									style={ {
+										fontWeight: 'normal',
+										cursor: 'pointer',
+									} }
+								>
+									Share my email with{ ' ' }
+									<a
+										href={ artist.url }
+										target="_blank"
+										rel="noopener noreferrer"
+										style={ {
+											color: cssVar( colors.linkColor ),
+										} }
+									>
+										{ artist.name }
+									</a>
+								</label>
+							</li>
+						) ) }
+					</ul>
+					<ActionRow>
+						<button
+							className="button-1 button-small"
+							style={ saving ? styles.button : undefined }
+							onClick={ handleSave }
+							disabled={ saving }
+						>
+							{ saving ? 'Saving...' : 'Save Preferences' }
+						</button>
+					</ActionRow>
+				</>
+			) }
 		</Panel>
 	);
 }
@@ -297,112 +623,349 @@ function NotificationsTab() {
 	const [ saving, setSaving ] = useState( false );
 	const [ emailsEnabled, setEmailsEnabled ] = useState( true );
 	const [ autoSubscribe, setAutoSubscribe ] = useState( true );
-	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
+	const [ notice, setNotice ] = useState< {
+		type: 'success' | 'error';
+		message: string;
+	} | null >( null );
 
 	useEffect( () => {
-		client.execute< NotificationPreferences >( 'extrachill/get-notification-preferences' ).then( ( result ) => {
-			setEmailsEnabled( result.emails_enabled );
-			setAutoSubscribe( result.auto_subscribe_replies );
-			setLoading( false );
-		} ).catch( () => setLoading( false ) );
+		client
+			.execute< NotificationPreferences >(
+				'extrachill/get-notification-preferences'
+			)
+			.then( ( result ) => {
+				setEmailsEnabled( result.emails_enabled );
+				setAutoSubscribe( result.auto_subscribe_replies );
+				setLoading( false );
+			} )
+			.catch( () => setLoading( false ) );
 	}, [] );
 
 	const handleSave = useCallback( async () => {
 		setSaving( true );
 		setNotice( null );
 		try {
-			await client.execute( 'extrachill/update-notification-preferences', { emails_enabled: emailsEnabled, auto_subscribe_replies: autoSubscribe } );
-			setNotice( { type: 'success', message: 'Notification preferences updated.' } );
+			await client.execute(
+				'extrachill/update-notification-preferences',
+				{
+					emails_enabled: emailsEnabled,
+					auto_subscribe_replies: autoSubscribe,
+				}
+			);
+			setNotice( {
+				type: 'success',
+				message: 'Notification preferences updated.',
+			} );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Update failed.' } );
+			setNotice( {
+				type: 'error',
+				message: err instanceof Error ? err.message : 'Update failed.',
+			} );
 		}
 		setSaving( false );
 	}, [ emailsEnabled, autoSubscribe ] );
 
-	if ( loading ) return <div className="notice notice-info"><p>Loading notification preferences...</p></div>;
+	if ( loading ) {
+		return (
+			<div className="notice notice-info">
+				<p>Loading notification preferences...</p>
+			</div>
+		);
+	}
 
 	return (
 		<Panel>
 			<PanelHeader description="Control how Extra Chill keeps you in the loop." />
-			{ notice && <Notice type={ notice.type } message={ notice.message } /> }
+			{ notice && (
+				<Notice type={ notice.type } message={ notice.message } />
+			) }
 			<ul style={ styles.checkboxList }>
 				<li style={ styles.checkboxItem }>
-					<input type="checkbox" id="ec-notif-emails" checked={ emailsEnabled } onChange={ ( e ) => setEmailsEnabled( e.target.checked ) } />
-					<label htmlFor="ec-notif-emails" style={ { fontWeight: 'normal', cursor: 'pointer' } }>
+					<input
+						type="checkbox"
+						id="ec-notif-emails"
+						checked={ emailsEnabled }
+						onChange={ ( e ) =>
+							setEmailsEnabled( e.target.checked )
+						}
+					/>
+					<label
+						htmlFor="ec-notif-emails"
+						style={ { fontWeight: 'normal', cursor: 'pointer' } }
+					>
 						<strong>Email notifications</strong>
-						<div style={ styles.mutedText }>Receive email digests for your notifications.</div>
+						<div style={ styles.mutedText }>
+							Receive email digests for your notifications.
+						</div>
 					</label>
 				</li>
 				<li style={ styles.checkboxItem }>
-					<input type="checkbox" id="ec-notif-auto-subscribe" checked={ autoSubscribe } onChange={ ( e ) => setAutoSubscribe( e.target.checked ) } />
-					<label htmlFor="ec-notif-auto-subscribe" style={ { fontWeight: 'normal', cursor: 'pointer' } }>
+					<input
+						type="checkbox"
+						id="ec-notif-auto-subscribe"
+						checked={ autoSubscribe }
+						onChange={ ( e ) =>
+							setAutoSubscribe( e.target.checked )
+						}
+					/>
+					<label
+						htmlFor="ec-notif-auto-subscribe"
+						style={ { fontWeight: 'normal', cursor: 'pointer' } }
+					>
 						<strong>Auto-subscribe to replies</strong>
-						<div style={ styles.mutedText }>Automatically follow topics you reply to.</div>
+						<div style={ styles.mutedText }>
+							Automatically follow topics you reply to.
+						</div>
 					</label>
 				</li>
 			</ul>
-			<ActionRow><button className="button-1 button-small" style={ saving ? styles.button : undefined } onClick={ handleSave } disabled={ saving }>{ saving ? 'Saving...' : 'Save Preferences' }</button></ActionRow>
+			<ActionRow>
+				<button
+					className="button-1 button-small"
+					style={ saving ? styles.button : undefined }
+					onClick={ handleSave }
+					disabled={ saving }
+				>
+					{ saving ? 'Saving...' : 'Save Preferences' }
+				</button>
+			</ActionRow>
 		</Panel>
 	);
 }
 
-function ArtistPlatformTab( { artistAccess, artistSiteUrl, hasArtists, canCreateArtists }: { artistAccess: { status: string; type: string; request_type?: string; requested_at?: number }; artistSiteUrl: string; hasArtists: boolean; canCreateArtists: boolean } ) {
-	const [ accessType, setAccessType ] = useState<'artist' | 'professional'>( 'artist' );
+function ArtistPlatformTab( {
+	artistAccess,
+	artistSiteUrl,
+	hasArtists,
+	canCreateArtists,
+}: {
+	artistAccess: {
+		status: string;
+		type: string;
+		request_type?: string;
+		requested_at?: number;
+	};
+	artistSiteUrl: string;
+	hasArtists: boolean;
+	canCreateArtists: boolean;
+} ) {
+	const [ accessType, setAccessType ] = useState< 'artist' | 'professional' >(
+		'artist'
+	);
 	const [ submitting, setSubmitting ] = useState( false );
-	const [ notice, setNotice ] = useState< { type: 'success' | 'error'; message: string } | null >( null );
+	const [ notice, setNotice ] = useState< {
+		type: 'success' | 'error';
+		message: string;
+	} | null >( null );
 	const [ currentStatus, setCurrentStatus ] = useState( artistAccess.status );
 
 	const handleRequest = useCallback( async () => {
 		setSubmitting( true );
 		setNotice( null );
 		try {
-			const result = await client.execute< RequestArtistAccessResponse >( 'extrachill/request-artist-access', { type: accessType } );
+			const result = await client.execute< RequestArtistAccessResponse >(
+				'extrachill/request-artist-access',
+				{ type: accessType }
+			);
 			setNotice( { type: 'success', message: result.message } );
 			setCurrentStatus( 'pending' );
 		} catch ( err ) {
-			setNotice( { type: 'error', message: err instanceof Error ? err.message : 'Request failed.' } );
+			setNotice( {
+				type: 'error',
+				message: err instanceof Error ? err.message : 'Request failed.',
+			} );
 		}
 		setSubmitting( false );
 	}, [ accessType ] );
 
 	return (
 		<Panel>
-			{ notice && <Notice type={ notice.type } message={ notice.message } /> }
-			{ currentStatus === 'approved' && <div className="notice notice-success"><p><strong>You have artist platform access!</strong></p><p>You can create artist profiles and link pages on extrachill.link.</p>{ hasArtists ? <ActionRow><a href={ `${ artistSiteUrl }/manage-artist/` } className="button-1 button-small">Manage Artist</a></ActionRow> : canCreateArtists ? <ActionRow><a href={ `${ artistSiteUrl }/create-artist/` } className="button-1 button-small">Create Artist Profile</a></ActionRow> : null }</div> }
-			{ currentStatus === 'pending' && <div className="notice notice-info"><p><strong>Your request is pending admin review.</strong></p>{ artistAccess.request_type && <p>You requested access as "{ artistAccess.request_type === 'artist' ? 'I am a musician' : 'I work in the music industry' }"{ artistAccess.requested_at ? ` on ${ new Date( artistAccess.requested_at * 1000 ).toLocaleDateString() }` : '' }.</p> }<p>An administrator will review your request shortly.</p></div> }
-			{ currentStatus === 'none' && <><p style={ { ...styles.mutedText, marginBottom: cssVar( spacing.spacingMd ) } }>Get access to create artist profiles and link pages on extrachill.link.</p><fieldset><legend>Select which best describes you:</legend><p><label><input type="radio" name="ec-artist-access-type" value="artist" checked={ accessType === 'artist' } onChange={ () => setAccessType( 'artist' ) } />I am a musician</label></p><p><label><input type="radio" name="ec-artist-access-type" value="professional" checked={ accessType === 'professional' } onChange={ () => setAccessType( 'professional' ) } />I work in the music industry</label></p></fieldset><ActionRow><button className="button-1 button-small" style={ submitting ? styles.button : undefined } onClick={ handleRequest } disabled={ submitting }>{ submitting ? 'Submitting...' : 'Request Access' }</button></ActionRow></> }
+			{ notice && (
+				<Notice type={ notice.type } message={ notice.message } />
+			) }
+			{ currentStatus === 'approved' && (
+				<div className="notice notice-success">
+					<p>
+						<strong>You have artist platform access!</strong>
+					</p>
+					<p>
+						You can create artist profiles and link pages on
+						extrachill.link.
+					</p>
+					{ hasArtists && (
+						<ActionRow>
+							<a
+								href={ `${ artistSiteUrl }/manage-artist/` }
+								className="button-1 button-small"
+							>
+								Manage Artist
+							</a>
+						</ActionRow>
+					) }
+					{ ! hasArtists && canCreateArtists && (
+						<ActionRow>
+							<a
+								href={ `${ artistSiteUrl }/create-artist/` }
+								className="button-1 button-small"
+							>
+								Create Artist Profile
+							</a>
+						</ActionRow>
+					) }
+				</div>
+			) }
+			{ currentStatus === 'pending' && (
+				<div className="notice notice-info">
+					<p>
+						<strong>Your request is pending admin review.</strong>
+					</p>
+					{ artistAccess.request_type && (
+						<p>
+							You requested access as &quot;
+							{ artistAccess.request_type === 'artist'
+								? 'I am a musician'
+								: 'I work in the music industry' }
+							&quot;
+							{ artistAccess.requested_at
+								? ` on ${ new Date(
+										artistAccess.requested_at * 1000
+								  ).toLocaleDateString() }`
+								: '' }
+							.
+						</p>
+					) }
+					<p>An administrator will review your request shortly.</p>
+				</div>
+			) }
+			{ currentStatus === 'none' && (
+				<>
+					<p
+						style={ {
+							...styles.mutedText,
+							marginBottom: cssVar( spacing.spacingMd ),
+						} }
+					>
+						Get access to create artist profiles and link pages on
+						extrachill.link.
+					</p>
+					<fieldset>
+						<legend>Select which best describes you:</legend>
+						<p>
+							<label htmlFor="ec-artist-access-type-artist">
+								<input
+									id="ec-artist-access-type-artist"
+									type="radio"
+									name="ec-artist-access-type"
+									value="artist"
+									checked={ accessType === 'artist' }
+									onChange={ () => setAccessType( 'artist' ) }
+								/>
+								I am a musician
+							</label>
+						</p>
+						<p>
+							<label htmlFor="ec-artist-access-type-professional">
+								<input
+									id="ec-artist-access-type-professional"
+									type="radio"
+									name="ec-artist-access-type"
+									value="professional"
+									checked={ accessType === 'professional' }
+									onChange={ () =>
+										setAccessType( 'professional' )
+									}
+								/>
+								I work in the music industry
+							</label>
+						</p>
+					</fieldset>
+					<ActionRow>
+						<button
+							className="button-1 button-small"
+							style={ submitting ? styles.button : undefined }
+							onClick={ handleRequest }
+							disabled={ submitting }
+						>
+							{ submitting ? 'Submitting...' : 'Request Access' }
+						</button>
+					</ActionRow>
+				</>
+			) }
 		</Panel>
 	);
 }
 
-type TabId = 'account-details' | 'security' | 'subscriptions' | 'notifications' | 'artist-platform';
+type TabId =
+	| 'account-details'
+	| 'security'
+	| 'subscriptions'
+	| 'notifications'
+	| 'artist-platform';
 
-function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId }: { artistSiteUrl: string; hasArtists: boolean; canCreateArtists: boolean; userId: number } ) {
-	const [ activeTab, setActiveTab ] = useState<TabId>( 'account-details' );
-	const [ settings, setSettings ] = useState<UserSettings | null>( null );
+function UserSettingsApp( {
+	artistSiteUrl,
+	hasArtists,
+	canCreateArtists,
+	userId,
+}: {
+	artistSiteUrl: string;
+	hasArtists: boolean;
+	canCreateArtists: boolean;
+	userId: number;
+} ) {
+	const [ activeTab, setActiveTab ] = useState< TabId >( 'account-details' );
+	const [ settings, setSettings ] = useState< UserSettings | null >( null );
 	const [ loading, setLoading ] = useState( true );
-	const [ error, setError ] = useState<string | null>( null );
-	const [ artistAccess, setArtistAccess ] = useState<{ status: string; type: string; request_type?: string; requested_at?: number }>( { status: 'none', type: '' } );
+	const [ error, setError ] = useState< string | null >( null );
+	const [ artistAccess, setArtistAccess ] = useState< {
+		status: string;
+		type: string;
+		request_type?: string;
+		requested_at?: number;
+	} >( { status: 'none', type: '' } );
 
 	useEffect( () => {
 		Promise.all( [
 			client.execute< UserSettings >( 'extrachill/get-user-settings' ),
-			client.execute< UserProfile >( 'extrachill/get-user-profile', { user_id: userId } ),
-		] ).then( ( [ settingsData, profileData ] ) => {
-			setSettings( settingsData );
-			setArtistAccess( profileData.artist_access );
-			setLoading( false );
-		} ).catch( ( err ) => {
-			setError( err instanceof Error ? err.message : 'Failed to load settings.' );
-			setLoading( false );
-		} );
+			client.execute< UserProfile >( 'extrachill/get-user-profile', {
+				user_id: userId,
+			} ),
+		] )
+			.then( ( [ settingsData, profileData ] ) => {
+				setSettings( settingsData );
+				setArtistAccess( profileData.artist_access );
+				setLoading( false );
+			} )
+			.catch( ( err ) => {
+				setError(
+					err instanceof Error
+						? err.message
+						: 'Failed to load settings.'
+				);
+				setLoading( false );
+			} );
 	}, [] );
 
-	const switchTab = useCallback( ( tab: TabId ) => { setActiveTab( tab ); }, [] );
-	if ( loading ) return <div className="notice notice-info"><p>Loading settings...</p></div>;
-	if ( error || ! settings ) return <Notice type="error" message={ error || 'Failed to load settings.' } />;
+	const switchTab = useCallback( ( tab: TabId ) => {
+		setActiveTab( tab );
+	}, [] );
+	if ( loading ) {
+		return (
+			<div className="notice notice-info">
+				<p>Loading settings...</p>
+			</div>
+		);
+	}
+	if ( error || ! settings ) {
+		return (
+			<Notice
+				type="error"
+				message={ error || 'Failed to load settings.' }
+			/>
+		);
+	}
 
-	const tabs: Array<{ id: TabId; label: string }> = [
+	const tabs: Array< { id: TabId; label: string } > = [
 		{ id: 'account-details', label: 'Account Details' },
 		{ id: 'security', label: 'Security' },
 		{ id: 'subscriptions', label: 'Subscriptions' },
@@ -413,15 +976,32 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId 
 	const renderTabPanel = ( id: string ) => {
 		switch ( id as TabId ) {
 			case 'account-details':
-				return <AccountTab settings={ settings } onUpdate={ setSettings } />;
+				return (
+					<AccountTab
+						settings={ settings }
+						onUpdate={ setSettings }
+					/>
+				);
 			case 'security':
-				return <SecurityTab settings={ settings } onSettingsChange={ setSettings } />;
+				return (
+					<SecurityTab
+						settings={ settings }
+						onSettingsChange={ setSettings }
+					/>
+				);
 			case 'subscriptions':
 				return <SubscriptionsTab />;
 			case 'notifications':
 				return <NotificationsTab />;
 			case 'artist-platform':
-				return <ArtistPlatformTab artistAccess={ artistAccess } artistSiteUrl={ artistSiteUrl } hasArtists={ hasArtists } canCreateArtists={ canCreateArtists } />;
+				return (
+					<ArtistPlatformTab
+						artistAccess={ artistAccess }
+						artistSiteUrl={ artistSiteUrl }
+						hasArtists={ hasArtists }
+						canCreateArtists={ canCreateArtists }
+					/>
+				);
 			default:
 				return null;
 		}
@@ -430,7 +1010,10 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId 
 	return (
 		<BlockShell>
 			<BlockShellInner maxWidth="narrow">
-				<BlockShellHeader title="Settings" description="Manage your account, security, subscriptions, notifications, and artist platform access." />
+				<BlockShellHeader
+					title="Settings"
+					description="Manage your account, security, subscriptions, notifications, and artist platform access."
+				/>
 				<ResponsiveTabs
 					tabs={ tabs }
 					active={ activeTab }
@@ -445,16 +1028,29 @@ function UserSettingsApp( { artistSiteUrl, hasArtists, canCreateArtists, userId 
 }
 
 function init(): void {
-	document.querySelectorAll<HTMLElement>( '.wp-block-extrachill-user-settings' ).forEach( ( container ) => {
-		if ( container.dataset.initialized === '1' ) return;
-		container.dataset.initialized = '1';
-		const artistSiteUrl = container.dataset.artistSiteUrl || 'https://artist.extrachill.com';
-		const hasArtists = container.dataset.hasArtists === '1';
-		const canCreateArtists = container.dataset.canCreateArtists === '1';
-		const userId = Number( container.dataset.userId || '0' );
-		const root = createRoot( container );
-		root.render( <UserSettingsApp artistSiteUrl={ artistSiteUrl } hasArtists={ hasArtists } canCreateArtists={ canCreateArtists } userId={ userId } /> );
-	} );
+	document
+		.querySelectorAll< HTMLElement >( '.wp-block-extrachill-user-settings' )
+		.forEach( ( container ) => {
+			if ( container.dataset.initialized === '1' ) {
+				return;
+			}
+			container.dataset.initialized = '1';
+			const artistSiteUrl =
+				container.dataset.artistSiteUrl ||
+				'https://artist.extrachill.com';
+			const hasArtists = container.dataset.hasArtists === '1';
+			const canCreateArtists = container.dataset.canCreateArtists === '1';
+			const userId = Number( container.dataset.userId || '0' );
+			const root = createRoot( container );
+			root.render(
+				<UserSettingsApp
+					artistSiteUrl={ artistSiteUrl }
+					hasArtists={ hasArtists }
+					canCreateArtists={ canCreateArtists }
+					userId={ userId }
+				/>
+			);
+		} );
 }
 
 if ( document.readyState === 'loading' ) {

--- a/src/term-picker/TermPicker.tsx
+++ b/src/term-picker/TermPicker.tsx
@@ -334,6 +334,7 @@ export function TermPicker( { config }: TermPickerProps ) {
 						{ loading && (
 							<li
 								className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
+								role="option"
 								aria-disabled="true"
 							>
 								{ __( 'Searching…', 'extra-chill-community' ) }
@@ -342,6 +343,7 @@ export function TermPicker( { config }: TermPickerProps ) {
 						{ ! loading && visibleSuggestions.length === 0 && (
 							<li
 								className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
+								role="option"
 								aria-disabled="true"
 							>
 								{ __(

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -113,7 +113,7 @@ export interface UserProfile {
 	bio: string;
 	local_scene?: LocalScene | null;
 	links: UserLink[];
-	link_types: Record<string, string>;
+	link_types: Record< string, string >;
 	artist_access: ArtistAccessStatus;
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
 /**
  * Custom webpack extends @wordpress/scripts defaults.
  *
- * - Disables strict ESM resolution for .mjs files so that
- *   @extrachill/tokens (and similar packages) can import
- *   internal modules without explicit extensions.
+ * - Disables strict ESM resolution for .mjs files so packages
+ *   like `@extrachill/tokens` can import internal modules without
+ *   explicit extensions.
  * - Adds the standalone composer term-picker entry (not a block — it mounts
  *   into the server-rendered bbPress topic form) alongside the default
  *   block.json-discovered entries.
@@ -18,11 +18,16 @@ module.exports = {
 	...defaultConfig,
 	entry: ( ...args ) => {
 		const blockEntries =
-			typeof defaultEntry === 'function' ? defaultEntry( ...args ) : defaultEntry;
+			typeof defaultEntry === 'function'
+				? defaultEntry( ...args )
+				: defaultEntry;
 
 		return {
 			...blockEntries,
-			'term-picker': path.resolve( process.cwd(), 'src/term-picker/index.tsx' ),
+			'term-picker': path.resolve(
+				process.cwd(),
+				'src/term-picker/index.tsx'
+			),
 		};
 	},
 	module: {


### PR DESCRIPTION
Closes #177.

## Summary

Clears all pre-existing ESLint errors so `npx wp-scripts lint-js inc/assets/js src webpack.config.js` (the homeboy release lint gate) passes with **0 errors**. No behavior changes; build still compiles.

**Final state:** 0 errors, 1 pre-existing `react-hooks/exhaustive-deps` warning that also predates this work (warnings are acceptable per the issue).

## Root cause of the bulk (~600 of 677 errors)

The project ships `.ts/.tsx` but did **not** list `typescript` as a devDependency, so the `@wordpress/eslint-plugin` TypeScript override — which gates on `isPackageInstalled('typescript')` (see `node_modules/@wordpress/eslint-plugin/configs/recommended.js`) — never activated. Babel was left to strip TS syntax, and eslint's core `no-undef` / `camelcase` then fired on **type-position** identifiers: interface property names (`per_page`, `total_pages`), DOM/lib globals in generics (`HTMLElement`/`Node`/`HTMLDivElement` in `useRef<T>`), snake_case API fields, and type aliases (`TabId`, `TermPickerProps`, `ReturnType`).

These are the same `no-undef`/`camelcase` findings the issue attributed to "browser/DOM globals needing `/* global */` comments," but on inspection they are almost entirely type-level, not runtime references. Adding `typescript@5.4.5` activates the shipped override + the real `@typescript-eslint/parser`, which understands type positions natively. `src/types/users.ts` alone dropped from **135 → 1** error.

A compatible TS version was required: the transitively-installed `@typescript-eslint@6.21` crashes with newer TS (`ts-api-utils` "Cannot read properties of undefined (reading 'Intrinsic')"), and `5.4.5` is the matching version per the 6.x support matrix.

## Changes

- **Add `typescript` ^5.4.5 devDependency** — activates the wp-scripts TS override as designed. `package-lock.json` is gitignored in this repo, so only `package.json` is committed.
- **`eslint --fix`** for the mechanical bulk (prettier formatting, `no-var`, `object-shorthand`, `curly`, `@wordpress/dependency-group` comment blocks). This accounts for the large diff.
- **Remove unused `BlockIntro` imports** in edit-profile, leaderboard, and user-settings (imported, never rendered).
- **Unused `notice` binding** (edit-profile): the state is set via `setNotice` on success/error paths but never read — a staged, unfinished feature. Changed `const [ notice, setNotice ]` → `const [, setNotice]` (destructuring hole). `setNotice` keeps working exactly as before; zero behavior change.
- **`jsx-a11y/label-has-associated-control`**: the wp-scripts config sets `assert: 'htmlFor'`, so label-wrapping-input (nesting) alone is insufficient. Added explicit `htmlFor`/`id` pairing to the avatar-upload label (edit-profile) and the local-scene visibility checkbox + artist-access radios (user-settings).
- **`jsx-a11y/role-supports-aria-props`**: the two term-picker status `<li>` items (`Searching…`, `No matching terms`) had `aria-disabled`, which isn't supported by the implicit `listitem` role. Added `role="option"` to each — consistent with the sibling selectable suggestions (which already use `role="option"`) and makes `aria-disabled` valid, preserving the non-selectable intent rather than dropping it.
- **`no-nested-ternary`**: flattened the artist-access conditionals (edit-profile and user-settings) into short-circuit `&&` blocks. Behavior identical.
- **`no-unused-expressions`**: converted a ternary-as-statement (`next.has(id) ? next.delete(id) : next.add(id)`) in user-settings to an `if/else`.
- **`react/no-unescaped-entities`**: escaped bare `"` in the artist-access pending notice as `&quot;` (preserves straight-quote rendering).
- **`jsdoc/check-tag-names`**: reworded prose `@tokens` at JSDoc line-start in `webpack.config.js` (`@extrachill/tokens`) and `bbpress-blocks-mentions.js` (`@mentions`) so they are no longer parsed as tag names.
- **`@wordpress/i18n-translator-comments`**: moved the translators comment to immediately precede the `__()` gettext call in contribution-heatmap (it previously sat before the wrapping `sprintf(`).

## Verification

```
$ npx wp-scripts lint-js inc/assets/js src webpack.config.js
✖ 1 problem (0 errors, 1 warning)   # pre-existing react-hooks/exhaustive-deps

$ npx wp-scripts build
webpack 5.108.4 compiled successfully
```

Behavior changes: **none** — pure mechanical lint/config cleanup. No CHANGELOG or version bumps (homeboy owns both).