### PR TITLE
fix: clarify artist email access settings

### DIFF
--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -38,7 +38,7 @@ import type {
 	ChangeEmailResponse,
 	ChangePasswordResponse,
 	UserSubscriptions,
-	FollowedArtist,
+	ArtistEmailConsent,
 	RequestArtistAccessResponse,
 	NotificationPreferences,
 } from '../../types/users';
@@ -566,27 +566,35 @@ function SubscriptionsTab() {
 		type: 'success' | 'error';
 		message: string;
 	} | null >( null );
-	const [ consented, setConsented ] = useState< Set< number > >( new Set() );
+	const [ consentedArtistIds, setConsentedArtistIds ] = useState<
+		Set< number >
+	>( new Set() );
 
 	useEffect( () => {
 		client
 			.execute< UserSubscriptions >( 'extrachill/get-subscriptions' )
 			.then( ( result ) => {
 				setData( result );
+				const artistEmailConsents =
+					result.artist_email_consents ??
+					result.followed_artists ??
+					[];
 				const ids = new Set< number >();
-				result.followed_artists.forEach( ( a: FollowedArtist ) => {
-					if ( a.email_consent ) {
-						ids.add( a.artist_id );
+				artistEmailConsents.forEach(
+					( consent: ArtistEmailConsent ) => {
+						if ( consent.email_consent ) {
+							ids.add( consent.artist_id );
+						}
 					}
-				} );
-				setConsented( ids );
+				);
+				setConsentedArtistIds( ids );
 				setLoading( false );
 			} )
 			.catch( () => setLoading( false ) );
 	}, [] );
 
 	const toggleConsent = useCallback( ( artistId: number ) => {
-		setConsented( ( prev ) => {
+		setConsentedArtistIds( ( prev ) => {
 			const next = new Set( prev );
 			if ( next.has( artistId ) ) {
 				next.delete( artistId );
@@ -602,11 +610,11 @@ function SubscriptionsTab() {
 		setNotice( null );
 		try {
 			await client.execute( 'extrachill/update-subscriptions', {
-				consented_artists: Array.from( consented ),
+				consented_artists: Array.from( consentedArtistIds ),
 			} );
 			setNotice( {
 				type: 'success',
-				message: 'Subscription preferences updated.',
+				message: 'Artist email preferences updated.',
 			} );
 		} catch ( err ) {
 			setNotice( {
@@ -615,7 +623,7 @@ function SubscriptionsTab() {
 			} );
 		}
 		setSaving( false );
-	}, [ consented ] );
+	}, [ consentedArtistIds ] );
 
 	if ( loading ) {
 		return (
@@ -624,57 +632,62 @@ function SubscriptionsTab() {
 			</div>
 		);
 	}
-	const artists = data?.followed_artists || [];
+	const artistEmailConsents =
+		data?.artist_email_consents ?? data?.followed_artists ?? [];
 
 	return (
 		<Panel>
-			<PanelHeader description="Manage email consent for bands you follow. Unchecking will prevent a band from seeing your email or including it in their exports." />
+			<PanelHeader description="Choose which artists may access your email for updates and subscriber exports." />
 			{ notice && (
 				<Notice type={ notice.type } message={ notice.message } />
 			) }
-			{ artists.length === 0 ? (
+			{ artistEmailConsents.length === 0 ? (
 				<p style={ styles.mutedText }>
-					You are not currently following any bands.
+					You have not shared your email with any artists.
 				</p>
 			) : (
 				<>
 					<ul style={ styles.checkboxList }>
-						{ artists.map( ( artist: FollowedArtist ) => (
-							<li
-								key={ artist.artist_id }
-								style={ styles.checkboxItem }
-							>
-								<input
-									type="checkbox"
-									id={ `ec-consent-${ artist.artist_id }` }
-									checked={ consented.has(
-										artist.artist_id
-									) }
-									onChange={ () =>
-										toggleConsent( artist.artist_id )
-									}
-								/>
-								<label
-									htmlFor={ `ec-consent-${ artist.artist_id }` }
-									style={ {
-										fontWeight: 'normal',
-										cursor: 'pointer',
-									} }
+						{ artistEmailConsents.map(
+							( artist: ArtistEmailConsent ) => (
+								<li
+									key={ artist.artist_id }
+									style={ styles.checkboxItem }
 								>
-									Share my email with{ ' ' }
-									<a
-										href={ artist.url }
-										target="_blank"
-										rel="noopener noreferrer"
+									<input
+										type="checkbox"
+										id={ `ec-consent-${ artist.artist_id }` }
+										checked={ consentedArtistIds.has(
+											artist.artist_id
+										) }
+										onChange={ () =>
+											toggleConsent( artist.artist_id )
+										}
+									/>
+									<label
+										htmlFor={ `ec-consent-${ artist.artist_id }` }
 										style={ {
-											color: cssVar( colors.linkColor ),
+											fontWeight: 'normal',
+											cursor: 'pointer',
 										} }
 									>
-										{ artist.name }
-									</a>
-								</label>
-							</li>
-						) ) }
+										Share my email with{ ' ' }
+										<a
+											href={ artist.url }
+											target="_blank"
+											rel="noopener noreferrer"
+											style={ {
+												color: cssVar(
+													colors.linkColor
+												),
+											} }
+										>
+											{ artist.name }
+										</a>
+									</label>
+								</li>
+							)
+						) }
 					</ul>
 					<ActionRow>
 						<button
@@ -788,7 +801,7 @@ function NotificationsTab() {
 					>
 						<strong>Auto-subscribe to replies</strong>
 						<div style={ styles.mutedText }>
-							Automatically follow topics you reply to.
+							Automatically subscribe to reply notifications.
 						</div>
 					</label>
 				</li>
@@ -1046,7 +1059,7 @@ export function UserSettingsApp( {
 	const tabs: Array< { id: TabId; label: string } > = [
 		{ id: 'account-details', label: 'Account Details' },
 		{ id: 'security', label: 'Security' },
-		{ id: 'subscriptions', label: 'Subscriptions' },
+		{ id: 'subscriptions', label: 'Artist Email Access' },
 		{ id: 'notifications', label: 'Notifications' },
 		{ id: 'artist-platform', label: 'Artist Platform' },
 	];

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -121,7 +121,7 @@ export interface UserProfile {
 
 // ─── User Subscriptions ───────────────────────────────────────────────────────
 
-export interface FollowedArtist {
+export interface ArtistEmailConsent {
 	artist_id: number;
 	name: string;
 	url: string;
@@ -130,7 +130,9 @@ export interface FollowedArtist {
 
 export interface UserSubscriptions {
 	user_id: number;
-	followed_artists: FollowedArtist[];
+	artist_email_consents?: ArtistEmailConsent[];
+	/** @deprecated Compatibility field from extrachill-users. */
+	followed_artists?: ArtistEmailConsent[];
 }
 
 // ─── Notification Preferences ────────────────────────────────────────────────

--- a/tests/js/user-settings-artist-email-access.test.tsx
+++ b/tests/js/user-settings-artist-email-access.test.tsx
@@ -1,0 +1,147 @@
+import { createRoot } from '@wordpress/element';
+// React is supplied by the WordPress test runtime rather than bundled here.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act } from 'react';
+
+jest.mock( 'wp-native-client', () => {
+	const execute = jest.fn();
+	return {
+		WPNativeClient: jest.fn().mockImplementation( () => ( { execute } ) ),
+		mockExecute: execute,
+	};
+} );
+jest.mock( 'wp-native-client/wordpress', () => ( {
+	WpApiFetchTransport: jest.fn(),
+} ) );
+jest.mock( '@extrachill/components', () => ( {
+	BlockShell: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	BlockShellInner: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	BlockShellHeader: ( { title }: { title: string } ) => <h1>{ title }</h1>,
+	Panel: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	PanelHeader: ( { description }: { description: string } ) => (
+		<p>{ description }</p>
+	),
+	ActionRow: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	FieldGroup: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	ResponsiveTabs: ( {
+		renderPanel,
+	}: {
+		renderPanel: ( id: string ) => React.ReactNode;
+	} ) => <div>{ renderPanel( 'subscriptions' ) }</div>,
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	ComboboxControl: () => <div />,
+} ) );
+jest.mock( '@extrachill/components/styles/components.scss', () => ( {} ) );
+
+import { UserSettingsApp } from '../../src/blocks/user-settings/view';
+
+const { mockExecute } = jest.requireMock( 'wp-native-client' ) as {
+	mockExecute: jest.Mock;
+};
+
+describe( 'artist email access settings', () => {
+	beforeAll( () => {
+		(
+			globalThis as typeof globalThis & {
+				IS_REACT_ACT_ENVIRONMENT: boolean;
+			}
+		 ).IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterEach( () => {
+		mockExecute.mockReset();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'uses private email-consent language and the canonical response field', async () => {
+		mockExecute.mockImplementation( ( ability: string ) => {
+			if ( ability === 'extrachill/get-user-settings' ) {
+				return Promise.resolve( {
+					user_id: 7,
+					display_name: 'Chubes',
+					display_name_options: [ 'Chubes' ],
+					email: 'chris@example.com',
+					pending_email: null,
+					local_scene: null,
+					local_scene_visibility: 'public',
+					concert_history_visibility: 'public',
+					event_attendance_visibility: 'public',
+				} );
+			}
+			if ( ability === 'extrachill/get-user-profile' ) {
+				return Promise.resolve( {
+					artist_access: { status: 'none', type: '' },
+				} );
+			}
+			if ( ability === 'extrachill/get-subscriptions' ) {
+				return Promise.resolve( {
+					user_id: 7,
+					artist_email_consents: [
+						{
+							artist_id: 42,
+							name: 'Kid Lake',
+							url: 'https://artist.example.com/kid-lake/',
+							email_consent: true,
+						},
+					],
+				} );
+			}
+			return Promise.resolve( { success: true } );
+		} );
+
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+
+		await act( async () => {
+			root.render(
+				<UserSettingsApp
+					artistSiteUrl="https://artist.example.com"
+					hasArtists={ false }
+					canCreateArtists={ false }
+					userId={ 7 }
+				/>
+			);
+		} );
+
+		expect( container.textContent ).toContain(
+			'Choose which artists may access your email'
+		);
+		expect( container.textContent ).toContain(
+			'Share my email with Kid Lake'
+		);
+		expect( container.textContent ).not.toMatch(
+			/\bfollow(?:er|ers|ing|s|ed)?\b/i
+		);
+
+		const checkbox =
+			container.querySelector< HTMLInputElement >( '#ec-consent-42' );
+		const save = Array.from( container.querySelectorAll( 'button' ) ).find(
+			( button ) => button.textContent === 'Save Preferences'
+		);
+
+		act( () => checkbox?.click() );
+		await act( async () => save?.click() );
+
+		expect( mockExecute ).toHaveBeenLastCalledWith(
+			'extrachill/update-subscriptions',
+			{ consented_artists: [] }
+		);
+		expect( mockExecute.mock.calls.at( -1 )?.[ 1 ] ).not.toHaveProperty(
+			'user_id'
+		);
+
+		act( () => root.unmount() );
+	} );
+} );


### PR DESCRIPTION
## Summary

- rename local types and state around private artist email consent
- consume canonical `artist_email_consents` with fallback support for the shipped compatibility field
- replace follower-style UI and topic copy with explicit email-access and notification language
- rename the settings tab to Artist Email Access
- add focused interaction coverage for canonical data, consent updates, privacy, and absence of follower language

## Verification

- focused Jest: 1 test passed
- ESLint/Prettier passed
- production `npm run build` passed

## Compatibility

Existing ability slugs and serialized request/response fields remain supported. This PR can deploy before or after the Users producer change because it falls back to the legacy response field.

Parent audit: Extra-Chill/extrachill-users#277

Closes #226
