### PR TITLE
Fix Local Scene prompt routing and presentation

### DIFF
--- a/inc/assets/css/local-scene-member-prompt.css
+++ b/inc/assets/css/local-scene-member-prompt.css
@@ -1,31 +1,30 @@
 .ec-local-scene-prompt {
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) minmax(360px, 1.4fr);
+	display: flex;
 	gap: var(--spacing-lg);
 	align-items: center;
-	width: min(var(--content-width), calc(100% - (2 * var(--spacing-md))));
-	margin: var(--spacing-md) auto;
-	padding: var(--spacing-md);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius-md);
-	background: var(--card-background);
 }
 
-.ec-local-scene-prompt h2,
 .ec-local-scene-prompt p {
 	margin: 0;
 }
 
-.ec-local-scene-prompt h2 {
-	font-size: var(--font-size-lg);
+.ec-local-scene-prompt__copy {
+	flex: 0 1 280px;
 }
 
-.ec-local-scene-prompt__copy p,
+.ec-local-scene-prompt__copy p + p,
 .ec-local-scene-prompt__status {
 	color: var(--muted-text);
 }
 
-.ec-local-scene-prompt__form,
+.ec-local-scene-prompt__form {
+	display: grid;
+	grid-template-columns: minmax(220px, 1fr) auto auto;
+	gap: var(--spacing-sm);
+	align-items: center;
+	flex: 1 1 560px;
+}
+
 .ec-local-scene-prompt__actions {
 	display: flex;
 	gap: var(--spacing-sm);
@@ -69,21 +68,35 @@
 }
 
 .ec-local-scene-prompt__status:not(:empty) {
-	flex-basis: 100%;
+	grid-column: 1 / -1;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 900px) {
 
 	.ec-local-scene-prompt {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.ec-local-scene-prompt__copy,
+	.ec-local-scene-prompt__form {
+		flex-basis: auto;
+	}
+}
+
+@media (max-width: 600px) {
+
+	.ec-local-scene-prompt__form {
 		grid-template-columns: 1fr;
 	}
 
-	.ec-local-scene-prompt__form {
-		align-items: stretch;
-		flex-wrap: wrap;
+	.ec-local-scene-prompt__visibility,
+	.ec-local-scene-prompt__actions,
+	.ec-local-scene-prompt__status:not(:empty) {
+		grid-column: 1;
 	}
 
-	.ec-local-scene-prompt__picker {
-		flex-basis: 100%;
+	.ec-local-scene-prompt__actions button {
+		flex: 1;
 	}
 }

--- a/inc/assets/js/local-scene-member-prompt.js
+++ b/inc/assets/js/local-scene-member-prompt.js
@@ -20,7 +20,11 @@
 	let requestId = 0;
 
 	function ability( name, input, readonly = false ) {
-		let url = config.abilitiesUrl + encodeURIComponent( name ) + '/run';
+		const abilityPath = name
+			.split( '/' )
+			.map( ( segment ) => encodeURIComponent( segment ) )
+			.join( '/' );
+		let url = config.abilitiesUrl + abilityPath + '/run';
 		if ( readonly ) {
 			const query = new URLSearchParams();
 			Object.entries( input ).forEach( ( [ key, value ] ) => {

--- a/inc/core/local-scene-member-prompt.php
+++ b/inc/core/local-scene-member-prompt.php
@@ -105,7 +105,7 @@ function extrachill_community_emit_local_scene_prompt_event( $event_type, $event
 }
 
 /**
- * Render the inline prompt in normal theme body flow.
+ * Render the prompt through the theme notice area.
  */
 function extrachill_community_render_local_scene_prompt() {
 	$settings = extrachill_community_local_scene_prompt_settings();
@@ -122,9 +122,9 @@ function extrachill_community_render_local_scene_prompt() {
 		)
 	);
 	?>
-	<section class="ec-local-scene-prompt" id="ec-local-scene-prompt" aria-labelledby="ec-local-scene-prompt-title">
+	<section class="notice notice-info ec-local-scene-prompt" id="ec-local-scene-prompt" aria-labelledby="ec-local-scene-prompt-title">
 		<div class="ec-local-scene-prompt__copy">
-			<h2 id="ec-local-scene-prompt-title"><?php esc_html_e( 'Find your Local Scene', 'extra-chill-community' ); ?></h2>
+			<p id="ec-local-scene-prompt-title"><strong><?php esc_html_e( 'Find your Local Scene', 'extra-chill-community' ); ?></strong></p>
 			<p><?php esc_html_e( 'Connect with people and discover live music near you.', 'extra-chill-community' ); ?></p>
 		</div>
 		<form class="ec-local-scene-prompt__form">
@@ -139,15 +139,15 @@ function extrachill_community_render_local_scene_prompt() {
 				<span><?php esc_html_e( 'Show publicly', 'extra-chill-community' ); ?></span>
 			</label>
 			<div class="ec-local-scene-prompt__actions">
-				<button type="submit" class="button-1"><?php esc_html_e( 'Save', 'extra-chill-community' ); ?></button>
-				<button type="button" class="button-2 ec-local-scene-prompt__dismiss"><?php esc_html_e( 'Not now', 'extra-chill-community' ); ?></button>
+				<button type="submit" class="button-1 button-small"><?php esc_html_e( 'Save', 'extra-chill-community' ); ?></button>
+				<button type="button" class="button-3 button-small ec-local-scene-prompt__dismiss"><?php esc_html_e( 'Dismiss', 'extra-chill-community' ); ?></button>
 			</div>
 			<p class="ec-local-scene-prompt__status" role="status" aria-live="polite"></p>
 		</form>
 	</section>
 	<?php
 }
-add_action( 'extrachill_before_body_content', 'extrachill_community_render_local_scene_prompt', 5 );
+add_action( 'extrachill_notices', 'extrachill_community_render_local_scene_prompt', 15 );
 
 /**
  * Record a client-side prompt outcome through the Analytics-owned Ability.


### PR DESCRIPTION
## Summary
- render the Local Scene member prompt through the platform `extrachill_notices` area and canonical informational notice styling
- compact the responsive layout and make dismissal a visually secondary, accurately labeled action
- preserve ability-name path separators so search, save, and dismissal reach the registered Abilities routes

## Verification
- `php -l inc/core/local-scene-member-prompt.php`
- `npm run lint:js -- inc/assets/js/local-scene-member-prompt.js`
- `npm run lint:css -- inc/assets/css/local-scene-member-prompt.css`
- live read-only REST route check returned HTTP 200 with a Local Scene result
- Homeboy umbrella review was deferred because the host resource policy reported load average 83.6 on 8 CPUs; targeted gates above passed

Closes #190