### PR TITLE
feat: welcome community newcomers

### DIFF
--- a/inc/assets/css/home.css
+++ b/inc/assets/css/home.css
@@ -7,6 +7,48 @@
 }
 
 /* --- Homepage Topic Actions --- */
+.community-newcomer-welcome {
+    width: 100%;
+    max-width: var(--content-width);
+    margin: 0 auto var(--spacing-xl);
+    padding: var(--spacing-xl);
+    background: linear-gradient(135deg, var(--card-background), var(--background-color));
+    border: 1px solid var(--border-color);
+    border-left: 5px solid var(--accent);
+    border-radius: var(--border-radius-xl);
+}
+
+.community-newcomer-welcome__eyebrow {
+    margin: 0 0 var(--spacing-sm);
+    color: var(--accent);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.community-newcomer-welcome h1 {
+    margin: 0 0 var(--spacing-md);
+    max-width: 13em;
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-3xl);
+    line-height: var(--line-height-tight);
+}
+
+.community-newcomer-welcome__lede {
+    max-width: 42rem;
+    margin: 0;
+    color: var(--muted-text);
+    font-size: var(--font-size-lg);
+}
+
+.community-newcomer-welcome__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-lg);
+}
+
 .community-home-topic-actions {
     display: flex;
     flex-wrap: wrap;
@@ -111,6 +153,21 @@
 }
 
 @media (max-width: 480px) {
+    .community-newcomer-welcome {
+        padding: var(--spacing-lg) var(--spacing-md);
+        border-left: none;
+        border-right: none;
+        border-radius: 0;
+    }
+
+    .community-newcomer-welcome h1 {
+        font-size: var(--font-size-2xl);
+    }
+
+    .community-newcomer-welcome__lede {
+        font-size: var(--font-size-base);
+    }
+
     .community-home-topic-actions {
         justify-content: center;
     }

--- a/inc/home/actions.php
+++ b/inc/home/actions.php
@@ -3,7 +3,7 @@
  * ExtraChill Community Home Action Hooks
  *
  * Hook-based homepage component registration for the feed-first homepage (#65):
- *   - extrachill_community_home_header      → "Start a conversation" CTA + modal
+ *   - extrachill_community_home_header      → newcomer welcome or member actions
  *   - extrachill_community_home_top         → "What's Happening" activity feed (hero)
  *   - extrachill_community_home_after_feed  → "Browse rooms" chip row (demoted nav)
  *
@@ -14,13 +14,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-function extrachill_community_new_topic_button() {
-	include EXTRACHILL_COMMUNITY_PLUGIN_DIR . 'inc/home/new-topic-button.php';
-}
-add_action( 'extrachill_community_home_header', 'extrachill_community_new_topic_button', 10 );
+/**
+ * Render newcomer messaging or member conversation actions.
+ */
+function extrachill_community_home_header() {
+	if ( is_user_logged_in() ) {
+		include EXTRACHILL_COMMUNITY_PLUGIN_DIR . 'inc/home/new-topic-button.php';
+		return;
+	}
 
+	include EXTRACHILL_COMMUNITY_PLUGIN_DIR . 'inc/home/newcomer-welcome.php';
+}
+add_action( 'extrachill_community_home_header', 'extrachill_community_home_header', 10 );
+
+/**
+ * Render the topic composer modal for logged-in homepage visitors.
+ */
 function extrachill_community_new_topic_modal() {
-	if ( ! is_front_page() ) {
+	if ( ! is_front_page() || ! is_user_logged_in() ) {
 		return;
 	}
 	include EXTRACHILL_COMMUNITY_PLUGIN_DIR . 'inc/home/new-topic-modal.php';

--- a/inc/home/newcomer-welcome.php
+++ b/inc/home/newcomer-welcome.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Logged-out welcome for the feed-first Community homepage.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$join_url = home_url( '/login/#tab-register' );
+?>
+<section class="community-newcomer-welcome" aria-labelledby="community-welcome-heading">
+	<p class="community-newcomer-welcome__eyebrow"><?php esc_html_e( 'The Online Music Scene', 'extra-chill-community' ); ?></p>
+	<h1 id="community-welcome-heading"><?php esc_html_e( 'Music is better when it starts a conversation.', 'extra-chill-community' ); ?></h1>
+	<p class="community-newcomer-welcome__lede">
+		<?php esc_html_e( 'Meet artists, fans, and industry people without an algorithm deciding who gets heard. Share what you love, find your people, and help shape the scene.', 'extra-chill-community' ); ?>
+	</p>
+	<div class="community-newcomer-welcome__actions">
+		<a class="button-1 button-medium" href="<?php echo esc_url( $join_url ); ?>"><?php esc_html_e( 'Join the scene', 'extra-chill-community' ); ?></a>
+		<a class="button-3 button-medium" href="<?php echo esc_url( home_url( '/recent' ) ); ?>"><?php esc_html_e( 'Explore conversations', 'extra-chill-community' ); ?></a>
+	</div>
+</section>

--- a/tests/test-homepage-header.php
+++ b/tests/test-homepage-header.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Focused tests for the personalized Community homepage header.
+ *
+ * Run: php tests/test-homepage-header.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+define( 'OBJECT', 'OBJECT' );
+define( 'EXTRACHILL_COMMUNITY_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+
+$GLOBALS['_test_logged_in'] = false;
+function add_action() {}
+function is_user_logged_in() {
+	return $GLOBALS['_test_logged_in'];
+}
+function is_front_page() {
+	return true;
+}
+function home_url( $path = '' ) {
+	return 'https://community.extrachill.com' . $path;
+}
+function esc_html_e( $text ) {
+	echo htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_url( $url ) {
+	return htmlspecialchars( $url, ENT_QUOTES );
+}
+
+require dirname( __DIR__ ) . '/inc/home/actions.php';
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+ob_start();
+extrachill_community_home_header();
+$logged_out = ob_get_clean();
+
+check( 'logged-out header leads with the community promise', false !== strpos( $logged_out, 'Music is better when it starts a conversation.' ) );
+check( 'logged-out header links to canonical registration tab', false !== strpos( $logged_out, '/login/#tab-register' ) );
+check( 'logged-out header links into live conversations', false !== strpos( $logged_out, '/recent' ) );
+check( 'logged-out header does not render member composer actions', false === strpos( $logged_out, 'Create Discussion' ) );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All homepage header tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- Show logged-out visitors a concise welcome above the live activity feed
- Route newcomers to the canonical registration tab and recent conversations
- Preserve create/share actions for logged-in members
- Avoid rendering the unused composer modal for logged-out visitors
- Add responsive styling using existing Extra Chill theme tokens

## Why
The feed-first homepage correctly shows a living community, but newcomers lost the emotional explanation of why they should join. This restores that invitation without bringing back the stale, text-heavy `Why Join?` page or its follower language.

## Verification
- `php tests/test-homepage-header.php` passed
- `php tests/test-legacy-topic-redirects.php` passed
- Changed production PHP passes WordPress PHPCS
- PHP syntax and whitespace checks passed

Homeboy wrapper lint was deferred because an unrelated active WP Codebox run caused a production process storm; tracked in Extra-Chill/homeboy-extensions#2253.

Closes #205