### PR TITLE
fix: redirect retired article topics to blog posts

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -37,6 +37,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-artist.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/breadcrumb-filter.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/page-templates.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/legacy-topic-redirects.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/local-scene-archives.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/bbpress-spam-adjustments.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/sidebar.php';

--- a/inc/core/legacy-topic-redirects.php
+++ b/inc/core/legacy-topic-redirects.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Redirect retired article-mirror topics to their canonical blog posts.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Extract a legacy topic slug from the current request.
+ *
+ * @return string Topic slug, or an empty string when the request is ineligible.
+ */
+function extrachill_community_get_legacy_topic_slug(): string {
+	if ( ! extrachill_community_is_community_site() || is_admin() || wp_doing_ajax() || ! is_404() ) {
+		return '';
+	}
+
+	$method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) ) : 'GET';
+	if ( ! in_array( $method, array( 'GET', 'HEAD' ), true ) ) {
+		return '';
+	}
+
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+	$path        = wp_parse_url( $request_uri, PHP_URL_PATH );
+	if ( ! is_string( $path ) || ! preg_match( '#^/t/([^/]+)/?$#', $path, $matches ) ) {
+		return '';
+	}
+
+	return sanitize_title( rawurldecode( $matches[1] ) );
+}
+
+/**
+ * Find the canonical main-site post URL for a retired topic request.
+ *
+ * Current slugs are preferred. WordPress's `_wp_old_slug` records cover posts
+ * renamed after their Community mirrors were created.
+ *
+ * @return string Canonical blog URL, or an empty string when none exists.
+ */
+function extrachill_community_get_legacy_topic_redirect_url(): string {
+	$slug = extrachill_community_get_legacy_topic_slug();
+	if ( '' === $slug ) {
+		return '';
+	}
+
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'main' ) : 1;
+	if ( $main_blog_id <= 0 || (int) get_current_blog_id() === $main_blog_id ) {
+		return '';
+	}
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$post = get_page_by_path( $slug, OBJECT, 'post' );
+
+		if ( ! $post || 'publish' !== get_post_status( $post ) ) {
+			$old_slug_posts = get_posts(
+				array(
+					'post_type'      => 'post',
+					'post_status'    => 'publish',
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'meta_key'       => '_wp_old_slug',
+					'meta_value'     => $slug,
+					'orderby'        => 'ID',
+					'order'          => 'DESC',
+					'no_found_rows'  => true,
+				)
+			);
+			$post           = ! empty( $old_slug_posts ) ? (int) $old_slug_posts[0] : null;
+		}
+
+		return $post ? (string) get_permalink( $post ) : '';
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Allow safe redirects from Community to the canonical main-site host.
+ *
+ * @param string[] $hosts Hosts already allowed by WordPress.
+ * @param string   $host  Host WordPress is validating.
+ * @return string[]
+ */
+function extrachill_community_allow_main_site_redirect_host( array $hosts, string $host ): array {
+	$main_site_url  = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'main' ) : network_home_url( '/' );
+	$main_site_host = wp_parse_url( $main_site_url, PHP_URL_HOST );
+
+	if ( is_string( $main_site_host ) && $main_site_host === $host ) {
+		$hosts[] = $host;
+	}
+
+	return array_unique( $hosts );
+}
+add_filter( 'allowed_redirect_hosts', 'extrachill_community_allow_main_site_redirect_host', 10, 2 );
+
+/**
+ * Redirect a missing legacy topic to its canonical main-site post.
+ */
+function extrachill_community_maybe_redirect_legacy_topic(): void {
+	$redirect_url = extrachill_community_get_legacy_topic_redirect_url();
+	if ( '' === $redirect_url ) {
+		return;
+	}
+
+	wp_safe_redirect( $redirect_url, 301, 'Extra Chill Community' );
+	exit;
+}
+add_action( 'template_redirect', 'extrachill_community_maybe_redirect_legacy_topic', 9 );

--- a/tests/test-legacy-topic-redirects.php
+++ b/tests/test-legacy-topic-redirects.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Focused tests for legacy Community topic redirects.
+ *
+ * Run: php tests/test-legacy-topic-redirects.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+define( 'OBJECT', 'OBJECT' );
+
+$GLOBALS['_test_actions']         = array();
+$GLOBALS['_test_blog_id']         = 2;
+$GLOBALS['_test_is_404']          = true;
+$GLOBALS['_test_is_admin']        = false;
+$GLOBALS['_test_is_ajax']         = false;
+$GLOBALS['_test_current_posts']   = array();
+$GLOBALS['_test_old_slug_posts']  = array();
+$GLOBALS['_test_switched_blogs']  = array();
+$GLOBALS['_test_restored_blogs']  = 0;
+$_SERVER['REQUEST_METHOD']        = 'GET';
+$_SERVER['REQUEST_URI']           = '/';
+
+function add_action( $tag, $callback, $priority = 10 ) {
+	$GLOBALS['_test_actions'][ $tag ][ $priority ][] = $callback;
+}
+
+function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
+	$GLOBALS['_test_filters'][ $tag ][ $priority ][] = $callback;
+}
+
+function extrachill_community_is_community_site(): bool {
+	return 2 === (int) $GLOBALS['_test_blog_id'];
+}
+
+function is_admin() {
+	return $GLOBALS['_test_is_admin'];
+}
+
+function wp_doing_ajax() {
+	return $GLOBALS['_test_is_ajax'];
+}
+
+function is_404() {
+	return $GLOBALS['_test_is_404'];
+}
+
+function sanitize_text_field( $value ) {
+	return (string) $value;
+}
+
+function wp_unslash( $value ) {
+	return $value;
+}
+
+function wp_parse_url( $url, $component = -1 ) {
+	return parse_url( $url, $component );
+}
+
+function sanitize_title( $title ) {
+	return strtolower( preg_replace( '/[^a-z0-9-]+/i', '-', trim( $title, '/' ) ) );
+}
+
+function ec_get_blog_id( $site ) {
+	return 'main' === $site ? 1 : 2;
+}
+
+function ec_get_site_url( $site ) {
+	return 'main' === $site ? 'https://extrachill.com' : 'https://community.extrachill.com';
+}
+
+function get_current_blog_id() {
+	return $GLOBALS['_test_blog_id'];
+}
+
+function switch_to_blog( $blog_id ) {
+	$GLOBALS['_test_switched_blogs'][] = $blog_id;
+	$GLOBALS['_test_blog_id']          = $blog_id;
+}
+
+function restore_current_blog() {
+	$GLOBALS['_test_restored_blogs']++;
+	$GLOBALS['_test_blog_id'] = 2;
+}
+
+function get_page_by_path( $slug, $output = OBJECT, $post_type = 'page' ) {
+	return $GLOBALS['_test_current_posts'][ $slug ] ?? null;
+}
+
+function get_post_status( $post ) {
+	return is_object( $post ) ? $post->post_status : 'publish';
+}
+
+function get_posts( $args ) {
+	return $GLOBALS['_test_old_slug_posts'][ $args['meta_value'] ] ?? array();
+}
+
+function get_permalink( $post ) {
+	$slug = is_object( $post ) ? $post->post_name : $GLOBALS['_test_old_slug_posts']['permalinks'][ $post ];
+	return 'https://extrachill.com/' . $slug . '/';
+}
+
+function wp_safe_redirect( $location, $status = 302, $x_redirect_by = 'WordPress' ) {
+	$GLOBALS['_test_redirect'] = compact( 'location', 'status', 'x_redirect_by' );
+	return true;
+}
+
+function reset_test_request( $uri = '/t/example-post/' ) {
+	$GLOBALS['_test_blog_id']        = 2;
+	$GLOBALS['_test_is_404']         = true;
+	$GLOBALS['_test_is_admin']       = false;
+	$GLOBALS['_test_is_ajax']        = false;
+	$GLOBALS['_test_current_posts']  = array();
+	$GLOBALS['_test_old_slug_posts'] = array();
+	$_SERVER['REQUEST_METHOD']       = 'GET';
+	$_SERVER['REQUEST_URI']          = $uri;
+}
+
+require __DIR__ . '/../inc/core/legacy-topic-redirects.php';
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	$failures++;
+}
+
+check(
+	'redirect handler registered before core canonical redirects',
+	in_array( 'extrachill_community_maybe_redirect_legacy_topic', $GLOBALS['_test_actions']['template_redirect'][9], true )
+);
+check(
+	'main-site host is registered for safe redirects',
+	in_array( 'extrachill.com', extrachill_community_allow_main_site_redirect_host( array( 'community.extrachill.com' ), 'extrachill.com' ), true )
+);
+check(
+	'unrelated external host is not allowed',
+	! in_array( 'example.com', extrachill_community_allow_main_site_redirect_host( array(), 'example.com' ), true )
+);
+
+reset_test_request( '/t/40-songs-about-cats/?utm_source=google' );
+$GLOBALS['_test_current_posts']['40-songs-about-cats'] = (object) array(
+	'post_name'   => '40-songs-about-cats',
+	'post_status' => 'publish',
+);
+check(
+	'published matching blog post resolves to its canonical URL',
+	'https://extrachill.com/40-songs-about-cats/' === extrachill_community_get_legacy_topic_redirect_url()
+);
+check( 'main-site lookup restores the Community blog', 2 === $GLOBALS['_test_blog_id'] );
+
+reset_test_request();
+$GLOBALS['_test_is_404'] = false;
+check( 'valid Community topic is never redirected', '' === extrachill_community_get_legacy_topic_redirect_url() );
+
+reset_test_request( '/not-a-topic/example-post/' );
+check( 'unrelated 404 is never redirected', '' === extrachill_community_get_legacy_topic_redirect_url() );
+
+reset_test_request();
+$GLOBALS['_test_blog_id'] = 1;
+check( 'main-site request is never redirected', '' === extrachill_community_get_legacy_topic_redirect_url() );
+
+reset_test_request();
+$GLOBALS['_test_current_posts']['example-post'] = (object) array(
+	'post_name'   => 'example-post',
+	'post_status' => 'draft',
+);
+check( 'draft blog post is never exposed', '' === extrachill_community_get_legacy_topic_redirect_url() );
+
+reset_test_request( '/t/old-article-slug/' );
+$GLOBALS['_test_old_slug_posts']['old-article-slug'] = array( 42 );
+$GLOBALS['_test_old_slug_posts']['permalinks'][42]    = 'current-article-slug';
+check(
+	'WordPress old slug resolves to the current canonical permalink',
+	'https://extrachill.com/current-article-slug/' === extrachill_community_get_legacy_topic_redirect_url()
+);
+
+reset_test_request();
+$_SERVER['REQUEST_METHOD'] = 'POST';
+check( 'non-idempotent requests are never redirected', '' === extrachill_community_get_legacy_topic_redirect_url() );
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "$failures test(s) FAILED.\n";
+	exit( 1 );
+}
+
+echo "All legacy-topic redirect tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Redirect missing legacy `/t/<slug>` article mirrors to matching published posts on `extrachill.com`
- Preserve valid community topics, unrelated 404s, drafts, and non-idempotent requests
- Resolve both current post slugs and WordPress `_wp_old_slug` records to canonical permalinks
- Restrict cross-domain safe redirects to the main Extra Chill host

## Why
Legacy article-mirror topic URLs still receive search and referral traffic, but now return Community 404s even when the original published blog post exists. Resolving only genuine topic-route 404s recovers those readers and preserves canonical blog traffic without a manual redirect table.

## Verification
- `php tests/test-legacy-topic-redirects.php` passed (11 assertions)
- `php tests/test-content-filters.php` passed
- Changed-file PHPCS passed with no findings
- Homeboy review audit passed with no findings
- Homeboy review lint passed with no findings
- Live read-only WordPress lookup resolved `/t/40-songs-about-cats/` to `https://extrachill.com/40-songs-about-cats`

## Test infrastructure note
The full Homeboy test stage failed before running tests because its dependency resolver mistook this repository's `bbpress/` template-override directory for the bbPress plugin dependency. This is tracked in Extra-Chill/homeboy-extensions#2252. The standalone repository suites above pass.

Closes #203