### PR TITLE
feat: add artist profile discussions

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -35,6 +35,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-location.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-festival.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/taxonomy-artist.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/artist-profile-discussions.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/breadcrumb-filter.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/page-templates.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/legacy-topic-redirects.php';

--- a/inc/core/artist-profile-discussions.php
+++ b/inc/core/artist-profile-discussions.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Artist profile discussion section.
+ *
+ * Community registers its own section through Artist Platform's public profile
+ * section registry. Artist Platform remains unaware of Community.
+ *
+ * @package ExtraChillCommunity
+ * @subpackage Core
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Maximum recent discussions rendered on an artist profile. */
+const EXTRACHILL_COMMUNITY_ARTIST_TOPIC_LIMIT = 4;
+
+/**
+ * Register the Community-owned artist discussion section.
+ *
+ * @param array[] $sections Registered profile sections.
+ * @return array[]
+ */
+function extrachill_community_register_artist_discussions_section( $sections ) {
+	$sections[] = array(
+		'id'       => 'discussions',
+		'label'    => __( 'Discussions', 'extra-chill-community' ),
+		'priority' => 50,
+		'as_tab'   => false,
+		'visible'  => 'extrachill_community_artist_discussions_visible',
+		'render'   => 'extrachill_community_render_artist_discussions_section',
+	);
+
+	return $sections;
+}
+add_filter( 'ec_artist_profile_sections', 'extrachill_community_register_artist_discussions_section', 10, 3 );
+
+/**
+ * Whether the current request is an Artist Platform profile surface.
+ *
+ * @return bool
+ */
+function extrachill_community_is_artist_profile_discussions_surface() {
+	return function_exists( 'is_singular' ) && is_singular( 'artist_profile' );
+}
+
+/**
+ * Load Community's existing topic-card styles on canonical artist profiles.
+ *
+ * @return void
+ */
+function extrachill_community_enqueue_artist_discussions_styles() {
+	if ( ! extrachill_community_is_artist_profile_discussions_surface() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'extrachill-bbpress',
+		EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/css/bbpress.css',
+		array(),
+		filemtime( EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/css/bbpress.css' )
+	);
+	wp_enqueue_style(
+		'topics-loop',
+		EXTRACHILL_COMMUNITY_PLUGIN_URL . '/inc/assets/css/topics-loop.css',
+		array( 'extrachill-bbpress' ),
+		filemtime( EXTRACHILL_COMMUNITY_PLUGIN_DIR . '/inc/assets/css/topics-loop.css' )
+	);
+}
+add_action( 'wp_enqueue_scripts', 'extrachill_community_enqueue_artist_discussions_styles', 20 );
+
+/**
+ * Resolve a bound main-blog artist term to its shared slug.
+ *
+ * @param int $artist_term_id Bound main-blog artist term ID.
+ * @return string
+ */
+function extrachill_community_resolve_bound_artist_slug( $artist_term_id ) {
+	$artist_term_id = (int) $artist_term_id;
+	if ( $artist_term_id <= 0 || ! function_exists( 'ec_get_blog_id' ) ) {
+		return '';
+	}
+
+	$main_blog_id = (int) ec_get_blog_id( 'main' );
+	if ( $main_blog_id <= 0 ) {
+		return '';
+	}
+
+	$slug = '';
+	switch_to_blog( $main_blog_id );
+	try {
+		if ( ! taxonomy_exists( 'artist' ) ) {
+			return '';
+		}
+
+		$term = get_term( $artist_term_id, 'artist' );
+		if ( $term instanceof WP_Term ) {
+			$slug = (string) $term->slug;
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	return $slug;
+}
+
+/**
+ * Gather the canonical Community destination and recent artist topics.
+ *
+ * The main-blog term ID cannot be queried directly against another site's
+ * term tables. Its slug is the shared join key, so Community resolves the
+ * local term by slug before deriving its real archive URL and topic query.
+ * Results are memoized because the registry calls visibility before render.
+ *
+ * @param int $artist_id      Artist profile post ID.
+ * @param int $artist_term_id Bound main-blog artist term ID.
+ * @return array{blog_id:int,url:string,name:string,topic_ids:int[]}
+ */
+function extrachill_community_get_artist_discussions( $artist_id, $artist_term_id ) {
+	static $memo = array();
+
+	$artist_id      = (int) $artist_id;
+	$artist_term_id = (int) $artist_term_id;
+	$key            = $artist_id . ':' . $artist_term_id;
+	$empty          = array(
+		'blog_id'   => 0,
+		'url'       => '',
+		'name'      => '',
+		'topic_ids' => array(),
+	);
+
+	if ( isset( $memo[ $key ] ) ) {
+		return $memo[ $key ];
+	}
+	$memo[ $key ] = $empty;
+
+	if (
+		$artist_id <= 0 ||
+		'artist_profile' !== get_post_type( $artist_id ) ||
+		! function_exists( 'ec_get_blog_id' ) ||
+		! function_exists( 'bbp_get_topic_post_type' ) ||
+		! function_exists( 'bbp_get_public_status_id' )
+	) {
+		return $empty;
+	}
+
+	$slug              = extrachill_community_resolve_bound_artist_slug( $artist_term_id );
+	$community_blog_id = (int) ec_get_blog_id( 'community' );
+	if ( '' === $slug || $community_blog_id <= 0 ) {
+		return $empty;
+	}
+
+	switch_to_blog( $community_blog_id );
+	try {
+		if ( ! taxonomy_exists( 'artist' ) ) {
+			return $empty;
+		}
+
+		$term = get_term_by( 'slug', $slug, 'artist' );
+		if ( ! ( $term instanceof WP_Term ) ) {
+			return $empty;
+		}
+
+		$url = get_term_link( $term );
+		if ( is_wp_error( $url ) || '' === (string) $url ) {
+			return $empty;
+		}
+
+		$query = new WP_Query(
+			array(
+				'post_type'              => bbp_get_topic_post_type(),
+				'post_status'            => bbp_get_public_status_id(),
+				'posts_per_page'         => EXTRACHILL_COMMUNITY_ARTIST_TOPIC_LIMIT,
+				'orderby'                => 'meta_value',
+				'meta_key'               => '_bbp_last_active_time', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_type'              => 'DATETIME',
+				'order'                  => 'DESC',
+				'ignore_sticky_posts'    => true,
+				'no_found_rows'          => true,
+				'update_post_term_cache' => true,
+				'update_post_meta_cache' => true,
+				'tax_query'              => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					array(
+						'taxonomy' => 'artist',
+						'field'    => 'term_id',
+						'terms'    => (int) $term->term_id,
+					),
+				),
+			)
+		);
+
+		$memo[ $key ] = array(
+			'blog_id'   => $community_blog_id,
+			'url'       => (string) $url,
+			'name'      => (string) $term->name,
+			'topic_ids' => array_map( 'intval', wp_list_pluck( $query->posts, 'ID' ) ),
+		);
+	} finally {
+		restore_current_blog();
+	}
+
+	return $memo[ $key ];
+}
+
+/**
+ * Hide the section when its profile, dependencies, or real destination fail.
+ *
+ * @param int $artist_id      Artist profile post ID.
+ * @param int $artist_term_id Bound main-blog artist term ID.
+ * @return bool
+ */
+function extrachill_community_artist_discussions_visible( $artist_id, $artist_term_id ) {
+	$data = extrachill_community_get_artist_discussions( $artist_id, $artist_term_id );
+
+	return '' !== $data['url'];
+}
+
+/**
+ * Render the Community discussion destination and recent topic cards.
+ *
+ * @param int $artist_id      Artist profile post ID.
+ * @param int $artist_term_id Bound main-blog artist term ID.
+ * @return void
+ */
+function extrachill_community_render_artist_discussions_section( $artist_id, $artist_term_id ) {
+	$data = extrachill_community_get_artist_discussions( $artist_id, $artist_term_id );
+	if ( '' === $data['url'] ) {
+		return;
+	}
+
+	echo '<section class="artist-discussions-section">';
+	echo '<h2 class="section-title">' . esc_html__( 'Discussions', 'extra-chill-community' ) . '</h2>';
+
+	if ( ! empty( $data['topic_ids'] ) ) {
+		switch_to_blog( $data['blog_id'] );
+		try {
+			if ( function_exists( 'extrachill_is_activity_feed_card' ) ) {
+				extrachill_is_activity_feed_card( true );
+			}
+
+			echo '<div class="artist-forum-topics ec-mobile-full-width-panel"><div class="bbp-body">';
+			foreach ( $data['topic_ids'] as $topic_id ) {
+				$topic = get_post( $topic_id );
+				if ( ! ( $topic instanceof WP_Post ) || bbp_get_topic_post_type() !== $topic->post_type ) {
+					continue;
+				}
+
+				require EXTRACHILL_COMMUNITY_PLUGIN_DIR . 'bbpress/loop-single-topic-card.php';
+			}
+			echo '</div></div>';
+		} finally {
+			if ( function_exists( 'extrachill_is_activity_feed_card' ) ) {
+				extrachill_is_activity_feed_card( false );
+			}
+			restore_current_blog();
+		}
+	} else {
+		echo '<p class="artist-discussions-empty">' . esc_html__( 'No discussions yet. Start the conversation in the Community.', 'extra-chill-community' ) . '</p>';
+	}
+
+	printf(
+		'<div class="artist-discussions-view-all"><a href="%1$s" class="button-3 button-small">%2$s</a></div>',
+		esc_url( $data['url'] ),
+		esc_html__( 'View artist discussions', 'extra-chill-community' )
+	);
+	echo '</section>';
+}

--- a/tests/test-artist-profile-discussions-dependency-absent.php
+++ b/tests/test-artist-profile-discussions-dependency-absent.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Verify missing Artist Platform/network/bbPress dependencies fail closed.
+ *
+ * Run: php tests/test-artist-profile-discussions-dependency-absent.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+function add_filter() {}
+
+function add_action() {}
+
+function __( $text ) {
+	return $text;
+}
+
+function get_post_type() {
+	return 'artist_profile';
+}
+
+require dirname( __DIR__ ) . '/inc/core/artist-profile-discussions.php';
+
+$data = extrachill_community_get_artist_discussions( 700, 55 );
+if ( '' !== $data['url'] || array() !== $data['topic_ids'] || extrachill_community_artist_discussions_visible( 700, 55 ) ) {
+	echo "FAIL: dependency-absent artist discussions should fail closed.\n";
+	exit( 1 );
+}
+
+echo "PASS: dependency-absent artist discussions fail closed.\n";
+exit( 0 );

--- a/tests/test-artist-profile-discussions.php
+++ b/tests/test-artist-profile-discussions.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Focused tests for the Community-owned artist profile discussion section.
+ *
+ * Run: php tests/test-artist-profile-discussions.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+class WP_Term {
+	public $term_id;
+	public $slug;
+	public $name;
+
+	public function __construct( $term_id, $slug, $name ) {
+		$this->term_id = $term_id;
+		$this->slug    = $slug;
+		$this->name    = $name;
+	}
+}
+
+class WP_Post {
+	public $ID;
+	public $post_type = 'topic';
+
+	public function __construct( $id ) {
+		$this->ID = $id;
+	}
+}
+
+class WP_Query {
+	public $posts;
+
+	public function __construct( $args ) {
+		$GLOBALS['_test_query_args'][] = $args;
+		$this->posts                   = array_map( static fn( $id ) => new WP_Post( $id ), $GLOBALS['_test_topic_ids'] );
+	}
+}
+
+$GLOBALS['_test_blog_id']    = 4;
+$GLOBALS['_test_query_args'] = array();
+$GLOBALS['_test_topic_ids']  = array( 91, 82, 73, 64 );
+$GLOBALS['_test_filters']    = array();
+
+function add_filter( $hook, $callback, $priority, $accepted_args ) {
+	$GLOBALS['_test_filters'][] = compact( 'hook', 'callback', 'priority', 'accepted_args' );
+}
+
+function add_action() {}
+
+function __( $text ) {
+	return $text;
+}
+
+function esc_html__( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES );
+}
+
+function esc_url( $url ) {
+	return htmlspecialchars( $url, ENT_QUOTES );
+}
+
+function is_singular( $post_type ) {
+	return 'artist_profile' === $post_type;
+}
+
+function get_post_type( $post_id ) {
+	return 700 === $post_id ? 'artist_profile' : 'post';
+}
+
+function ec_get_blog_id( $key ) {
+	return array( 'main' => 1, 'community' => 2 )[ $key ] ?? 0;
+}
+
+function switch_to_blog( $blog_id ) {
+	$GLOBALS['_test_blog_stack'][] = $GLOBALS['_test_blog_id'];
+	$GLOBALS['_test_blog_id']      = (int) $blog_id;
+}
+
+function restore_current_blog() {
+	$GLOBALS['_test_blog_id'] = array_pop( $GLOBALS['_test_blog_stack'] );
+}
+
+function taxonomy_exists( $taxonomy ) {
+	return 'artist' === $taxonomy;
+}
+
+function get_term( $term_id, $taxonomy ) {
+	if ( 1 !== $GLOBALS['_test_blog_id'] || 'artist' !== $taxonomy ) {
+		return false;
+	}
+
+	if ( 55 === $term_id ) {
+		return new WP_Term( 55, 'kid-lake', 'Kid Lake' );
+	}
+
+	return 56 === $term_id ? new WP_Term( 56, 'quiet-artist', 'Quiet Artist' ) : false;
+}
+
+function get_term_by( $field, $slug, $taxonomy ) {
+	if ( 2 !== $GLOBALS['_test_blog_id'] || 'slug' !== $field || 'artist' !== $taxonomy ) {
+		return false;
+	}
+
+	if ( 'kid-lake' === $slug ) {
+		return new WP_Term( 155, 'kid-lake', 'Kid Lake' );
+	}
+
+	return 'quiet-artist' === $slug ? new WP_Term( 156, 'quiet-artist', 'Quiet Artist' ) : false;
+}
+
+function get_term_link( $term ) {
+	return 'https://community.extrachill.com/artist/' . $term->slug . '/?ref="unsafe';
+}
+
+function is_wp_error() {
+	return false;
+}
+
+function bbp_get_topic_post_type() {
+	return 'topic';
+}
+
+function bbp_get_public_status_id() {
+	return 'publish';
+}
+
+function wp_list_pluck( $posts, $field ) {
+	return array_map( static fn( $post ) => $post->{$field}, $posts );
+}
+
+require dirname( __DIR__ ) . '/inc/core/artist-profile-discussions.php';
+
+$failures = 0;
+
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+check( 'Community registers through the profile section seam with all arguments', array( 'hook' => 'ec_artist_profile_sections', 'callback' => 'extrachill_community_register_artist_discussions_section', 'priority' => 10, 'accepted_args' => 3 ) === $GLOBALS['_test_filters'][0] );
+
+$sections = extrachill_community_register_artist_discussions_section( array(), 700, 55 );
+check( 'section is Community-owned and ordered after existing profile sections', 'discussions' === $sections[0]['id'] && 50 === $sections[0]['priority'] );
+
+$data = extrachill_community_get_artist_discussions( 700, 55 );
+check( 'bound main term resolves to the Community term and canonical archive', 2 === $data['blog_id'] && false !== strpos( $data['url'], '/artist/kid-lake/' ) );
+check( 'recent topic output is bounded to four IDs', array( 91, 82, 73, 64 ) === $data['topic_ids'] && 4 === $GLOBALS['_test_query_args'][0]['posts_per_page'] );
+check( 'query uses Community term ID instead of the main-blog term ID', 155 === $GLOBALS['_test_query_args'][0]['tax_query'][0]['terms'] );
+check( 'query is cheap and recent-activity ordered', true === $GLOBALS['_test_query_args'][0]['no_found_rows'] && '_bbp_last_active_time' === $GLOBALS['_test_query_args'][0]['meta_key'] );
+check( 'cross-blog work restores the artist blog context', 4 === $GLOBALS['_test_blog_id'] );
+check( 'invalid profile dependency fails closed', false === extrachill_community_artist_discussions_visible( 701, 55 ) );
+
+$GLOBALS['_test_topic_ids'] = array();
+$empty_data                 = extrachill_community_get_artist_discussions( 700, 56 );
+check( 'real destination remains available when no recent topics exist', false !== strpos( $empty_data['url'], '/artist/quiet-artist/' ) && array() === $empty_data['topic_ids'] );
+
+ob_start();
+extrachill_community_render_artist_discussions_section( 700, 56 );
+$rendered = ob_get_clean();
+check( 'empty topic state points to the real Community archive', false !== strpos( $rendered, 'No discussions yet.' ) && false !== strpos( $rendered, 'View artist discussions' ) );
+check( 'destination output is escaped', false !== strpos( $rendered, '?ref=&quot;unsafe' ) && false === strpos( $rendered, '?ref="unsafe' ) );
+
+$missing_data = extrachill_community_get_artist_discussions( 700, 57 );
+check( 'missing bound term fails closed', '' === $missing_data['url'] && array() === $missing_data['topic_ids'] );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All artist profile discussion tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- register a Community-owned `discussions` section through Artist Platform's existing `ec_artist_profile_sections` seam, without adding any Community knowledge to Artist Platform
- resolve the bound main-site artist term through its shared slug, then resolve the Community-local term and canonical `get_term_link()` archive in Community blog context
- render up to four recently active artist-tagged topics with Community's canonical topic-card partial and link every valid term to its real Community discussion archive

## Ownership and behavior
Community owns the section registration, taxonomy lookup, topic query, archive destination, card rendering, and styles. The integration only exists when Community is loaded on the artist-profile request; missing Community, bbPress, network helpers, a valid `artist_profile`, the bound main term, the Community-local term, or a valid term link causes the section to fail closed.

The main-site term ID is never reused against Community's term tables. It resolves to the shared artist slug on the main site, then Community resolves its own term ID by that slug before querying.

The destination is generated by `get_term_link()` while switched to the Community blog, so no synthetic search URL or hardcoded route is introduced. A valid Community term with no recent topics still renders an honest empty state and its real archive destination; unavailable dependencies or terms render nothing.

The recent-topic query is fixed at four published topics, ordered by `_bbp_last_active_time`, with `no_found_rows`, sticky suppression, and request memoization so registry visibility and rendering do not duplicate cross-site work. Output owned by this section is escaped, and existing topic markup comes from Community's canonical card partial.

## Verification
- `php tests/test-artist-profile-discussions.php`
- `php tests/test-artist-profile-discussions-dependency-absent.php`
- `php tests/test-artist-platform-cta.php`
- `php tests/test-artist-platform-cta-dependency-absent.php`
- `php -l inc/core/artist-profile-discussions.php`
- `php -l extrachill-community.php`
- `php -l tests/test-artist-profile-discussions.php`
- `php -l tests/test-artist-profile-discussions-dependency-absent.php`
- `/tmp/opencode/phpcs-209/vendor/bin/phpcs --standard=WordPress --extensions=php inc/core/artist-profile-discussions.php`
- `npm run build`
- `git diff --check`

`npm run lint:css` was also run. It reports the repository's existing 1,280 legacy stylesheet errors; this PR changes no CSS.

Closes #209