### PR TITLE
feat: prompt members to choose Local Scene

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -45,6 +45,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/bbpress-scripts.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/filter-bar.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/notice-bridge.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/local-scene-member-prompt.php';
 
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/blocks-everywhere.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/draft-abilities-category.php';

--- a/inc/assets/css/local-scene-member-prompt.css
+++ b/inc/assets/css/local-scene-member-prompt.css
@@ -1,0 +1,89 @@
+.ec-local-scene-prompt {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(360px, 1.4fr);
+	gap: var(--spacing-lg);
+	align-items: center;
+	width: min(var(--content-width), calc(100% - (2 * var(--spacing-md))));
+	margin: var(--spacing-md) auto;
+	padding: var(--spacing-md);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--card-background);
+}
+
+.ec-local-scene-prompt h2,
+.ec-local-scene-prompt p {
+	margin: 0;
+}
+
+.ec-local-scene-prompt h2 {
+	font-size: var(--font-size-lg);
+}
+
+.ec-local-scene-prompt__copy p,
+.ec-local-scene-prompt__status {
+	color: var(--muted-text);
+}
+
+.ec-local-scene-prompt__form,
+.ec-local-scene-prompt__actions {
+	display: flex;
+	gap: var(--spacing-sm);
+	align-items: center;
+}
+
+.ec-local-scene-prompt__picker {
+	position: relative;
+	flex: 1 1 240px;
+}
+
+.ec-local-scene-prompt__picker input[type="search"] {
+	width: 100%;
+}
+
+.ec-local-scene-prompt__results {
+	position: absolute;
+	z-index: 20;
+	top: calc(100% + var(--spacing-xs));
+	left: 0;
+	right: 0;
+	max-height: 220px;
+	overflow-y: auto;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-sm);
+	background: var(--card-background);
+}
+
+.ec-local-scene-prompt__option {
+	padding: var(--spacing-sm);
+	cursor: pointer;
+}
+
+.ec-local-scene-prompt__option[aria-selected="true"],
+.ec-local-scene-prompt__option:hover {
+	background: var(--background-color);
+}
+
+.ec-local-scene-prompt__visibility {
+	white-space: nowrap;
+}
+
+.ec-local-scene-prompt__status:not(:empty) {
+	flex-basis: 100%;
+}
+
+@media (max-width: 720px) {
+
+	.ec-local-scene-prompt {
+		grid-template-columns: 1fr;
+	}
+
+	.ec-local-scene-prompt__form {
+		align-items: stretch;
+		flex-wrap: wrap;
+	}
+
+	.ec-local-scene-prompt__picker {
+		flex-basis: 100%;
+	}
+}

--- a/inc/assets/js/local-scene-member-prompt.js
+++ b/inc/assets/js/local-scene-member-prompt.js
@@ -1,0 +1,208 @@
+( function () {
+	'use strict';
+
+	const prompt = document.getElementById( 'ec-local-scene-prompt' );
+	const config = window.extrachillLocalScenePrompt;
+	if ( ! prompt || ! config ) {
+		return;
+	}
+
+	const form = prompt.querySelector( 'form' );
+	const search = document.getElementById( 'ec-local-scene-search' );
+	const slug = document.getElementById( 'ec-local-scene-slug' );
+	const results = document.getElementById( 'ec-local-scene-results' );
+	const visibility = document.getElementById( 'ec-local-scene-public' );
+	const status = prompt.querySelector( '.ec-local-scene-prompt__status' );
+	const dismiss = prompt.querySelector( '.ec-local-scene-prompt__dismiss' );
+	let options = [];
+	let activeIndex = -1;
+	let timer;
+	let requestId = 0;
+
+	function ability( name, input, readonly = false ) {
+		let url = config.abilitiesUrl + encodeURIComponent( name ) + '/run';
+		if ( readonly ) {
+			const query = new URLSearchParams();
+			Object.entries( input ).forEach( ( [ key, value ] ) => {
+				query.set( `input[${ key }]`, String( value ) );
+			} );
+			url += '?' + query.toString();
+		}
+
+		return fetch( url, {
+			method: readonly ? 'GET' : 'POST',
+			credentials: 'same-origin',
+			headers: {
+				...( readonly ? {} : { 'Content-Type': 'application/json' } ),
+				'X-WP-Nonce': config.restNonce,
+			},
+			...( readonly ? {} : { body: JSON.stringify( { input } ) } ),
+		} ).then( async ( response ) => {
+			const body = await response.json();
+			if ( ! response.ok ) {
+				throw new Error( body.message || 'Request failed.' );
+			}
+			return body;
+		} );
+	}
+
+	function track( outcome ) {
+		const data = new URLSearchParams( {
+			action: 'extrachill_local_scene_prompt_analytics',
+			nonce: config.analyticsNonce,
+			outcome,
+			visibility: visibility.checked ? '1' : '',
+		} );
+		fetch( config.analyticsUrl, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: data,
+		} ).catch( function () {} );
+	}
+
+	function closeResults() {
+		results.hidden = true;
+		search.setAttribute( 'aria-expanded', 'false' );
+		search.removeAttribute( 'aria-activedescendant' );
+		activeIndex = -1;
+	}
+
+	function choose( option ) {
+		search.value = option.label;
+		slug.value = option.slug;
+		closeResults();
+	}
+
+	function setActive( index ) {
+		activeIndex = index;
+		results
+			.querySelectorAll( '[role="option"]' )
+			.forEach( ( element, optionIndex ) => {
+				const selected = optionIndex === index;
+				element.setAttribute(
+					'aria-selected',
+					selected ? 'true' : 'false'
+				);
+				if ( selected ) {
+					search.setAttribute( 'aria-activedescendant', element.id );
+					element.scrollIntoView( { block: 'nearest' } );
+				}
+			} );
+	}
+
+	function renderOptions( locations ) {
+		options = locations.map( ( location ) => ( {
+			slug: location.slug,
+			label: location.hierarchy?.label || location.name,
+		} ) );
+		results.replaceChildren();
+		options.forEach( ( option, index ) => {
+			const element = document.createElement( 'div' );
+			element.id = 'ec-local-scene-option-' + index;
+			element.className = 'ec-local-scene-prompt__option';
+			element.setAttribute( 'role', 'option' );
+			element.setAttribute( 'aria-selected', 'false' );
+			element.textContent = option.label;
+			element.addEventListener( 'mousedown', ( event ) => {
+				event.preventDefault();
+				choose( option );
+			} );
+			results.appendChild( element );
+		} );
+		results.hidden = options.length === 0;
+		search.setAttribute(
+			'aria-expanded',
+			options.length ? 'true' : 'false'
+		);
+	}
+
+	search.addEventListener( 'input', function () {
+		slug.value = '';
+		window.clearTimeout( timer );
+		const query = search.value.trim();
+		if ( ! query ) {
+			closeResults();
+			return;
+		}
+		const currentRequest = ++requestId;
+		timer = window.setTimeout( function () {
+			ability(
+				'extrachill/user-event-locations',
+				{ mode: 'search', search: query, limit: 10 },
+				true
+			)
+				.then( ( response ) => {
+					if ( currentRequest === requestId ) {
+						renderOptions( response.locations || [] );
+					}
+				} )
+				.catch( () => {
+					status.textContent = 'Unable to search Local Scenes.';
+				} );
+		}, 250 );
+	} );
+
+	search.addEventListener( 'keydown', function ( event ) {
+		if ( results.hidden || ! options.length ) {
+			return;
+		}
+		if ( event.key === 'ArrowDown' || event.key === 'ArrowUp' ) {
+			event.preventDefault();
+			const delta = event.key === 'ArrowDown' ? 1 : -1;
+			setActive(
+				( activeIndex + delta + options.length ) % options.length
+			);
+		} else if ( event.key === 'Enter' && activeIndex >= 0 ) {
+			event.preventDefault();
+			choose( options[ activeIndex ] );
+		} else if ( event.key === 'Escape' ) {
+			closeResults();
+		}
+	} );
+
+	search.addEventListener( 'blur', () =>
+		window.setTimeout( closeResults, 100 )
+	);
+
+	form.addEventListener( 'submit', function ( event ) {
+		event.preventDefault();
+		if ( ! slug.value ) {
+			status.textContent = 'Choose a Local Scene from the results.';
+			search.focus();
+			return;
+		}
+		form.querySelectorAll( 'button' ).forEach(
+			( button ) => ( button.disabled = true )
+		);
+		ability( 'extrachill/update-user-settings', {
+			local_scene: slug.value,
+			local_scene_visibility: visibility.checked ? 'public' : 'private',
+		} )
+			.then( function () {
+				track( 'completed' );
+				prompt.remove();
+			} )
+			.catch( ( error ) => {
+				status.textContent = error.message;
+				form.querySelectorAll( 'button' ).forEach(
+					( button ) => ( button.disabled = false )
+				);
+			} );
+	} );
+
+	dismiss.addEventListener( 'click', function () {
+		dismiss.disabled = true;
+		ability( 'extrachill/update-user-settings', {
+			local_scene_prompt_dismissed: true,
+		} )
+			.then( function () {
+				track( 'dismissed' );
+				prompt.remove();
+			} )
+			.catch( ( error ) => {
+				status.textContent = error.message;
+				dismiss.disabled = false;
+			} );
+	} );
+} )();

--- a/inc/core/local-scene-member-prompt.php
+++ b/inc/core/local-scene-member-prompt.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Local Scene member prompt.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return eligible settings, or false when this request should not show the prompt.
+ *
+ * @return array|false
+ */
+function extrachill_community_local_scene_prompt_settings() {
+	static $settings;
+
+	if ( null !== $settings ) {
+		return $settings;
+	}
+
+	$settings          = false;
+	$community_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'community' ) : 0;
+	if ( ! $community_blog_id || (int) get_current_blog_id() !== (int) $community_blog_id || ! is_user_logged_in() || is_admin() ) {
+		return false;
+	}
+
+	if ( is_page( array( 'onboarding', 'settings' ) ) || extrachill_community_is_local_scene_archive() ) {
+		return false;
+	}
+
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/get-user-settings' ) : null;
+	if ( ! $ability ) {
+		return false;
+	}
+
+	$result = $ability->execute( array() );
+	if ( is_wp_error( $result ) || ! is_array( $result ) ) {
+		return false;
+	}
+
+	if ( empty( $result['onboarding_completed'] ) || ! empty( $result['local_scene'] ) || ! empty( $result['local_scene_prompt_dismissed'] ) ) {
+		return false;
+	}
+
+	$settings = $result;
+	return $settings;
+}
+
+/**
+ * Enqueue prompt assets only for eligible requests.
+ */
+function extrachill_community_enqueue_local_scene_prompt_assets() {
+	if ( ! extrachill_community_local_scene_prompt_settings() ) {
+		return;
+	}
+
+	$css_path = EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/css/local-scene-member-prompt.css';
+	$js_path  = EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/js/local-scene-member-prompt.js';
+
+	wp_enqueue_style(
+		'extrachill-local-scene-member-prompt',
+		EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/css/local-scene-member-prompt.css',
+		array( 'extrachill-community-global' ),
+		filemtime( $css_path )
+	);
+
+	wp_enqueue_script(
+		'extrachill-local-scene-member-prompt',
+		EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/js/local-scene-member-prompt.js',
+		array(),
+		filemtime( $js_path ),
+		true
+	);
+
+	wp_localize_script(
+		'extrachill-local-scene-member-prompt',
+		'extrachillLocalScenePrompt',
+		array(
+			'abilitiesUrl' => rest_url( 'wp-abilities/v1/abilities/' ),
+			'restNonce'    => wp_create_nonce( 'wp_rest' ),
+			'analyticsUrl' => admin_url( 'admin-ajax.php' ),
+			'analyticsNonce' => wp_create_nonce( 'extrachill_local_scene_prompt_analytics' ),
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_community_enqueue_local_scene_prompt_assets', 30 );
+
+/**
+ * Emit a privacy-safe prompt analytics event.
+ *
+ * @param string $event_type Analytics-owned event constant.
+ * @param array  $event_data Bounded event payload.
+ */
+function extrachill_community_emit_local_scene_prompt_event( $event_type, $event_data ) {
+	$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/track-analytics-event' ) : null;
+	if ( $ability ) {
+		$ability->execute(
+			array(
+				'event_type' => $event_type,
+				'event_data' => $event_data,
+			)
+		);
+	}
+}
+
+/**
+ * Render the inline prompt in normal theme body flow.
+ */
+function extrachill_community_render_local_scene_prompt() {
+	$settings = extrachill_community_local_scene_prompt_settings();
+	if ( ! $settings ) {
+		return;
+	}
+
+	extrachill_community_emit_local_scene_prompt_event(
+		EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_VIEWED,
+		array(
+			'user_id'         => (int) $settings['user_id'],
+			'visibility'      => 'public' === ( $settings['local_scene_visibility'] ?? 'public' ),
+			'has_local_scene' => false,
+		)
+	);
+	?>
+	<section class="ec-local-scene-prompt" id="ec-local-scene-prompt" aria-labelledby="ec-local-scene-prompt-title">
+		<div class="ec-local-scene-prompt__copy">
+			<h2 id="ec-local-scene-prompt-title"><?php esc_html_e( 'Find your Local Scene', 'extra-chill-community' ); ?></h2>
+			<p><?php esc_html_e( 'Connect with people and discover live music near you.', 'extra-chill-community' ); ?></p>
+		</div>
+		<form class="ec-local-scene-prompt__form">
+			<div class="ec-local-scene-prompt__picker">
+				<label class="screen-reader-text" for="ec-local-scene-search"><?php esc_html_e( 'Search Local Scenes', 'extra-chill-community' ); ?></label>
+				<input type="search" id="ec-local-scene-search" placeholder="<?php esc_attr_e( 'Search cities and regions', 'extra-chill-community' ); ?>" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false" aria-controls="ec-local-scene-results" required>
+				<input type="hidden" id="ec-local-scene-slug" value="">
+				<div id="ec-local-scene-results" class="ec-local-scene-prompt__results" role="listbox" hidden></div>
+			</div>
+			<label class="ec-checkbox-row ec-local-scene-prompt__visibility">
+				<input type="checkbox" id="ec-local-scene-public" checked>
+				<span><?php esc_html_e( 'Show publicly', 'extra-chill-community' ); ?></span>
+			</label>
+			<div class="ec-local-scene-prompt__actions">
+				<button type="submit" class="button-1"><?php esc_html_e( 'Save', 'extra-chill-community' ); ?></button>
+				<button type="button" class="button-2 ec-local-scene-prompt__dismiss"><?php esc_html_e( 'Not now', 'extra-chill-community' ); ?></button>
+			</div>
+			<p class="ec-local-scene-prompt__status" role="status" aria-live="polite"></p>
+		</form>
+	</section>
+	<?php
+}
+add_action( 'extrachill_before_body_content', 'extrachill_community_render_local_scene_prompt', 5 );
+
+/**
+ * Record a client-side prompt outcome through the Analytics-owned Ability.
+ */
+function extrachill_community_local_scene_prompt_analytics() {
+	check_ajax_referer( 'extrachill_local_scene_prompt_analytics', 'nonce' );
+
+	if ( ! is_user_logged_in() ) {
+		wp_send_json_error( null, 403 );
+	}
+
+	$outcome = isset( $_POST['outcome'] ) ? sanitize_key( wp_unslash( $_POST['outcome'] ) ) : '';
+	$events  = array(
+		'dismissed' => EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_DISMISSED,
+		'completed' => EC_ANALYTICS_EVENT_LOCAL_SCENE_PROMPT_COMPLETED,
+	);
+	if ( ! isset( $events[ $outcome ] ) ) {
+		wp_send_json_error( null, 400 );
+	}
+
+	extrachill_community_emit_local_scene_prompt_event(
+		$events[ $outcome ],
+		array(
+			'user_id'         => get_current_user_id(),
+			'visibility'      => ! empty( $_POST['visibility'] ),
+			'has_local_scene' => 'completed' === $outcome,
+		)
+	);
+
+	wp_send_json_success();
+}
+add_action( 'wp_ajax_extrachill_local_scene_prompt_analytics', 'extrachill_community_local_scene_prompt_analytics' );


### PR DESCRIPTION
Adds a contextual inline Local Scene selector for eligible authenticated Community members. Uses Users abilities for eligibility/search/save/dismissal, includes explicit visibility, loads assets only when eligible, and emits privacy-safe conversion events. Fixes #187.