### PR TITLE
feat: publish discussion composer contract

### DIFF
--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -78,6 +78,64 @@ function extrachill_community_term_picker_taxonomies() {
 }
 
 /**
+ * Return the public discussion composer contract.
+ *
+ * This serializable definition is both the live resolver configuration and the
+ * deployment marker read by cross-site consumers with get_blog_option().
+ *
+ * @return array{
+ *     schema_version:int,
+ *     action:string,
+ *     query_parameters:array{action:string,taxonomy:string,slug:string},
+ *     supported_taxonomies:string[]
+ * }
+ */
+function extrachill_community_discussion_composer_contract() {
+	$taxonomies = array_column( extrachill_community_term_picker_taxonomies(), 'taxonomy' );
+
+	return array(
+		'schema_version'       => 1,
+		'action'               => 'discussion',
+		'query_parameters'     => array(
+			'action'   => 'compose',
+			'taxonomy' => 'entity_taxonomy',
+			'slug'     => 'entity_slug',
+		),
+		'supported_taxonomies' => array_values( array_unique( $taxonomies ) ),
+	);
+}
+
+/**
+ * Option key used to publish the composer contract on the Community site.
+ *
+ * @return string
+ */
+function extrachill_community_discussion_composer_contract_option() {
+	return 'extrachill_community_discussion_composer_contract';
+}
+
+/**
+ * Publish or migrate the deployment-discoverable composer contract.
+ *
+ * The plugin is site-active on Community, so the current-site option is
+ * directly readable from any network site with get_blog_option().
+ *
+ * @return bool Whether the stored contract changed.
+ */
+function extrachill_community_publish_discussion_composer_contract() {
+	$option   = extrachill_community_discussion_composer_contract_option();
+	$contract = extrachill_community_discussion_composer_contract();
+
+	if ( get_option( $option, null ) === $contract ) {
+		return false;
+	}
+
+	update_option( $option, $contract, false );
+	return true;
+}
+add_action( 'plugins_loaded', 'extrachill_community_publish_discussion_composer_contract', 20 );
+
+/**
  * Resolve a valid entity continuation from composer query state.
  *
  * Contract: `?compose=discussion&entity_taxonomy=<taxonomy>&entity_slug=<slug>`.
@@ -88,28 +146,31 @@ function extrachill_community_term_picker_taxonomies() {
  * @return array{taxonomy:string,term:object}|null Valid continuation state.
  */
 function extrachill_community_get_discussion_composer_state( $query = null ) {
+	$contract = extrachill_community_discussion_composer_contract();
+	$keys     = $contract['query_parameters'];
+
 	if ( null === $query ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only composer state; no mutation occurs.
 		$query = $_GET;
 	}
 
-	if ( ! isset( $query['compose'], $query['entity_taxonomy'], $query['entity_slug'] )
-		|| ! is_scalar( $query['compose'] )
-		|| ! is_scalar( $query['entity_taxonomy'] )
-		|| ! is_scalar( $query['entity_slug'] ) ) {
+	if ( ! isset( $query[ $keys['action'] ], $query[ $keys['taxonomy'] ], $query[ $keys['slug'] ] )
+		|| ! is_scalar( $query[ $keys['action'] ] )
+		|| ! is_scalar( $query[ $keys['taxonomy'] ] )
+		|| ! is_scalar( $query[ $keys['slug'] ] ) ) {
 		return null;
 	}
 
-	$raw_compose  = wp_unslash( (string) $query['compose'] );
-	$raw_taxonomy = wp_unslash( (string) $query['entity_taxonomy'] );
-	$raw_slug     = wp_unslash( (string) $query['entity_slug'] );
+	$raw_compose  = wp_unslash( (string) $query[ $keys['action'] ] );
+	$raw_taxonomy = wp_unslash( (string) $query[ $keys['taxonomy'] ] );
+	$raw_slug     = wp_unslash( (string) $query[ $keys['slug'] ] );
 	$compose      = sanitize_key( $raw_compose );
 	$taxonomy     = sanitize_key( $raw_taxonomy );
 	$slug         = sanitize_title( $raw_slug );
 
 	if ( $raw_compose !== $compose || $raw_taxonomy !== $taxonomy || $raw_slug !== $slug
-		|| 'discussion' !== $compose
-		|| ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true )
+		|| $contract['action'] !== $compose
+		|| ! in_array( $taxonomy, $contract['supported_taxonomies'], true )
 		|| '' === $slug ) {
 		return null;
 	}
@@ -138,11 +199,13 @@ function extrachill_community_get_discussion_composer_state( $query = null ) {
  * @return string Composer URL, or an empty string for invalid state.
  */
 function extrachill_community_get_discussion_composer_url( $taxonomy, $slug ) {
-	$state = extrachill_community_get_discussion_composer_state(
+	$contract = extrachill_community_discussion_composer_contract();
+	$keys     = $contract['query_parameters'];
+	$state    = extrachill_community_get_discussion_composer_state(
 		array(
-			'compose'         => 'discussion',
-			'entity_taxonomy' => $taxonomy,
-			'entity_slug'     => $slug,
+			$keys['action']   => $contract['action'],
+			$keys['taxonomy'] => $taxonomy,
+			$keys['slug']     => $slug,
 		)
 	);
 	if ( ! $state ) {
@@ -153,9 +216,9 @@ function extrachill_community_get_discussion_composer_url( $taxonomy, $slug ) {
 
 	return add_query_arg(
 		array(
-			'compose'         => 'discussion',
-			'entity_taxonomy' => $state['taxonomy'],
-			'entity_slug'     => $state['term']->slug,
+			$keys['action']   => $contract['action'],
+			$keys['taxonomy'] => $state['taxonomy'],
+			$keys['slug']     => $state['term']->slug,
 		),
 		trailingslashit( $community_url )
 	);

--- a/tests/test-discussion-composer-contract.php
+++ b/tests/test-discussion-composer-contract.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Focused tests for the deployment-discoverable composer contract.
+ *
+ * Run: php tests/test-discussion-composer-contract.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['_test_options']        = array();
+$GLOBALS['_test_option_updates'] = 0;
+
+function add_action() {}
+function apply_filters( $hook, $value ) {
+	return $value;
+}
+function __( $text ) {
+	return $text;
+}
+function get_option( $key, $default = false ) {
+	return $GLOBALS['_test_options'][ $key ] ?? $default;
+}
+function update_option( $key, $value, $autoload = null ) {
+	$GLOBALS['_test_options'][ $key ] = $value;
+	++$GLOBALS['_test_option_updates'];
+	return true;
+}
+function sanitize_key( $value ) {
+	return strtolower( preg_replace( '/[^a-z0-9_-]/', '', $value ) );
+}
+function sanitize_title( $value ) {
+	return strtolower( trim( preg_replace( '/[^a-z0-9]+/i', '-', $value ), '-' ) );
+}
+function wp_unslash( $value ) {
+	return $value;
+}
+function get_taxonomy( $taxonomy ) {
+	if ( ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true ) ) {
+		return false;
+	}
+
+	return (object) array( 'show_in_rest' => true );
+}
+function is_object_in_taxonomy( $post_type, $taxonomy ) {
+	return 'topic' === $post_type && in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true );
+}
+function get_term_by( $field, $slug, $taxonomy ) {
+	return (object) array(
+		'slug'    => $slug,
+		'term_id' => 1,
+	);
+}
+function is_wp_error() {
+	return false;
+}
+
+require dirname( __DIR__ ) . '/inc/content/editor/composer-term-picker.php';
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+$option            = extrachill_community_discussion_composer_contract_option();
+$contract          = extrachill_community_discussion_composer_contract();
+$picker_taxonomies = array_column( extrachill_community_term_picker_taxonomies(), 'taxonomy' );
+
+check( 'contract is absent before initial publication', null === get_option( $option, null ) );
+check( 'marker taxonomies exactly match the composer taxonomy source', $picker_taxonomies === $contract['supported_taxonomies'] );
+check( 'initial runtime publishes the contract', extrachill_community_publish_discussion_composer_contract() );
+check( 'published option exactly matches the live definition', $contract === get_option( $option ) );
+check( 'initial publication performs one option write', 1 === $GLOBALS['_test_option_updates'] );
+
+check( 'unchanged runtime publication is idempotent', ! extrachill_community_publish_discussion_composer_contract() );
+check( 'idempotent publication performs no additional write', 1 === $GLOBALS['_test_option_updates'] );
+
+$GLOBALS['_test_options'][ $option ] = array(
+	'schema_version' => 0,
+);
+check( 'old contract version is upgraded', extrachill_community_publish_discussion_composer_contract() );
+check( 'upgrade stores the complete current contract', $contract === get_option( $option ) );
+check( 'upgrade performs exactly one additional write', 2 === $GLOBALS['_test_option_updates'] );
+
+$keys  = $contract['query_parameters'];
+$query = array(
+	$keys['action']   => $contract['action'],
+	$keys['taxonomy'] => 'artist',
+	$keys['slug']     => 'phish',
+);
+check( 'marker query keys resolve through the live resolver', null !== extrachill_community_get_discussion_composer_state( $query ) );
+
+foreach ( $contract['supported_taxonomies'] as $taxonomy ) {
+	$query[ $keys['taxonomy'] ] = $taxonomy;
+	check( "marker taxonomy {$taxonomy} is accepted by the live resolver", null !== extrachill_community_get_discussion_composer_state( $query ) );
+}
+
+$query[ $keys['taxonomy'] ] = 'post_tag';
+check( 'taxonomy absent from marker is rejected by the live resolver', null === extrachill_community_get_discussion_composer_state( $query ) );
+check( 'publication does not require bbPress functions', ! function_exists( 'bbp_get_topic_id' ) );
+check( 'publication uses a site option without network activation APIs', ! function_exists( 'is_plugin_active_for_network' ) );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All discussion composer contract tests passed.\n";
+exit( 0 );

--- a/tests/test-discussion-composer-contract.php
+++ b/tests/test-discussion-composer-contract.php
@@ -9,8 +9,21 @@ define( 'ABSPATH', __DIR__ );
 
 $GLOBALS['_test_options']        = array();
 $GLOBALS['_test_option_updates'] = 0;
+$GLOBALS['_test_actions']        = array();
 
-function add_action() {}
+function add_action( $hook, $callback, $priority = 10 ) {
+	$GLOBALS['_test_actions'][ $hook ][ $priority ][] = $callback;
+}
+function run_test_action( $hook ) {
+	$callbacks = $GLOBALS['_test_actions'][ $hook ] ?? array();
+	ksort( $callbacks );
+
+	foreach ( $callbacks as $priority_callbacks ) {
+		foreach ( $priority_callbacks as $callback ) {
+			call_user_func( $callback );
+		}
+	}
+}
 function apply_filters( $hook, $value ) {
 	return $value;
 }
@@ -74,17 +87,24 @@ $picker_taxonomies = array_column( extrachill_community_term_picker_taxonomies()
 
 check( 'contract is absent before initial publication', null === get_option( $option, null ) );
 check( 'marker taxonomies exactly match the composer taxonomy source', $picker_taxonomies === $contract['supported_taxonomies'] );
-check( 'initial runtime publishes the contract', extrachill_community_publish_discussion_composer_contract() );
+check(
+	'publisher is registered on plugins_loaded at priority 20',
+	in_array( 'extrachill_community_publish_discussion_composer_contract', $GLOBALS['_test_actions']['plugins_loaded'][20] ?? array(), true )
+);
+
+run_test_action( 'plugins_loaded' );
+check( 'initial plugins_loaded lifecycle publishes the contract', $contract === get_option( $option ) );
 check( 'published option exactly matches the live definition', $contract === get_option( $option ) );
 check( 'initial publication performs one option write', 1 === $GLOBALS['_test_option_updates'] );
 
-check( 'unchanged runtime publication is idempotent', ! extrachill_community_publish_discussion_composer_contract() );
+run_test_action( 'plugins_loaded' );
 check( 'idempotent publication performs no additional write', 1 === $GLOBALS['_test_option_updates'] );
 
 $GLOBALS['_test_options'][ $option ] = array(
 	'schema_version' => 0,
 );
-check( 'old contract version is upgraded', extrachill_community_publish_discussion_composer_contract() );
+run_test_action( 'plugins_loaded' );
+check( 'plugins_loaded lifecycle upgrades the old contract version', $contract === get_option( $option ) );
 check( 'upgrade stores the complete current contract', $contract === get_option( $option ) );
 check( 'upgrade performs exactly one additional write', 2 === $GLOBALS['_test_option_updates'] );
 


### PR DESCRIPTION
## Summary
- publish the Community-owned discussion composer contract as the non-autoloaded `extrachill_community_discussion_composer_contract` site option
- make the live resolver and URL builder consume the same canonical query-key, action, and supported-taxonomy definition that is serialized into the marker
- update the marker idempotently during normal Community runtime, replacing absent or older contract shapes without requiring bbPress calls or network activation

## Topology

Community and bbPress remain site-active on the Community site. WordPress does not load destination-site plugins when a source-site request calls `switch_to_blog()`, so cross-site consumers cannot use Community PHP helpers from those requests. The marker is persisted in the Community site's options table and can therefore be read from a source site with `get_blog_option( $community_blog_id, 'extrachill_community_discussion_composer_contract' )` without loading Community code, activating either plugin network-wide, or introducing an endpoint.

## Marker Contract

Schema version `1` publishes this shape:

```php
array(
    'schema_version'       => 1,
    'action'               => 'discussion',
    'query_parameters'     => array(
        'action'   => 'compose',
        'taxonomy' => 'entity_taxonomy',
        'slug'     => 'entity_slug',
    ),
    'supported_taxonomies' => array( 'location', 'festival', 'artist' ),
)
```

The supported taxonomy list is derived from the existing composer term-picker source. The live continuation resolver and URL builder now read this same contract function rather than maintaining separate hardcoded query keys or taxonomy allowlists.

The contract publisher runs on `plugins_loaded` after Community initializes. It compares the complete stored value to the current definition and writes only when absent or changed, which makes normal requests idempotent and schema/shape changes self-migrating. The option is not autoloaded.

Consumers must fail closed when the option is absent, malformed, or has a schema version they do not support. Community remains authoritative for request validation, destination-local term existence, REST/topic taxonomy support, permissions, and composer preselection.

## Verification

Passed:

```text
php tests/test-discussion-composer-contract.php
php tests/test-discussion-composer-continuation.php
npm run test:js -- tests/js/discussion-composer.test.tsx
npx wp-scripts lint-js tests/js/discussion-composer.test.tsx
php -l inc/content/editor/composer-term-picker.php
php -l tests/test-discussion-composer-contract.php
homeboy --placement local review lint extrachill-community --path /var/lib/datamachine/workspace/extrachill-community@issue-218-composer-contract --changed-only --summary
git diff --check
```

The focused contract test covers initial publication, unchanged idempotence, replacement of an older schema, exact marker/taxonomy-source parity, marker-key resolution through the live resolver, rejection outside the advertised taxonomy set, and publication without bbPress or network-activation APIs.

No build was run because no JavaScript, CSS, block metadata, or generated asset source changed. Homeboy's changed-file PHPCS lint passed; its PHPStan phase was unavailable because the installed Homeboy WordPress extension reported a corrupted PHPStan binary and skipped static analysis.

Closes #218