### PR TITLE
fix: cache and bound Twitter oEmbed requests during content rendering

### DIFF
--- a/inc/content/content-filters.php
+++ b/inc/content/content-filters.php
@@ -5,25 +5,111 @@
  * bbPress content transformation: Twitter/X embed handling, inline style stripping.
  */
 
+/**
+ * Cache TTL for a successful tweet oEmbed lookup (the embed HTML is effectively
+ * static). Bounded so a deleted/private tweet eventually falls back to the URL.
+ */
+if ( ! defined( 'EXTRACHILL_COMMUNITY_TWEET_OEMBED_TTL' ) ) {
+	define( 'EXTRACHILL_COMMUNITY_TWEET_OEMBED_TTL', 30 * DAY_IN_SECONDS );
+}
+
+/**
+ * Cache TTL for a failed lookup. Short, so a transient Twitter outage doesn't
+ * pin the raw URL in place for long, but long enough to stop repeated renders
+ * from hammering the endpoint while it's down.
+ */
+if ( ! defined( 'EXTRACHILL_COMMUNITY_TWEET_OEMBED_FAIL_TTL' ) ) {
+	define( 'EXTRACHILL_COMMUNITY_TWEET_OEMBED_FAIL_TTL', 5 * MINUTE_IN_SECONDS );
+}
+
+/**
+ * Transform Twitter/X status URLs into cached, latency-bounded oEmbed HTML.
+ *
+ * Each unique content body is resolved at most once per request via a static
+ * memo keyed on the content hash, so overlapping filters (the_content +
+ * bbp_get_topic_content + bbp_get_reply_content) never re-process the same
+ * body. Per-URL results are cached with the core Transients API: successes are
+ * cached long-term and failures short-term, so page latency is never coupled
+ * to Twitter's response time on repeat renders.
+ */
 function embed_tweets($content) {
+	static $processed = array();
+
+	$content_hash = md5((string) $content);
+	if ( array_key_exists($content_hash, $processed) ) {
+		return $processed[$content_hash];
+	}
+
+	// Reserve the slot before resolution so a nested filter call can't re-enter.
+	$processed[$content_hash] = $content;
+
+	if ( false === stripos($content, 'twitter.com') && false === stripos($content, 'x.com') ) {
+		return $content;
+	}
+
 	$pattern = '/https?:\/\/(?:www\.)?(twitter\.com|x\.com)\/(?:#!\/)?(\w+)\/status(?:es)?\/(\d+)/i';
 
 	$callback = function($matches) {
-		$tweet_url       = 'https://' . $matches[1] . '/' . $matches[2] . '/status/' . $matches[3];
-		$oembed_endpoint = 'https://publish.twitter.com/oembed?url=' . urlencode($tweet_url);
-		$response        = wp_remote_get($oembed_endpoint);
+		$tweet_url = 'https://' . $matches[1] . '/' . $matches[2] . '/status/' . $matches[3];
+		$html      = extrachill_community_get_tweet_oembed($tweet_url);
 
-		if ( ! is_wp_error($response) && isset($response['body']) ) {
-			$embed_data = json_decode($response['body'], true);
-			if ( $embed_data && isset($embed_data['html']) ) {
-				return '<div class="twitter-embed">' . $embed_data['html'] . '</div>';
-			}
+		if ( false === $html ) {
+			return $matches[0];
 		}
 
-		return $matches[0];
+		return '<div class="twitter-embed">' . $html . '</div>';
 	};
 
-	return preg_replace_callback($pattern, $callback, $content);
+	$processed[$content_hash] = preg_replace_callback($pattern, $callback, $content);
+	return $processed[$content_hash];
+}
+
+/**
+ * Resolve a single tweet's oEmbed HTML through the core Transients cache.
+ *
+ * Uses the core Transients API directly (the standard WP cache primitive) so
+ * no wrapper substrate is introduced. Returns the oEmbed HTML on success, or
+ * boolean false on any failure (HTTP error, malformed JSON, missing html key);
+ * the caller is responsible for the fallback markup.
+ *
+ * @param string $tweet_url Normalized https://twitter.com/.../status/<id> URL.
+ * @return string|false
+ */
+function extrachill_community_get_tweet_oembed($tweet_url) {
+	$cache_key   = 'ec_tweet_oembed_' . md5($tweet_url);
+	$cached_html = get_transient($cache_key);
+
+	/*
+	 * Sentinel values stored in the transient:
+	 *   - false  : cache miss; perform a bounded fetch below.
+	 *   - ''     : cached failure; return false so the caller renders the URL.
+	 *   - string : cached oEmbed HTML.
+	 */
+	if ( '' === $cached_html ) {
+		return false;
+	}
+	if ( is_string($cached_html) ) {
+		return $cached_html;
+	}
+
+	$oembed_endpoint = 'https://publish.twitter.com/oembed?url=' . urlencode($tweet_url);
+	$response        = wp_remote_get($oembed_endpoint, array('timeout' => 5));
+
+	$html = false;
+	if ( ! is_wp_error($response) && ! empty($response['body']) ) {
+		$embed_data = json_decode($response['body'], true);
+		if ( is_array($embed_data) && ! empty($embed_data['html']) ) {
+			$html = (string) $embed_data['html'];
+		}
+	}
+
+	if ( false === $html ) {
+		set_transient($cache_key, '', EXTRACHILL_COMMUNITY_TWEET_OEMBED_FAIL_TTL);
+		return false;
+	}
+
+	set_transient($cache_key, $html, EXTRACHILL_COMMUNITY_TWEET_OEMBED_TTL);
+	return $html;
 }
 
 add_filter('the_content', 'embed_tweets', 9);

--- a/tests/test-content-filters.php
+++ b/tests/test-content-filters.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Focused tests for the cached Twitter oEmbed content filter.
+ *
+ * This repo has no Composer/phpunit harness, so this is a standalone,
+ * dependency-free script: it stubs the WordPress primitives the filter relies
+ * on, loads the real content-filters.php, and asserts behavior with simple
+ * pass/fail reporting.
+ *
+ * Run: php tests/test-content-filters.php
+ */
+
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 86400 );
+}
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
+$GLOBALS['_test_transients']      = array();
+$GLOBALS['_test_transient_ttls']  = array();
+$GLOBALS['_test_remote_calls']    = 0;
+$GLOBALS['_test_remote_response'] = null;
+
+class WP_Error_Test {}
+
+function add_filter( $tag, $cb, $prio = 10 ) {
+	$GLOBALS['_test_filters'][ $tag ][] = $cb;
+}
+function add_action( $tag, $cb, $prio = 10 ) {
+	$GLOBALS['_test_actions'][ $tag ][] = $cb;
+}
+
+function get_transient( $key ) {
+	return array_key_exists( $key, $GLOBALS['_test_transients'] ) ? $GLOBALS['_test_transients'][ $key ] : false;
+}
+function set_transient( $key, $value, $ttl = 0 ) {
+	$GLOBALS['_test_transients'][ $key ]     = $value;
+	$GLOBALS['_test_transient_ttls'][ $key ] = $ttl;
+}
+
+function wp_remote_get( $url, $args = array() ) {
+	$GLOBALS['_test_remote_calls']++;
+	$GLOBALS['_test_remote_args'] = $args;
+	if ( $GLOBALS['_test_remote_response'] instanceof WP_Error_Test ) {
+		return $GLOBALS['_test_remote_response'];
+	}
+	return is_array( $GLOBALS['_test_remote_response'] )
+		? $GLOBALS['_test_remote_response']
+		: array( 'body' => $GLOBALS['_test_remote_response'] );
+}
+function is_wp_error( $thing ) {
+	return $thing instanceof WP_Error_Test;
+}
+
+function _test_reset_state() {
+	$GLOBALS['_test_transients']      = array();
+	$GLOBALS['_test_transient_ttls']  = array();
+	$GLOBALS['_test_remote_calls']    = 0;
+	$GLOBALS['_test_remote_response'] = null;
+
+	// Reset the static memo inside embed_tweets by reflecting on a fresh load
+	// is not possible; instead we drive each scenario with unique content.
+}
+
+require __DIR__ . '/../inc/content/content-filters.php';
+
+$failures = 0;
+function check( $label, $cond ) {
+	global $failures;
+	if ( $cond ) {
+		echo "PASS: $label\n";
+	} else {
+		echo "FAIL: $label\n";
+		$failures++;
+	}
+}
+
+/* -----------------------------------------------------------------
+ * 1. Filters are still wired to all three content hooks exactly once.
+ * ---------------------------------------------------------------- */
+check( 'embed_tweets registered on the_content',   in_array( 'embed_tweets', $GLOBALS['_test_filters']['the_content'], true ) );
+check( 'embed_tweets registered on topic content', in_array( 'embed_tweets', $GLOBALS['_test_filters']['bbp_get_topic_content'], true ) );
+check( 'embed_tweets registered on reply content', in_array( 'embed_tweets', $GLOBALS['_test_filters']['bbp_get_reply_content'], true ) );
+
+/* -----------------------------------------------------------------
+ * 2. Content with no tweet URL is untouched and makes no HTTP call.
+ * ---------------------------------------------------------------- */
+_test_reset_state();
+$out = embed_tweets( '<p>Just a normal post about music.</p>' );
+check( 'no-tweet content unchanged', '<p>Just a normal post about music.</p>' === $out );
+check( 'no-tweet content makes no HTTP call', 0 === $GLOBALS['_test_remote_calls'] );
+
+/* -----------------------------------------------------------------
+ * 3. Successful fetch wraps the oEmbed HTML and is cached long-term.
+ *    Each unique body is resolved once even across overlapping filters
+ *    (call embed_tweets twice with identical content).
+ * ---------------------------------------------------------------- */
+_test_reset_state();
+$GLOBALS['_test_remote_response'] = '{"html":"<blockquote>Tweet!<\/blockquote>"}';
+$content = '<p>see https://twitter.com/ec/status/123</p>';
+$first   = embed_tweets( $content );
+$second  = embed_tweets( $content ); // same body again -> memo hit, no extra work.
+
+check( 'successful fetch wraps embed html', false !== strpos( $first, '<div class="twitter-embed"><blockquote>Tweet!</blockquote></div>' ) );
+check( 'identical body fetched once per request (dedupe)', 1 === $GLOBALS['_test_remote_calls'] );
+check( 'second call returns memoized result', $first === $second );
+
+// Transient was written with the success TTL, not the fail TTL.
+$cache_key = 'ec_tweet_oembed_' . md5( 'https://twitter.com/ec/status/123' );
+check( 'success cached with long TTL (30d)', 30 * DAY_IN_SECONDS === $GLOBALS['_test_transient_ttls'][ $cache_key ] );
+
+/* -----------------------------------------------------------------
+ * 4. A different body referencing the SAME tweet reuses the transient
+ *    cache -> no second HTTP call (cross-body cache reuse).
+ * ---------------------------------------------------------------- */
+_test_reset_state();
+$GLOBALS['_test_remote_response'] = '{"html":"<blockquote>Hi<\/blockquote>"}';
+embed_tweets( '<p>one https://twitter.com/ec/status/999</p>' );
+embed_tweets( '<p>two https://twitter.com/ec/status/999</p>' );
+check( 'same tweet across bodies is one HTTP call', 1 === $GLOBALS['_test_remote_calls'] );
+
+/* -----------------------------------------------------------------
+ * 5. Failed fetch falls back to the raw URL and caches the failure
+ *    with the short TTL, so the next render does not hit Twitter.
+ * ---------------------------------------------------------------- */
+_test_reset_state();
+$GLOBALS['_test_remote_response'] = new WP_Error_Test();
+$url   = 'https://x.com/EC/status/555';
+$out   = embed_tweets( '<p>' . $url . '</p>' );
+check( 'failed fetch leaves URL in place', false !== strpos( $out, $url ) );
+
+$fail_key = 'ec_tweet_oembed_' . md5( $url );
+check( 'failure cached with short TTL (5m)', EXTRACHILL_COMMUNITY_TWEET_OEMBED_FAIL_TTL === $GLOBALS['_test_transient_ttls'][ $fail_key ] );
+check( 'failure sentinel stored as empty string', '' === $GLOBALS['_test_transients'][ $fail_key ] );
+
+// Second body, same tweet: transient serves the cached failure, no HTTP.
+$before = $GLOBALS['_test_remote_calls'];
+embed_tweets( '<p>again ' . $url . '</p>' );
+check( 'cached failure makes no HTTP call', $before === $GLOBALS['_test_remote_calls'] );
+
+/* -----------------------------------------------------------------
+ * 6. Malformed oEmbed body (no html key) is treated as a failure.
+ * ---------------------------------------------------------------- */
+_test_reset_state();
+$GLOBALS['_test_remote_response'] = '{"not_html":"nope"}';
+$out = embed_tweets( '<p>see https://twitter.com/x/status/1</p>' );
+check( 'malformed oEmbed falls back to URL', false !== strpos( $out, 'twitter.com/x/status/1' ) );
+
+/* -----------------------------------------------------------------
+ * 7. Bounded timeout is passed to wp_remote_get.
+ * ---------------------------------------------------------------- */
+_test_reset_state();
+$GLOBALS['_test_remote_response'] = '{"html":"<blockquote>x<\/blockquote>"}';
+embed_tweets( '<p>https://twitter.com/t/status/2</p>' );
+check( 'wp_remote_get receives a 5s timeout', 5 === $GLOBALS['_test_remote_args']['timeout'] );
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "$failures test(s) FAILED.\n";
+	exit( 1 );
+}
+echo "All content-filter tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Impact

`embed_tweets` did a **synchronous, uncached `wp_remote_get()` to `publish.twitter.com/oembed`** for every matched Twitter/X URL on **every render**, and was hooked into `the_content`, `bbp_get_topic_content`, *and* `bbp_get_reply_content` (inc/content/content-filters.php). Overlapping filters could fire the same body multiple times per request, so a topic page containing embeds issued repeated blocking third-party calls — coupling community page latency to Twitter's response time and availability.

## Cache / failure semantics

- **Core Transients API, no wrapper substrate.** Each tweet's oEmbed HTML is cached under `ec_tweet_oembed_<md5(url)>` using `get/set_transient` directly — the standard WP cache primitive, backed by the site's Redis object cache. WordPress core's `WP_oEmbed` registers Twitter but **only `twitter.com`, not `x.com`**, and `wp_oembed_get()` does **not** cache, so core alone doesn't solve this.
- **Success → long TTL.** Cached for `30 * DAY_IN_SECONDS` (`EXTRACHILL_COMMUNITY_TWEET_OEMBED_TTL`, filterable via `define`). Tweet embed HTML is effectively static; the bound lets a deleted/private tweet eventually fall back to the raw URL.
- **Failure → short TTL with sentinel.** HTTP error, malformed JSON, or missing `html` key stores an empty-string sentinel (`''`) for `5 * MINUTE_IN_SECONDS` (`EXTRACHILL_COMMUNITY_TWEET_OEMBED_FAIL_TTL`). `get_transient` returns `false` on miss, so `''` is cleanly distinguishable and suppresses repeat calls while Twitter is down without pinning the raw URL long-term.
- **Bounded timeout.** `wp_remote_get()` now passes `['timeout' => 5]` so a slow Twitter can't stall the render indefinitely.
- **Once per body per request.** `embed_tweets` memoizes each content body in a `static` array keyed on its MD5 hash, so the same body is transformed at most once per request even when multiple of the three filters fire on it. The per-URL transient additionally prevents repeat HTTP calls across different bodies referencing the same tweet.

## Tests

New `tests/test-content-filters.php` — standalone, dependency-free (the repo has no Composer/phpunit harness). Stubs the WP primitives (`get/set_transient`, `wp_remote_get`, `is_wp_error`, filter registration), loads the real filter, and asserts (all 16 passing):

- all three content filters still register `embed_tweets` exactly once;
- no-tweet content is untouched and makes zero HTTP calls;
- successful fetch wraps the oEmbed HTML and the **identical body is fetched once per request** (dedupe), with the success cached at the 30d TTL;
- the same tweet across **different bodies** is a single HTTP call (transient reuse);
- a failed fetch leaves the raw URL in place, caches the failure sentinel at the 5m TTL, and a subsequent body makes **no HTTP call**;
- a malformed oEmbed body (no `html` key) is treated as a failure;
- `wp_remote_get` receives the 5s timeout.

## Verification

- `php -l inc/content/content-filters.php` — clean
- `php -l tests/test-content-filters.php` — clean
- `php tests/test-content-filters.php` — **16/16 PASS**
- **Not run (unavailable gate, reported honestly):** the repo's only configured gates are npm-based (`npm run lint:js`, `lint:css`, `build` via wp-scripts); `node_modules` is not present and the change is PHP-only, so they are unaffected. There is no PHP lint/test gate (no phpcs/phpunit config).

Fixes #196

— *Extra Chill Bot, sending on Chris's behalf. PR only — not merging, releasing, or deploying.*