### PR TITLE
feat: add concert privacy settings

### DIFF
--- a/inc/user-profiles/concert-history.php
+++ b/inc/user-profiles/concert-history.php
@@ -13,10 +13,6 @@
  * taxonomy enrichment (artist/venue/city names) requires events-site context,
  * so we always route through the events site.
  *
- * Performance: stats are cached per-user in a short transient on the community
- * site so repeated profile views don't re-dispatch a cross-site request each
- * time. The cache is invalidated by TTL only (concert history changes rarely).
- *
  * @package ExtraChillCommunity
  * @since 0.x
  */
@@ -24,17 +20,12 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Cache TTL for per-user concert stats on the profile (seconds).
- */
-const EC_CONCERT_HISTORY_CACHE_TTL = 15 * MINUTE_IN_SECONDS;
-
-/**
  * Fetch a user's aggregate concert stats from the events site.
  *
  * Calls the public get-user-concert-stats ability via in-process cross-site
- * REST dispatch and caches the result in a per-user transient. Returns null
- * on any failure (missing primitive, cross-site error, malformed payload) so
- * the caller can silently skip the card without ever breaking the profile.
+ * REST dispatch. Returns null on any failure (missing primitive, cross-site
+ * error, malformed payload) so the renderer can distinguish unavailable data
+ * from a legitimate zero-show response.
  *
  * @param int $user_id User ID.
  * @return array|null Stats payload, or null on failure / unavailable.
@@ -44,11 +35,10 @@ function ec_community_get_concert_stats( int $user_id ): ?array {
 		return null;
 	}
 
-	$cache_key = 'ec_concert_stats_' . $user_id;
-	$cached    = get_transient( $cache_key );
-	if ( false !== $cached ) {
-		// Empty-array sentinel means "fetched, but user has no shows".
-		return is_array( $cached ) ? $cached : null;
+	// Authorization must precede the cross-site request so private data is never
+	// fetched for an unauthorized viewer.
+	if ( ! function_exists( 'extrachill_users_can_view_concert_history' ) || ! extrachill_users_can_view_concert_history( $user_id ) ) {
+		return null;
 	}
 
 	if ( ! function_exists( 'ec_cross_site_rest_request' ) ) {
@@ -62,13 +52,9 @@ function ec_community_get_concert_stats( int $user_id ): ?array {
 		array( 'user_id' => $user_id )
 	);
 
-	if ( is_wp_error( $response ) || ! is_array( $response ) ) {
-		// Cache a brief negative result to avoid hammering on every view.
-		set_transient( $cache_key, 'none', MINUTE_IN_SECONDS );
+	if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['total_shows'] ) || ! is_numeric( $response['total_shows'] ) ) {
 		return null;
 	}
-
-	set_transient( $cache_key, $response, EC_CONCERT_HISTORY_CACHE_TTL );
 
 	return $response;
 }
@@ -139,9 +125,9 @@ function ec_community_render_top_list( array $items, int $limit = 5 ): string {
  * Display the Concert History card on the bbPress user profile.
  *
  * Pulls real tracked shows from the events site and renders an aggregate
- * summary with a link to the full My Shows history. Skips silently when the
- * data is unavailable. For a profile owner with zero tracked shows, renders a
- * soft call-to-action to start their history.
+ * summary with a link to the full My Shows history. Visitors see no card when
+ * data is unavailable; owners see an explicit unavailable state. For a profile
+ * owner with zero tracked shows, renders a soft call-to-action instead.
  */
 function ec_community_display_concert_history() {
 	$user_id = bbp_get_displayed_user_id();
@@ -152,7 +138,20 @@ function ec_community_display_concert_history() {
 	$is_own = ( (int) get_current_user_id() === (int) $user_id );
 	$stats  = ec_community_get_concert_stats( (int) $user_id );
 
-	$total_shows = is_array( $stats ) && isset( $stats['total_shows'] ) ? (int) $stats['total_shows'] : 0;
+	if ( null === $stats ) {
+		if ( ! $is_own ) {
+			return;
+		}
+		?>
+		<div class="bbp-user-profile-card ec-concert-history-card ec-concert-history-unavailable">
+			<h3><?php esc_html_e( 'Concert History', 'extra-chill-community' ); ?></h3>
+			<p><?php esc_html_e( 'Your concert history is temporarily unavailable. Please try again later.', 'extra-chill-community' ); ?></p>
+		</div>
+		<?php
+		return;
+	}
+
+	$total_shows = (int) $stats['total_shows'];
 
 	// No tracked shows: show a CTA on the owner's profile, hide for visitors.
 	if ( $total_shows < 1 ) {

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -89,13 +89,18 @@ function Notice( {
 	message: string;
 } ) {
 	return (
-		<div className={ `notice notice-${ type }` }>
+		<div
+			className={ `notice notice-${ type }` }
+			role={ type === 'error' ? 'alert' : 'status' }
+			aria-live={ type === 'error' ? 'assertive' : 'polite' }
+			aria-atomic="true"
+		>
 			<p>{ message }</p>
 		</div>
 	);
 }
 
-function AccountTab( {
+export function AccountTab( {
 	settings,
 	onUpdate,
 }: {
@@ -111,6 +116,11 @@ function AccountTab( {
 	const [ localSceneVisibility, setLocalSceneVisibility ] = useState(
 		settings.local_scene_visibility
 	);
+	const [ concertHistoryVisibility, setConcertHistoryVisibility ] = useState(
+		settings.concert_history_visibility
+	);
+	const [ eventAttendanceVisibility, setEventAttendanceVisibility ] =
+		useState( settings.event_attendance_visibility );
 	const [ localSceneChanged, setLocalSceneChanged ] = useState( false );
 	const [ locationOptions, setLocationOptions ] = useState<
 		Array< { label: string; value: string } >
@@ -205,6 +215,8 @@ function AccountTab( {
 				last_name: lastName,
 				display_name: displayName,
 				local_scene_visibility: localSceneVisibility,
+				concert_history_visibility: concertHistoryVisibility,
+				event_attendance_visibility: eventAttendanceVisibility,
 			};
 			if ( localSceneChanged ) {
 				input.local_scene = localSceneSlug ?? '';
@@ -215,6 +227,8 @@ function AccountTab( {
 			onUpdate( result );
 			setLocalSceneSlug( result.local_scene?.slug ?? null );
 			setLocalSceneVisibility( result.local_scene_visibility );
+			setConcertHistoryVisibility( result.concert_history_visibility );
+			setEventAttendanceVisibility( result.event_attendance_visibility );
 			setLocalSceneChanged( false );
 			setNotice( {
 				type: 'success',
@@ -233,6 +247,8 @@ function AccountTab( {
 		displayName,
 		localSceneSlug,
 		localSceneVisibility,
+		concertHistoryVisibility,
+		eventAttendanceVisibility,
 		localSceneChanged,
 		onUpdate,
 	] );
@@ -305,6 +321,53 @@ function AccountTab( {
 					/>
 					Show my Local Scene publicly
 				</label>
+			</FieldGroup>
+			<FieldGroup>
+				<label htmlFor="ec-concert-history-visibility">
+					<input
+						id="ec-concert-history-visibility"
+						type="checkbox"
+						aria-describedby="ec-concert-history-visibility-help"
+						checked={ concertHistoryVisibility === 'public' }
+						onChange={ ( event ) =>
+							setConcertHistoryVisibility(
+								event.target.checked ? 'public' : 'private'
+							)
+						}
+					/>
+					Show my concert history publicly
+				</label>
+				<p
+					id="ec-concert-history-visibility-help"
+					style={ styles.mutedText }
+				>
+					When private, only you and network administrators can view
+					your tracked shows and concert stats.
+				</p>
+			</FieldGroup>
+			<FieldGroup>
+				<label htmlFor="ec-event-attendance-visibility">
+					<input
+						id="ec-event-attendance-visibility"
+						type="checkbox"
+						aria-describedby="ec-event-attendance-visibility-help"
+						checked={ eventAttendanceVisibility === 'public' }
+						onChange={ ( event ) =>
+							setEventAttendanceVisibility(
+								event.target.checked ? 'public' : 'private'
+							)
+						}
+					/>
+					Show me in event attendee lists
+				</label>
+				<p
+					id="ec-event-attendance-visibility-help"
+					style={ styles.mutedText }
+				>
+					Your attendance still counts toward event totals when this
+					is private, but your name and avatar stay hidden from
+					attendee lists.
+				</p>
 			</FieldGroup>
 			<ActionRow>
 				<button
@@ -913,7 +976,7 @@ type TabId =
 	| 'notifications'
 	| 'artist-platform';
 
-function UserSettingsApp( {
+export function UserSettingsApp( {
 	artistSiteUrl,
 	hasArtists,
 	canCreateArtists,
@@ -936,15 +999,19 @@ function UserSettingsApp( {
 	} >( { status: 'none', type: '' } );
 
 	useEffect( () => {
-		Promise.all( [
-			client.execute< UserSettings >( 'extrachill/get-user-settings' ),
-			client.execute< UserProfile >( 'extrachill/get-user-profile', {
+		client
+			.execute< UserProfile >( 'extrachill/get-user-profile', {
 				user_id: userId,
-			} ),
-		] )
-			.then( ( [ settingsData, profileData ] ) => {
-				setSettings( settingsData );
+			} )
+			.then( ( profileData ) => {
 				setArtistAccess( profileData.artist_access );
+			} )
+			.catch( () => undefined );
+
+		client
+			.execute< UserSettings >( 'extrachill/get-user-settings' )
+			.then( ( settingsData ) => {
+				setSettings( settingsData );
 				setLoading( false );
 			} )
 			.catch( ( err ) => {
@@ -955,7 +1022,7 @@ function UserSettingsApp( {
 				);
 				setLoading( false );
 			} );
-	}, [] );
+	}, [ userId ] );
 
 	const switchTab = useCallback( ( tab: TabId ) => {
 		setActiveTab( tab );

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -76,6 +76,8 @@ export interface UserSettings {
 	pending_email: string | null;
 	local_scene: LocalScene | null;
 	local_scene_visibility: 'public' | 'private';
+	concert_history_visibility: 'public' | 'private';
+	event_attendance_visibility: 'public' | 'private';
 }
 
 export interface ChangeEmailResponse {

--- a/tests/js/user-settings-privacy.test.tsx
+++ b/tests/js/user-settings-privacy.test.tsx
@@ -1,0 +1,232 @@
+import { createRoot } from '@wordpress/element';
+// React is supplied by the WordPress test runtime rather than bundled here.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act } from 'react';
+
+jest.mock( 'wp-native-client', () => {
+	const execute = jest.fn();
+	return {
+		WPNativeClient: jest.fn().mockImplementation( () => ( { execute } ) ),
+		mockExecute: execute,
+	};
+} );
+jest.mock( 'wp-native-client/wordpress', () => ( {
+	WpApiFetchTransport: jest.fn(),
+} ) );
+jest.mock( '@extrachill/components', () => ( {
+	BlockShell: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	BlockShellInner: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	BlockShellHeader: ( { title }: { title: string } ) => <h1>{ title }</h1>,
+	Panel: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	PanelHeader: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	ActionRow: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	FieldGroup: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	ResponsiveTabs: ( {
+		renderPanel,
+	}: {
+		renderPanel: ( id: string ) => React.ReactNode;
+	} ) => <div>{ renderPanel( 'account-details' ) }</div>,
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	ComboboxControl: () => <div />,
+} ) );
+jest.mock( '@extrachill/components/styles/components.scss', () => ( {} ) );
+
+import { UserSettingsApp } from '../../src/blocks/user-settings/view';
+import type { UserSettings } from '../../src/types/users';
+
+const { mockExecute } = jest.requireMock( 'wp-native-client' ) as {
+	mockExecute: jest.Mock;
+};
+
+const settings: UserSettings = {
+	user_id: 7,
+	first_name: 'Chris',
+	last_name: 'Huber',
+	display_name: 'Chubes',
+	display_name_options: [ 'Chubes' ],
+	email: 'chris@example.com',
+	pending_email: null,
+	local_scene: null,
+	local_scene_visibility: 'public',
+	concert_history_visibility: 'public',
+	event_attendance_visibility: 'public',
+};
+
+async function renderSettings( {
+	profileFails = false,
+	updateFails = false,
+}: {
+	profileFails?: boolean;
+	updateFails?: boolean;
+} = {} ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	mockExecute.mockImplementation( ( ability: string ) => {
+		if ( ability === 'extrachill/get-user-settings' ) {
+			return Promise.resolve( settings );
+		}
+		if ( ability === 'extrachill/get-user-profile' ) {
+			if ( profileFails ) {
+				return Promise.reject( new Error( 'Profile unavailable' ) );
+			}
+			return Promise.resolve( {
+				artist_access: { status: 'none', type: '' },
+			} );
+		}
+		if ( ability === 'extrachill/update-user-settings' && updateFails ) {
+			return Promise.reject( new Error( 'Settings update failed' ) );
+		}
+		return Promise.resolve( settings );
+	} );
+
+	await act( async () => {
+		root.render(
+			<UserSettingsApp
+				artistSiteUrl="https://artist.example.com"
+				hasArtists={ false }
+				canCreateArtists={ false }
+				userId={ 7 }
+			/>
+		);
+	} );
+
+	return { container, root };
+}
+
+describe( 'concert privacy settings', () => {
+	beforeAll( () => {
+		(
+			globalThis as typeof globalThis & {
+				IS_REACT_ACT_ENVIRONMENT: boolean;
+			}
+		 ).IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterEach( () => {
+		mockExecute.mockReset();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'loads both independent visibility controls', async () => {
+		const { container, root } = await renderSettings();
+		const history = container.querySelector< HTMLInputElement >(
+			'#ec-concert-history-visibility'
+		);
+		const attendance = container.querySelector< HTMLInputElement >(
+			'#ec-event-attendance-visibility'
+		);
+
+		expect( history?.checked ).toBe( true );
+		expect( attendance?.checked ).toBe( true );
+		expect( history?.getAttribute( 'aria-describedby' ) ).toBe(
+			'ec-concert-history-visibility-help'
+		);
+		expect( attendance?.getAttribute( 'aria-describedby' ) ).toBe(
+			'ec-event-attendance-visibility-help'
+		);
+		expect(
+			container.querySelector( '#ec-concert-history-visibility-help' )
+		).not.toBeNull();
+		expect(
+			container.querySelector( '#ec-event-attendance-visibility-help' )
+		).not.toBeNull();
+		expect( container.textContent ).toContain(
+			'Show my concert history publicly'
+		);
+		expect( container.textContent ).toContain(
+			'Show me in event attendee lists'
+		);
+		expect( mockExecute ).toHaveBeenCalledWith(
+			'extrachill/get-user-settings'
+		);
+
+		act( () => root.unmount() );
+	} );
+
+	it( 'loads privacy settings when the optional profile request fails', async () => {
+		const { container, root } = await renderSettings( {
+			profileFails: true,
+		} );
+
+		expect(
+			container.querySelector( '#ec-concert-history-visibility' )
+		).not.toBeNull();
+		expect( container.textContent ).not.toContain( 'Profile unavailable' );
+
+		act( () => root.unmount() );
+	} );
+
+	it.each( [
+		[ 'history', '#ec-concert-history-visibility', 'private', 'public' ],
+		[
+			'attendance',
+			'#ec-event-attendance-visibility',
+			'public',
+			'private',
+		],
+	] )(
+		'saves the %s toggle without changing the other setting',
+		async ( _label, selector, historyValue, attendanceValue ) => {
+			const { container, root } = await renderSettings();
+			const toggle =
+				container.querySelector< HTMLInputElement >( selector );
+			const save = Array.from(
+				container.querySelectorAll( 'button' )
+			).find(
+				( button ) => button.textContent === 'Save Account Details'
+			);
+
+			act( () => toggle?.click() );
+			await act( async () => save?.click() );
+
+			expect( mockExecute ).toHaveBeenLastCalledWith(
+				'extrachill/update-user-settings',
+				expect.objectContaining( {
+					concert_history_visibility: historyValue,
+					event_attendance_visibility: attendanceValue,
+				} )
+			);
+			const payload = mockExecute.mock.calls.at( -1 )?.[ 1 ];
+			expect( payload ).not.toHaveProperty( 'email' );
+			expect( payload ).not.toHaveProperty( 'user_id' );
+			expect( payload ).not.toHaveProperty( 'local_scene' );
+			const notice = container.querySelector( '[role="status"]' );
+			expect( notice?.getAttribute( 'aria-live' ) ).toBe( 'polite' );
+			expect( notice?.getAttribute( 'aria-atomic' ) ).toBe( 'true' );
+
+			act( () => root.unmount() );
+		}
+	);
+
+	it( 'announces a save failure as an assertive alert', async () => {
+		const { container, root } = await renderSettings( {
+			updateFails: true,
+		} );
+		const save = Array.from( container.querySelectorAll( 'button' ) ).find(
+			( button ) => button.textContent === 'Save Account Details'
+		);
+
+		await act( async () => save?.click() );
+
+		const notice = container.querySelector( '[role="alert"]' );
+		expect( notice?.textContent ).toContain( 'Settings update failed' );
+		expect( notice?.getAttribute( 'aria-live' ) ).toBe( 'assertive' );
+		expect( notice?.getAttribute( 'aria-atomic' ) ).toBe( 'true' );
+
+		act( () => root.unmount() );
+	} );
+} );

--- a/tests/test-concert-history-dependency-absent.php
+++ b/tests/test-concert-history-dependency-absent.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Verify owners see an unavailable state without the cross-site dependency.
+ *
+ * Run: php tests/test-concert-history-dependency-absent.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+function add_action() {}
+
+function extrachill_users_can_view_concert_history() {
+	return true;
+}
+
+function bbp_get_displayed_user_id() {
+	return 10;
+}
+
+function get_current_user_id() {
+	return 10;
+}
+
+function esc_html_e( $value ) {
+	echo htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+}
+
+require __DIR__ . '/../inc/user-profiles/concert-history.php';
+
+ob_start();
+ec_community_display_concert_history();
+$output = ob_get_clean();
+
+if ( false === strpos( $output, 'temporarily unavailable' ) || false !== strpos( $output, 'haven\'t tracked any shows' ) ) {
+	echo "FAIL: dependency failure must render the owner unavailable state.\n";
+	exit( 1 );
+}
+
+echo "PASS: dependency failure renders the owner unavailable state.\n";

--- a/tests/test-concert-history-privacy.php
+++ b/tests/test-concert-history-privacy.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Focused tests for Community concert-history privacy and availability.
+ *
+ * Run: php tests/test-concert-history-privacy.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['_test_current_user_id'] = 0;
+$GLOBALS['_test_visibility']      = array();
+$GLOBALS['_test_rest_calls']      = 0;
+$GLOBALS['_test_rest_response']   = array( 'total_shows' => 2 );
+$GLOBALS['_test_display_user_id'] = 10;
+
+class WP_Error {}
+
+function add_action() {}
+
+function extrachill_users_can_view_concert_history( $user_id ) {
+	return (int) $GLOBALS['_test_current_user_id'] === (int) $user_id || ( $GLOBALS['_test_visibility'][ $user_id ] ?? false );
+}
+
+function ec_cross_site_rest_request() {
+	++$GLOBALS['_test_rest_calls'];
+	return $GLOBALS['_test_rest_response'];
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function bbp_get_displayed_user_id() {
+	return $GLOBALS['_test_display_user_id'];
+}
+
+function get_current_user_id() {
+	return $GLOBALS['_test_current_user_id'];
+}
+
+function ec_get_blog_id( $site ) {
+	return 'events' === $site ? 7 : 0;
+}
+
+function get_home_url() {
+	return 'https://events.example.com/my-shows/';
+}
+
+function add_query_arg( $key, $value, $url ) {
+	return $url . '?' . $key . '=' . $value;
+}
+
+function esc_url( $value ) {
+	return $value;
+}
+
+function esc_html( $value ) {
+	return (string) $value;
+}
+
+function __( $value ) {
+	return $value;
+}
+
+function esc_html_e( $value ) {
+	echo esc_html( $value );
+}
+
+function number_format_i18n( $value ) {
+	return (string) $value;
+}
+
+function _n( $single, $plural, $number ) {
+	return 1 === $number ? $single : $plural;
+}
+
+function wp_kses_post( $value ) {
+	return $value;
+}
+
+require __DIR__ . '/../inc/user-profiles/concert-history.php';
+
+$failures = 0;
+
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+$GLOBALS['_test_visibility'][10]      = true;
+$GLOBALS['_test_current_user_id']     = 20;
+$GLOBALS['_test_rest_response']       = array( 'total_shows' => 8 );
+$GLOBALS['_test_rest_calls']          = 0;
+
+check( 'other user can read public stats', 8 === ec_community_get_concert_stats( 10 )['total_shows'] );
+ob_start();
+ec_community_display_concert_history();
+$public_output = ob_get_clean();
+check( 'other user sees the public concert card', false !== strpos( $public_output, 'Concert History' ) );
+check( 'each authorized read requests fresh Events data', 2 === $GLOBALS['_test_rest_calls'] );
+
+$GLOBALS['_test_visibility'][10]  = false;
+$GLOBALS['_test_current_user_id'] = 20;
+$calls_before                     = $GLOBALS['_test_rest_calls'];
+check( 'other user cannot read private stats', null === ec_community_get_concert_stats( 10 ) );
+check( 'privacy denial happens before the cross-site request', $calls_before === $GLOBALS['_test_rest_calls'] );
+
+$GLOBALS['_test_current_user_id'] = 0;
+check( 'anonymous viewer cannot read private stats', null === ec_community_get_concert_stats( 10 ) );
+
+$GLOBALS['_test_current_user_id'] = 10;
+$GLOBALS['_test_rest_response']   = array( 'total_shows' => 8 );
+check( 'owner can read private stats', 8 === ec_community_get_concert_stats( 10 )['total_shows'] );
+ob_start();
+ec_community_display_concert_history();
+$owner_output = ob_get_clean();
+check( 'owner sees and can manage a private concert history', false !== strpos( $owner_output, 'My Concert History' ) && false !== strpos( $owner_output, 'View your full concert history' ) );
+
+$GLOBALS['_test_rest_response'] = array( 'total_shows' => 0 );
+ob_start();
+ec_community_display_concert_history();
+$zero_output = ob_get_clean();
+check( 'legitimate zero stats render the owner start-history state', false !== strpos( $zero_output, 'haven\'t tracked any shows' ) );
+check( 'legitimate zero stats are not reported as unavailable', false === strpos( $zero_output, 'temporarily unavailable' ) );
+
+$GLOBALS['_test_rest_response'] = new WP_Error();
+ob_start();
+ec_community_display_concert_history();
+$error_output = ob_get_clean();
+check( 'API failure renders an unavailable state for the owner', false !== strpos( $error_output, 'temporarily unavailable' ) );
+check( 'API failure is not presented as zero shows', false === strpos( $error_output, 'haven\'t tracked any shows' ) );
+
+$GLOBALS['_test_rest_response'] = array();
+ob_start();
+ec_community_display_concert_history();
+$malformed_output = ob_get_clean();
+check( 'malformed stats render an unavailable state for the owner', false !== strpos( $malformed_output, 'temporarily unavailable' ) );
+
+$GLOBALS['_test_current_user_id'] = 20;
+$GLOBALS['_test_visibility'][10]  = true;
+$GLOBALS['_test_rest_response']   = new WP_Error();
+ob_start();
+ec_community_display_concert_history();
+$visitor_error_output = ob_get_clean();
+check( 'unavailable stats render no card for another user', '' === $visitor_error_output );
+
+$GLOBALS['_test_current_user_id'] = 0;
+ob_start();
+ec_community_display_concert_history();
+$anonymous_error_output = ob_get_clean();
+check( 'unavailable stats render no card for an anonymous viewer', '' === $anonymous_error_output );
+
+$source = file_get_contents( __DIR__ . '/../inc/user-profiles/concert-history.php' );
+check( 'concert profile has no transient cache coupling', false === strpos( $source, '_transient' ) );
+check( 'concert profile has no mark or visibility invalidation hooks', false === strpos( $source, 'ec_users_event_marked' ) && false === strpos( $source, 'extrachill_users_visibility_changed' ) );
+
+echo "\n";
+if ( $failures > 0 ) {
+	echo "$failures test(s) FAILED.\n";
+	exit( 1 );
+}
+
+echo "All concert-history privacy tests passed.\n";


### PR DESCRIPTION
## Summary
- expose concert-history and attendee-list controls on `/settings/`
- enforce canonical history policy before public profile requests
- distinguish unavailable stats from legitimate empty history
- make settings resilient and accessible

## Verification
- 8 JS tests passed
- standalone PHP privacy suites passed
- JS lint and production build passed
- final independent review: merge

Depends on Extra-Chill/extrachill-users#227 implementation PR.