### PR TITLE
fix: claim community topic notifications before delivery

### DIFF
--- a/inc/social/notifications/capture-festival-topics.php
+++ b/inc/social/notifications/capture-festival-topics.php
@@ -81,6 +81,12 @@ function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
 		return;
 	}
 
+	// Claim before delivery so concurrent bbPress hooks cannot duplicate notices.
+	// The claim remains when delivery inserts no rows, making retries at-most-once.
+	if ( ! add_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META, current_time( 'mysql', true ), true ) ) {
+		return;
+	}
+
 	ec_users_notify(
 		$recipients,
 		array(
@@ -91,9 +97,6 @@ function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
 			'item_id'  => $topic_id,
 		)
 	);
-
-	// Keep a repeated bbPress new-topic action from creating duplicate notices.
-	update_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META, current_time( 'mysql', true ) );
 }
 add_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscribers', 30 );
 
@@ -151,6 +154,12 @@ function extrachill_community_notify_artist_topic_subscribers( $topic_id ) {
 		return;
 	}
 
+	// Claim before delivery so concurrent bbPress hooks cannot duplicate notices.
+	// The claim remains when delivery inserts no rows, making retries at-most-once.
+	if ( ! add_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META, current_time( 'mysql', true ), true ) ) {
+		return;
+	}
+
 	ec_users_notify(
 		$recipients,
 		array(
@@ -161,8 +170,5 @@ function extrachill_community_notify_artist_topic_subscribers( $topic_id ) {
 			'item_id'  => $topic_id,
 		)
 	);
-
-	// Keep a repeated bbPress new-topic action from creating duplicate notices.
-	update_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META, current_time( 'mysql', true ) );
 }
 add_action( 'bbp_new_topic', 'extrachill_community_notify_artist_topic_subscribers', 30 );


### PR DESCRIPTION
## Summary
- Claims festival and artist topic notification markers before calling `ec_users_notify()`.
- A concurrent hook or retry that cannot claim the unique marker exits without creating duplicate notifications.

## Failure and Retry Semantics
- A successful claim is retained after the delivery attempt, including when `ec_users_notify()` inserts zero rows.
- This deliberately provides at-most-once notification attempts: delivery failures are not automatically retried, preventing duplicate notifications from retries.

## Tests
- `php -l inc/social/notifications/capture-festival-topics.php`
- `git diff --check`
- `npm run lint:js` (unavailable: `wp-scripts` is not installed in this worktree)
- `npm run lint:css` (unavailable: `wp-scripts` is not installed in this worktree)
- No PHP test suite is configured in this repository.

Fixes #197