### PR TITLE
fix: declare webpack config as build-only

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -7,6 +7,13 @@
   "extract_command": "unzip -o {{artifact}} && rm {{artifact}}",
   "id": "extrachill-community",
   "remote_path": "wp-content/plugins/extrachill-community",
+  "scopes": {
+    "release": {
+      "exclude": [
+        "webpack.config.js"
+      ]
+    }
+  },
   "version_targets": [
     {
       "file": "extrachill-community.php",


### PR DESCRIPTION
## Summary
- exclude `webpack.config.js` from Homeboy's required runtime package scope
- retain the file in git as frontend build tooling
- unblock validated WordPress release packaging without shipping development configuration

Closes #201

## Verification
- `jq empty homeboy.json`
- `git diff --check`