### PR TITLE
Fix topic pagination label

### DIFF
--- a/bbpress/content-single-topic.php
+++ b/bbpress/content-single-topic.php
@@ -64,7 +64,7 @@ defined( 'ABSPATH' ) || exit;
 
 					$bbp = bbpress();
 					if ( ! empty( $bbp->reply_query ) && bbp_get_topic_reply_count() > 0 ) {
-						extrachill_pagination( $bbp->reply_query, 'bbpress', 'reply' );
+						extrachill_pagination( $bbp->reply_query, 'bbpress' );
 					}
 
 				endif;


### PR DESCRIPTION
## Summary
- restore the generic `posts` pagination label for the mixed topic/reply bbPress loop
- remove the malformed `replys` text introduced in v1.20.2
- retain the 15-item flat pagination behavior

## Testing
- `php -l bbpress/content-single-topic.php`
- `git diff --check`

Closes #194
