### PR TITLE
Fix topic reply pagination

### DIFF
--- a/bbpress/content-single-topic.php
+++ b/bbpress/content-single-topic.php
@@ -64,7 +64,7 @@ defined( 'ABSPATH' ) || exit;
 
 					$bbp = bbpress();
 					if ( ! empty( $bbp->reply_query ) && bbp_get_topic_reply_count() > 0 ) {
-						extrachill_pagination( $bbp->reply_query, 'bbpress' );
+						extrachill_pagination( $bbp->reply_query, 'bbpress', 'reply' );
 					}
 
 				endif;

--- a/inc/core/bbpress-templates.php
+++ b/inc/core/bbpress-templates.php
@@ -75,3 +75,18 @@ add_filter( 'bbp_get_single_forum_description', '__return_empty_string' );
  * line-by-line.
  */
 add_filter( 'bbp_no_breadcrumb', '__return_true' );
+
+/**
+ * Keep topic conversations compatible with bbPress reply pagination.
+ *
+ * bbPress intentionally queries and renders every reply when threading is
+ * enabled, regardless of the configured replies-per-page value. A flat
+ * display keeps pagination, direct reply URLs, and Jump to Latest aligned.
+ * Reply-to relationships are still stored and available to the composer.
+ *
+ * @return bool
+ */
+function extrachill_community_disable_threaded_reply_display() {
+	return false;
+}
+add_filter( 'bbp_thread_replies', 'extrachill_community_disable_threaded_reply_display' );

--- a/scripts/smoke-topic-reply-pagination.php
+++ b/scripts/smoke-topic-reply-pagination.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Verify topic replies use bbPress's paginated flat display.
+ *
+ * Run with: wp eval-file scripts/smoke-topic-reply-pagination.php
+ *
+ * @package ExtraChillCommunity
+ */
+
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	exit( 1 );
+}
+
+if ( false !== bbp_thread_replies() ) {
+	WP_CLI::error( 'Threaded reply rendering is still enabled.' );
+}
+
+if ( bbp_get_replies_per_page() < 1 ) {
+	WP_CLI::error( 'The bbPress replies-per-page setting is invalid.' );
+}
+
+if ( false !== apply_filters( 'bbp_thread_replies', true, 2, true ) ) {
+	WP_CLI::error( 'The community pagination filter does not override threaded rendering.' );
+}
+
+WP_CLI::success( 'Topic reply pagination smoke check passed.' );


### PR DESCRIPTION
## Summary
- force bbPress topic replies into its flat paginated query so the configured 8-reply limit is honored
- keep direct reply and Jump to Latest URLs aligned with their actual page
- label pagination counts as replies and add a non-mutating smoke check

## Testing
- `php -l inc/core/bbpress-templates.php`
- `php -l bbpress/content-single-topic.php`
- `php -l scripts/smoke-topic-reply-pagination.php`
- worktree-loaded `wp eval` smoke check against the community site: passed
- `git diff --check`

The Homeboy umbrella was not forced because host resource policy reported load average 79.0 on 8 CPUs. Focused checks above passed.

Closes #192
