### PR TITLE
feat: continue entity discussions in composer

### DIFF
--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -78,6 +78,117 @@ function extrachill_community_term_picker_taxonomies() {
 }
 
 /**
+ * Resolve a valid entity continuation from composer query state.
+ *
+ * Contract: `?compose=discussion&entity_taxonomy=<taxonomy>&entity_slug=<slug>`.
+ * Only the entity taxonomies already supported by the composer are accepted,
+ * and the slug must resolve to an existing REST-enabled topic term.
+ *
+ * @param array<string,mixed>|null $query Query values, or null for the request.
+ * @return array{taxonomy:string,term:object}|null Valid continuation state.
+ */
+function extrachill_community_get_discussion_composer_state( $query = null ) {
+	if ( null === $query ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only composer state; no mutation occurs.
+		$query = $_GET;
+	}
+
+	$compose  = isset( $query['compose'] ) && is_scalar( $query['compose'] ) ? sanitize_key( wp_unslash( (string) $query['compose'] ) ) : '';
+	$taxonomy = isset( $query['entity_taxonomy'] ) && is_scalar( $query['entity_taxonomy'] ) ? sanitize_key( wp_unslash( (string) $query['entity_taxonomy'] ) ) : '';
+	$slug     = isset( $query['entity_slug'] ) && is_scalar( $query['entity_slug'] ) ? sanitize_title( wp_unslash( (string) $query['entity_slug'] ) ) : '';
+
+	if ( 'discussion' !== $compose || ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true ) || '' === $slug ) {
+		return null;
+	}
+
+	$tax_object = get_taxonomy( $taxonomy );
+	if ( ! $tax_object || empty( $tax_object->show_in_rest ) || ! is_object_in_taxonomy( 'topic', $taxonomy ) ) {
+		return null;
+	}
+
+	$term = get_term_by( 'slug', $slug, $taxonomy );
+	if ( ! $term || is_wp_error( $term ) ) {
+		return null;
+	}
+
+	return array(
+		'taxonomy' => $taxonomy,
+		'term'     => $term,
+	);
+}
+
+/**
+ * Build the canonical Community composer URL for a validated entity term.
+ *
+ * @param string $taxonomy Entity taxonomy.
+ * @param string $slug     Existing term slug.
+ * @return string Composer URL, or an empty string for invalid state.
+ */
+function extrachill_community_get_discussion_composer_url( $taxonomy, $slug ) {
+	$state = extrachill_community_get_discussion_composer_state(
+		array(
+			'compose'         => 'discussion',
+			'entity_taxonomy' => $taxonomy,
+			'entity_slug'     => $slug,
+		)
+	);
+	if ( ! $state ) {
+		return '';
+	}
+
+	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url( '/' );
+
+	return add_query_arg(
+		array(
+			'compose'         => 'discussion',
+			'entity_taxonomy' => $state['taxonomy'],
+			'entity_slug'     => $state['term']->slug,
+		),
+		trailingslashit( $community_url )
+	);
+}
+
+/**
+ * Whether the current user may receive composer preselection state.
+ *
+ * The normal bbPress form and submission checks remain authoritative; this
+ * gate only prevents continuation state from bypassing topic permissions.
+ *
+ * @return bool
+ */
+function extrachill_community_can_continue_discussion_composer() {
+	return is_user_logged_in()
+		&& function_exists( 'bbp_current_user_can_publish_topics' )
+		&& bbp_current_user_can_publish_topics();
+}
+
+/**
+ * Send logged-out continuation requests through the canonical login page.
+ */
+function extrachill_community_maybe_redirect_discussion_composer_login() {
+	if ( ! is_front_page() || is_user_logged_in() ) {
+		return;
+	}
+
+	$state = extrachill_community_get_discussion_composer_state();
+	if ( ! $state ) {
+		return;
+	}
+
+	$redirect_to = extrachill_community_get_discussion_composer_url( $state['taxonomy'], $state['term']->slug );
+	if ( '' === $redirect_to ) {
+		return;
+	}
+
+	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url( '/' );
+	$login_url     = add_query_arg( 'redirect_to', $redirect_to, trailingslashit( $community_url ) . 'login/' );
+
+	wp_safe_redirect( $login_url );
+	exit;
+}
+add_action( 'template_redirect', 'extrachill_community_maybe_redirect_discussion_composer_login' );
+
+/**
  * Build the localized config the React picker consumes.
  *
  * Filters out taxonomies that are not actually registered/REST-enabled, and
@@ -87,7 +198,10 @@ function extrachill_community_term_picker_taxonomies() {
  * @return array<string,mixed> Localizable config.
  */
 function extrachill_community_term_picker_config( $topic_id = 0 ) {
-	$taxonomies = array();
+	$taxonomies   = array();
+	$continuation = 0 === (int) $topic_id && extrachill_community_can_continue_discussion_composer()
+		? extrachill_community_get_discussion_composer_state()
+		: null;
 
 	foreach ( extrachill_community_term_picker_taxonomies() as $entry ) {
 		$taxonomy = $entry['taxonomy'];
@@ -109,6 +223,12 @@ function extrachill_community_term_picker_config( $topic_id = 0 ) {
 					);
 				}
 			}
+		} elseif ( $continuation && $taxonomy === $continuation['taxonomy'] ) {
+			$selected[] = array(
+				'id'     => (int) $continuation['term']->term_id,
+				'name'   => $continuation['term']->name,
+				'parent' => (int) $continuation['term']->parent,
+			);
 		}
 
 		$rest_base = ! empty( $tax_object->rest_base ) ? $tax_object->rest_base : $taxonomy;

--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -93,11 +93,24 @@ function extrachill_community_get_discussion_composer_state( $query = null ) {
 		$query = $_GET;
 	}
 
-	$compose  = isset( $query['compose'] ) && is_scalar( $query['compose'] ) ? sanitize_key( wp_unslash( (string) $query['compose'] ) ) : '';
-	$taxonomy = isset( $query['entity_taxonomy'] ) && is_scalar( $query['entity_taxonomy'] ) ? sanitize_key( wp_unslash( (string) $query['entity_taxonomy'] ) ) : '';
-	$slug     = isset( $query['entity_slug'] ) && is_scalar( $query['entity_slug'] ) ? sanitize_title( wp_unslash( (string) $query['entity_slug'] ) ) : '';
+	if ( ! isset( $query['compose'], $query['entity_taxonomy'], $query['entity_slug'] )
+		|| ! is_scalar( $query['compose'] )
+		|| ! is_scalar( $query['entity_taxonomy'] )
+		|| ! is_scalar( $query['entity_slug'] ) ) {
+		return null;
+	}
 
-	if ( 'discussion' !== $compose || ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true ) || '' === $slug ) {
+	$raw_compose  = wp_unslash( (string) $query['compose'] );
+	$raw_taxonomy = wp_unslash( (string) $query['entity_taxonomy'] );
+	$raw_slug     = wp_unslash( (string) $query['entity_slug'] );
+	$compose      = sanitize_key( $raw_compose );
+	$taxonomy     = sanitize_key( $raw_taxonomy );
+	$slug         = sanitize_title( $raw_slug );
+
+	if ( $raw_compose !== $compose || $raw_taxonomy !== $taxonomy || $raw_slug !== $slug
+		|| 'discussion' !== $compose
+		|| ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true )
+		|| '' === $slug ) {
 		return null;
 	}
 
@@ -149,6 +162,27 @@ function extrachill_community_get_discussion_composer_url( $taxonomy, $slug ) {
 }
 
 /**
+ * Build the canonical login URL for a validated composer continuation.
+ *
+ * Extra Chill Users owns validation and precedence for the eventual login
+ * round trip. Community only supplies its validated same-network destination.
+ *
+ * @param string $taxonomy Entity taxonomy.
+ * @param string $slug     Existing term slug.
+ * @return string Login URL, or an empty string for invalid state.
+ */
+function extrachill_community_get_discussion_composer_login_url( $taxonomy, $slug ) {
+	$redirect_to = extrachill_community_get_discussion_composer_url( $taxonomy, $slug );
+	if ( '' === $redirect_to ) {
+		return '';
+	}
+
+	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url( '/' );
+
+	return add_query_arg( 'redirect_to', $redirect_to, trailingslashit( $community_url ) . 'login/' );
+}
+
+/**
  * Whether the current user may receive composer preselection state.
  *
  * The normal bbPress form and submission checks remain authoritative; this
@@ -175,13 +209,10 @@ function extrachill_community_maybe_redirect_discussion_composer_login() {
 		return;
 	}
 
-	$redirect_to = extrachill_community_get_discussion_composer_url( $state['taxonomy'], $state['term']->slug );
-	if ( '' === $redirect_to ) {
+	$login_url = extrachill_community_get_discussion_composer_login_url( $state['taxonomy'], $state['term']->slug );
+	if ( '' === $login_url ) {
 		return;
 	}
-
-	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url( '/' );
-	$login_url     = add_query_arg( 'redirect_to', $redirect_to, trailingslashit( $community_url ) . 'login/' );
 
 	wp_safe_redirect( $login_url );
 	exit;

--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -179,7 +179,7 @@ function extrachill_community_get_discussion_composer_login_url( $taxonomy, $slu
 
 	$community_url = function_exists( 'ec_get_site_url' ) ? ec_get_site_url( 'community' ) : home_url( '/' );
 
-	return add_query_arg( 'redirect_to', $redirect_to, trailingslashit( $community_url ) . 'login/' );
+	return add_query_arg( 'redirect_to', rawurlencode( $redirect_to ), trailingslashit( $community_url ) . 'login/' );
 }
 
 /**

--- a/inc/home/assets/js/new-topic-modal.js
+++ b/inc/home/assets/js/new-topic-modal.js
@@ -137,9 +137,8 @@
 		}
 	}
 
-	function openModal( e ) {
-		e.preventDefault();
-		activeTrigger = e.currentTarget;
+	function showModal( triggerEl ) {
+		activeTrigger = triggerEl;
 
 		modal.classList.add( 'is-open' );
 		overlay.classList.add( 'is-open' );
@@ -159,6 +158,11 @@
 		}
 
 		document.addEventListener( 'keydown', trapFocus );
+	}
+
+	function openModal( e ) {
+		e.preventDefault();
+		showModal( e.currentTarget );
 	}
 
 	function closeModal() {
@@ -222,4 +226,8 @@
 	}
 
 	overlay.addEventListener( 'click', closeModal );
+
+	if ( modal.dataset.autoOpen === 'true' ) {
+		showModal( discussionTrigger );
+	}
 } )();

--- a/inc/home/new-topic-modal.php
+++ b/inc/home/new-topic-modal.php
@@ -12,10 +12,14 @@
 if ( ! defined('ABSPATH') ) {
 	exit;
 }
+
+$discussion_continuation = extrachill_community_can_continue_discussion_composer()
+	? extrachill_community_get_discussion_composer_state()
+	: null;
 ?>
 
 <div id="new-topic-modal-overlay" class="new-topic-modal-overlay"></div>
-<div id="new-topic-modal" class="new-topic-modal" role="dialog" aria-modal="true" aria-labelledby="new-topic-modal-title">
+<div id="new-topic-modal" class="new-topic-modal" role="dialog" aria-modal="true" aria-labelledby="new-topic-modal-title" data-auto-open="<?php echo $discussion_continuation ? 'true' : 'false'; ?>">
 	<div class="new-topic-modal-content">
 		<button type="button" class="new-topic-modal-close" aria-label="<?php esc_attr_e( 'Close modal', 'extra-chill-community' ); ?>">&times;</button>
 		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'Create Discussion', 'extra-chill-community' ); ?></h2>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "wp-scripts build --webpack-copy-php",
     "start": "wp-scripts start",
+    "test:js": "wp-scripts test-unit-js --runInBand",
     "lint:js": "wp-scripts lint-js",
     "lint:css": "wp-scripts lint-style",
     "format": "wp-scripts format",

--- a/tests/js/discussion-composer.test.tsx
+++ b/tests/js/discussion-composer.test.tsx
@@ -1,0 +1,98 @@
+import { createRoot } from '@wordpress/element';
+// React is supplied by the WordPress test runtime rather than bundled here.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act } from 'react';
+
+import { TermPicker } from '../../src/term-picker/TermPicker';
+import type { TaxonomyConfig } from '../../src/term-picker/types';
+
+function renderModalMarkup( autoOpen: boolean ) {
+	document.body.innerHTML = `
+		<a id="new-topic-modal-trigger" data-modal-mode="discussion" href="#new-post">Create Discussion</a>
+		<div id="new-topic-modal-overlay"></div>
+		<div id="new-topic-modal" data-auto-open="${ autoOpen }">
+			<button type="button" class="new-topic-modal-close">Close</button>
+			<h2 id="new-topic-modal-title">Create Discussion</h2>
+			<p id="new-topic-modal-description"></p>
+			<p><select id="bbp_forum_id"><option value="1">Music</option></select></p>
+			<input id="bbp_topic_title" type="text" />
+			<textarea id="bbp_topic_content"></textarea>
+		</div>`;
+}
+
+describe( 'discussion composer continuation', () => {
+	beforeAll( () => {
+		const reactGlobal = globalThis as typeof globalThis & {
+			IS_REACT_ACT_ENVIRONMENT: boolean;
+		};
+		reactGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		jest.resetModules();
+	} );
+
+	it( 'auto-opens the existing discussion modal when instructed', () => {
+		renderModalMarkup( true );
+
+		jest.isolateModules( () => {
+			require( '../../inc/home/assets/js/new-topic-modal.js' );
+		} );
+
+		expect(
+			document.getElementById( 'new-topic-modal' )?.classList
+		).toContain( 'is-open' );
+		expect(
+			document.getElementById( 'new-topic-modal-overlay' )?.classList
+		).toContain( 'is-open' );
+		expect( document.body.classList ).toContain( 'new-topic-modal-open' );
+		const modal = document.getElementById( 'new-topic-modal' );
+		expect( modal?.ownerDocument.activeElement ).toBe(
+			document.getElementById( 'bbp_topic_title' )
+		);
+		expect(
+			document.getElementById( 'new-topic-modal-description' )
+				?.textContent
+		).toBe( 'Start a new topic in the community.' );
+	} );
+
+	it( 'does not auto-open the normal composer without continuation state', () => {
+		renderModalMarkup( false );
+
+		jest.isolateModules( () => {
+			require( '../../inc/home/assets/js/new-topic-modal.js' );
+		} );
+
+		expect(
+			document.getElementById( 'new-topic-modal' )?.classList
+		).not.toContain( 'is-open' );
+	} );
+
+	it( 'renders a server-validated initial term through the existing picker', () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		const config: TaxonomyConfig = {
+			taxonomy: 'artist',
+			restBase: 'artist',
+			label: 'Artist',
+			placeholder: 'Search artists...',
+			hierarchical: false,
+			field: 'bbp_topic_artist',
+			selected: [ { id: 42, name: 'Phish', parent: 0 } ],
+		};
+
+		act( () => {
+			root.render( <TermPicker config={ config } /> );
+		} );
+
+		const selectedInput = container.querySelector< HTMLInputElement >(
+			'input[name="bbp_topic_artist[]"]'
+		);
+		expect( selectedInput?.value ).toBe( '42' );
+		expect( container.textContent ).toContain( 'Phish' );
+
+		act( () => root.unmount() );
+	} );
+} );

--- a/tests/test-discussion-composer-continuation.php
+++ b/tests/test-discussion-composer-continuation.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Focused tests for validated entity continuation into the topic composer.
+ *
+ * Run: php tests/test-discussion-composer-continuation.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['_test_query']       = array();
+$GLOBALS['_test_logged_in']   = true;
+$GLOBALS['_test_can_publish'] = true;
+$GLOBALS['_test_terms']       = array(
+	'artist' => array(
+		'phish' => (object) array(
+			'term_id' => 42,
+			'name'    => 'Phish',
+			'slug'    => 'phish',
+			'parent'  => 0,
+		),
+	),
+);
+
+function add_action() {}
+function apply_filters( $hook, $value ) {
+	return $value;
+}
+function __( $text ) {
+	return $text;
+}
+function sanitize_key( $value ) {
+	return strtolower( preg_replace( '/[^a-z0-9_-]/', '', $value ) );
+}
+function sanitize_title( $value ) {
+	return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $value ), '-' ) );
+}
+function wp_unslash( $value ) {
+	return $value;
+}
+function get_taxonomy( $taxonomy ) {
+	if ( ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true ) ) {
+		return false;
+	}
+
+	return (object) array(
+		'show_in_rest' => true,
+		'rest_base'    => $taxonomy,
+		'hierarchical' => 'location' === $taxonomy,
+	);
+}
+function is_object_in_taxonomy( $post_type, $taxonomy ) {
+	return 'topic' === $post_type && in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true );
+}
+function get_term_by( $field, $slug, $taxonomy ) {
+	return $GLOBALS['_test_terms'][ $taxonomy ][ $slug ] ?? false;
+}
+function is_wp_error() {
+	return false;
+}
+function is_user_logged_in() {
+	return $GLOBALS['_test_logged_in'];
+}
+function bbp_current_user_can_publish_topics() {
+	return $GLOBALS['_test_can_publish'];
+}
+function ec_get_site_url() {
+	return 'https://community.extrachill.com';
+}
+function home_url( $path = '' ) {
+	return 'https://community.extrachill.com' . $path;
+}
+function trailingslashit( $value ) {
+	return rtrim( $value, '/' ) . '/';
+}
+function add_query_arg( $args, $url = '' ) {
+	if ( ! is_array( $args ) ) {
+		$args = array( $args => $url );
+		$url  = func_get_arg( 2 );
+	}
+
+	return $url . '?' . http_build_query( $args );
+}
+function rest_url() {
+	return 'https://community.extrachill.com/wp-json/';
+}
+function esc_url_raw( $url ) {
+	return $url;
+}
+function wp_create_nonce() {
+	return 'nonce';
+}
+function get_the_terms() {
+	return array();
+}
+
+require dirname( __DIR__ ) . '/inc/content/editor/composer-term-picker.php';
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+$valid_query = array(
+	'compose'         => 'discussion',
+	'entity_taxonomy' => 'artist',
+	'entity_slug'     => 'phish',
+);
+
+$state = extrachill_community_get_discussion_composer_state( $valid_query );
+check( 'valid supported existing term resolves', $state && 42 === (int) $state['term']->term_id );
+check(
+	'canonical URL uses taxonomy and slug state',
+	'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=phish' === extrachill_community_get_discussion_composer_url( 'artist', 'phish' )
+);
+check(
+	'unsupported taxonomy is rejected',
+	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_taxonomy' => 'post_tag' ) ) )
+);
+check(
+	'missing existing term is rejected',
+	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_slug' => 'missing' ) ) )
+);
+check(
+	'missing discussion action degrades to normal composer',
+	null === extrachill_community_get_discussion_composer_state( array_diff_key( $valid_query, array( 'compose' => true ) ) )
+);
+
+$_GET = $valid_query;
+$config = extrachill_community_term_picker_config();
+$artist = array_values( array_filter( $config['taxonomies'], fn( $entry ) => 'artist' === $entry['taxonomy'] ) )[0];
+check( 'authorized continuation preselects the existing picker term', 42 === $artist['selected'][0]['id'] );
+
+$GLOBALS['_test_can_publish'] = false;
+$config                       = extrachill_community_term_picker_config();
+$artist                       = array_values( array_filter( $config['taxonomies'], fn( $entry ) => 'artist' === $entry['taxonomy'] ) )[0];
+check( 'topic permissions gate preselection', array() === $artist['selected'] );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All discussion composer continuation tests passed.\n";
+exit( 0 );

--- a/tests/test-discussion-composer-continuation.php
+++ b/tests/test-discussion-composer-continuation.php
@@ -73,12 +73,18 @@ function trailingslashit( $value ) {
 	return rtrim( $value, '/' ) . '/';
 }
 function add_query_arg( $args, $url = '' ) {
+	// Match WordPress: newly assigned values must already be URL-encoded.
 	if ( ! is_array( $args ) ) {
 		$args = array( $args => $url );
 		$url  = func_get_arg( 2 );
 	}
 
-	return $url . '?' . http_build_query( $args );
+	$pairs = array();
+	foreach ( $args as $key => $value ) {
+		$pairs[] = $key . '=' . $value;
+	}
+
+	return $url . '?' . implode( '&', $pairs );
 }
 function rest_url() {
 	return 'https://community.extrachill.com/wp-json/';
@@ -135,6 +141,8 @@ check(
 	'logged-out continuation preserves the validated composer URL',
 	'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=phish' === ( $login_query['redirect_to'] ?? '' )
 );
+check( 'nested composer state does not leak into outer login arguments', ! isset( $login_query['entity_taxonomy'], $login_query['entity_slug'] ) );
+check( 'login query contains only the complete redirect destination', array( 'redirect_to' ) === array_keys( $login_query ) );
 check(
 	'unsupported taxonomy is rejected',
 	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_taxonomy' => 'post_tag' ) ) )

--- a/tests/test-discussion-composer-continuation.php
+++ b/tests/test-discussion-composer-continuation.php
@@ -92,6 +92,15 @@ function wp_create_nonce() {
 function get_the_terms() {
 	return array();
 }
+function esc_attr_e( $text ) {
+	echo htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_html_e( $text ) {
+	echo htmlspecialchars( $text, ENT_QUOTES );
+}
+function bbp_get_template_part() {
+	echo '<form id="new-post"></form>';
+}
 
 require dirname( __DIR__ ) . '/inc/content/editor/composer-term-picker.php';
 
@@ -119,6 +128,13 @@ check(
 	'canonical URL uses taxonomy and slug state',
 	'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=phish' === extrachill_community_get_discussion_composer_url( 'artist', 'phish' )
 );
+$login_url = extrachill_community_get_discussion_composer_login_url( 'artist', 'phish' );
+parse_str( (string) parse_url( $login_url, PHP_URL_QUERY ), $login_query );
+check( 'logged-out continuation uses the canonical login path', 'https://community.extrachill.com/login/' === strtok( $login_url, '?' ) );
+check(
+	'logged-out continuation preserves the validated composer URL',
+	'https://community.extrachill.com/?compose=discussion&entity_taxonomy=artist&entity_slug=phish' === ( $login_query['redirect_to'] ?? '' )
+);
 check(
 	'unsupported taxonomy is rejected',
 	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_taxonomy' => 'post_tag' ) ) )
@@ -131,6 +147,22 @@ check(
 	'missing discussion action degrades to normal composer',
 	null === extrachill_community_get_discussion_composer_state( array_diff_key( $valid_query, array( 'compose' => true ) ) )
 );
+check(
+	'array taxonomy state is rejected',
+	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_taxonomy' => array( 'artist' ) ) ) )
+);
+check(
+	'array term state is rejected',
+	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_slug' => array( 'phish' ) ) ) )
+);
+check(
+	'non-canonical taxonomy state is rejected',
+	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_taxonomy' => 'Artist!' ) ) )
+);
+check(
+	'non-canonical term state is rejected',
+	null === extrachill_community_get_discussion_composer_state( array_merge( $valid_query, array( 'entity_slug' => '../phish' ) ) )
+);
 
 $_GET = $valid_query;
 $config = extrachill_community_term_picker_config();
@@ -141,6 +173,23 @@ $GLOBALS['_test_can_publish'] = false;
 $config                       = extrachill_community_term_picker_config();
 $artist                       = array_values( array_filter( $config['taxonomies'], fn( $entry ) => 'artist' === $entry['taxonomy'] ) )[0];
 check( 'topic permissions gate preselection', array() === $artist['selected'] );
+
+function render_topic_modal() {
+	ob_start();
+	include dirname( __DIR__ ) . '/inc/home/new-topic-modal.php';
+	return ob_get_clean();
+}
+
+$GLOBALS['_test_can_publish'] = true;
+$_GET                         = $valid_query;
+check( 'valid authorized continuation marks modal for auto-open', false !== strpos( render_topic_modal(), 'data-auto-open="true"' ) );
+
+$_GET = array_merge( $valid_query, array( 'entity_slug' => '../phish' ) );
+check( 'malformed continuation leaves modal closed', false !== strpos( render_topic_modal(), 'data-auto-open="false"' ) );
+
+$GLOBALS['_test_can_publish'] = false;
+$_GET                         = $valid_query;
+check( 'unauthorized continuation leaves modal closed', false !== strpos( render_topic_modal(), 'data-auto-open="false"' ) );
 
 if ( $failures > 0 ) {
 	exit( 1 );


### PR DESCRIPTION
## Summary
- add a Community-owned composer continuation URL that opens the existing topic composer with an existing entity term preselected
- validate supported taxonomy and term state server-side, then reuse the existing picker and bbPress topic form without adding a write API or term creation path
- construct the canonical logged-out login URL with the nested composer destination explicitly encoded as one `redirect_to` value

## URL and state contract

`https://community.extrachill.com/?compose=discussion&entity_taxonomy=<taxonomy>&entity_slug=<slug>`

Supported entity taxonomies are `artist`, `festival`, and `location`. Slugs are resolved on Community so consumers do not depend on cross-site term IDs.

## Validation and permissions
- requires the exact `compose=discussion` action
- allowlists the three supported entity taxonomies
- rejects non-scalar and non-canonical taxonomy/slug values instead of normalizing malformed state into a valid destination
- requires the taxonomy to be REST-enabled and attached to `topic`
- resolves an existing term by slug; no arbitrary term creation is possible
- applies preselection only to authenticated users who pass bbPress `publish_topics` checks
- leaves the existing bbPress form, nonce, submission permissions, save handlers, and topic creation ability authoritative

## Login and fallback
- valid logged-out continuation URLs encode the complete composer URL once before assigning it to `redirect_to`
- one normal query parse restores the full composer destination without leaking `entity_taxonomy` or `entity_slug` as outer login arguments
- after a successful upstream login continuation, the homepage composer auto-opens with the validated existing term selected
- invalid, unsupported, missing, malformed, or unauthorized state is ignored and degrades to the normal composer/homepage behavior

## Upstream dependency

Authentication continuation remains owned by Extra-Chill/extrachill-users#209. Extra Chill Users must prefer the validated request `redirect_to` over a fixed login block redirect. This PR does not add a Community authentication workaround or alter shared login precedence; its coverage stops at exact logged-out redirect URL construction and resumes at the returned composer URL.

## Verification
- `php tests/test-discussion-composer-continuation.php`
- `php tests/test-homepage-header.php`
- `npm run test:js`
- `npm run lint:js -- tests/js/discussion-composer.test.tsx inc/home/assets/js/new-topic-modal.js src/term-picker/TermPicker.tsx`
- `php -l inc/content/editor/composer-term-picker.php`
- `php -l inc/home/new-topic-modal.php`
- `php -l tests/test-discussion-composer-continuation.php`
- `homeboy --placement local review extrachill-community lint --path /var/lib/datamachine/workspace/extrachill-community@issue-211-discussion-composer --changed-only --summary`
- `homeboy review build extrachill-community --path /var/lib/datamachine/workspace/extrachill-community@issue-211-discussion-composer --placement local`
- `git diff --check origin/main...HEAD`

The PHP regression stub now matches WordPress `add_query_arg()` semantics for newly assigned values rather than masking the bug with `http_build_query()`. It proves `parse_str()` receives the complete nested `redirect_to`, performs only the expected single decode, and exposes no outer entity arguments. Additional PHP assertions cover malformed values, permissions, picker preselection config, and modal `data-auto-open` rendering. Jest covers modal auto-open/fallback and rendering validated initial selection through the real `TermPicker`.

Changed-file PHPCS and focused ESLint passed with no findings. Homeboy skipped PHPStan because its installed WordPress extension binary is corrupted; focused tests, direct syntax checks, and the full build/package syntax gate passed.

Closes #211