### PR TITLE
feat: centralize Local Scene digest consent

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -57,6 +57,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/editor/composer-term-picker.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/ability-helpers.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/core/infrastructure-abilities.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/core/local-scene-digest-settings.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-formatters.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-read.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/topic-reply-write.php';

--- a/inc/core/local-scene-digest-settings.php
+++ b/inc/core/local-scene-digest-settings.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Local Scene digest integration for Community settings.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Register the Events-owned consent identity on the Community site. */
+function extrachill_community_register_local_scene_digest_entity( array $entities ): array {
+	$entities['local_scene_digest'] = 'location';
+	return $entities;
+}
+add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_community_register_local_scene_digest_entity' );

--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -41,6 +41,7 @@ import type {
 	ArtistEmailConsent,
 	RequestArtistAccessResponse,
 	NotificationPreferences,
+	EntitySubscriptionStatus,
 } from '../../types/users';
 
 const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), {
@@ -705,40 +706,90 @@ function SubscriptionsTab() {
 	);
 }
 
-function NotificationsTab() {
+function NotificationsTab( {
+	localScene,
+}: {
+	localScene: UserSettings[ 'local_scene' ];
+} ) {
 	const [ loading, setLoading ] = useState( true );
 	const [ saving, setSaving ] = useState( false );
 	const [ emailsEnabled, setEmailsEnabled ] = useState( true );
 	const [ autoSubscribe, setAutoSubscribe ] = useState( true );
+	const [ sceneDigestEnabled, setSceneDigestEnabled ] = useState( false );
+	const [ savedSceneDigestEnabled, setSavedSceneDigestEnabled ] =
+		useState( false );
 	const [ notice, setNotice ] = useState< {
 		type: 'success' | 'error';
 		message: string;
 	} | null >( null );
 
 	useEffect( () => {
-		client
-			.execute< NotificationPreferences >(
+		setLoading( true );
+		const digestStatus = localScene
+			? client.execute< EntitySubscriptionStatus >(
+					'extrachill/entity-subscription-status',
+					{
+						entity_type: 'local_scene_digest',
+						taxonomy: 'location',
+						slug: localScene.slug,
+					}
+			  )
+			: Promise.resolve( null );
+
+		Promise.all( [
+			client.execute< NotificationPreferences >(
 				'extrachill/get-notification-preferences'
-			)
-			.then( ( result ) => {
-				setEmailsEnabled( result.emails_enabled );
-				setAutoSubscribe( result.auto_subscribe_replies );
+			),
+			digestStatus,
+		] )
+			.then( ( [ preferences, status ] ) => {
+				setEmailsEnabled( preferences.emails_enabled );
+				setAutoSubscribe( preferences.auto_subscribe_replies );
+				setSceneDigestEnabled( status?.subscribed ?? false );
+				setSavedSceneDigestEnabled( status?.subscribed ?? false );
 				setLoading( false );
 			} )
-			.catch( () => setLoading( false ) );
-	}, [] );
+			.catch( ( err ) => {
+				setNotice( {
+					type: 'error',
+					message:
+						err instanceof Error
+							? err.message
+							: 'Notification preferences could not be loaded.',
+				} );
+				setLoading( false );
+			} );
+	}, [ localScene ] );
 
 	const handleSave = useCallback( async () => {
 		setSaving( true );
 		setNotice( null );
 		try {
-			await client.execute(
-				'extrachill/update-notification-preferences',
-				{
+			const updates = [
+				client.execute( 'extrachill/update-notification-preferences', {
 					emails_enabled: emailsEnabled,
 					auto_subscribe_replies: autoSubscribe,
-				}
-			);
+				} ),
+			];
+			if (
+				localScene &&
+				sceneDigestEnabled !== savedSceneDigestEnabled
+			) {
+				updates.push(
+					client.execute(
+						sceneDigestEnabled
+							? 'extrachill/entity-subscribe'
+							: 'extrachill/entity-unsubscribe',
+						{
+							entity_type: 'local_scene_digest',
+							taxonomy: 'location',
+							slug: localScene.slug,
+						}
+					)
+				);
+			}
+			await Promise.all( updates );
+			setSavedSceneDigestEnabled( sceneDigestEnabled );
 			setNotice( {
 				type: 'success',
 				message: 'Notification preferences updated.',
@@ -750,7 +801,13 @@ function NotificationsTab() {
 			} );
 		}
 		setSaving( false );
-	}, [ emailsEnabled, autoSubscribe ] );
+	}, [
+		emailsEnabled,
+		autoSubscribe,
+		localScene,
+		sceneDigestEnabled,
+		savedSceneDigestEnabled,
+	] );
 
 	if ( loading ) {
 		return (
@@ -804,6 +861,48 @@ function NotificationsTab() {
 							Automatically subscribe to reply notifications.
 						</div>
 					</label>
+				</li>
+				<li style={ styles.checkboxItem }>
+					{ localScene ? (
+						<>
+							<input
+								type="checkbox"
+								id="ec-local-scene-digest"
+								checked={ sceneDigestEnabled }
+								onChange={ ( e ) =>
+									setSceneDigestEnabled( e.target.checked )
+								}
+							/>
+							<label
+								htmlFor="ec-local-scene-digest"
+								style={ {
+									fontWeight: 'normal',
+									cursor: 'pointer',
+								} }
+							>
+								<strong>
+									Weekly { localScene.name } Local Scene
+									digest
+								</strong>
+								<div style={ styles.mutedText }>
+									Receive weekly email and in-app event picks.
+									Email delivery also requires Email
+									notifications above.
+								</div>
+							</label>
+						</>
+					) : (
+						<div>
+							<strong>Weekly Local Scene digest</strong>
+							<div style={ styles.mutedText }>
+								Choose a Local Scene in{ ' ' }
+								<a href="#tab-account-details">
+									Account Details
+								</a>{ ' ' }
+								before subscribing.
+							</div>
+						</div>
+					) }
 				</li>
 			</ul>
 			<ActionRow>
@@ -1083,7 +1182,7 @@ export function UserSettingsApp( {
 			case 'subscriptions':
 				return <SubscriptionsTab />;
 			case 'notifications':
-				return <NotificationsTab />;
+				return <NotificationsTab localScene={ settings.local_scene } />;
 			case 'artist-platform':
 				return (
 					<ArtistPlatformTab

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -14,6 +14,8 @@
  *     change-user-email, change-user-password
  *   - extrachill/get-subscriptions, update-subscriptions
  *   - extrachill/get-notification-preferences, update-notification-preferences
+ *   - extrachill/entity-subscription-status, entity-subscribe,
+ *     entity-unsubscribe
  *   - extrachill/request-artist-access
  */
 
@@ -145,6 +147,13 @@ export interface NotificationPreferences {
 	user_id: number;
 	emails_enabled: boolean;
 	auto_subscribe_replies: boolean;
+}
+
+export interface EntitySubscriptionStatus {
+	entity_type: string;
+	taxonomy: string;
+	slug: string;
+	subscribed: boolean;
 }
 
 // ─── Artist Access Request ──────────────────────────────────────────────────

--- a/tests/js/user-settings-local-scene-digest.test.tsx
+++ b/tests/js/user-settings-local-scene-digest.test.tsx
@@ -1,0 +1,213 @@
+import { createRoot } from '@wordpress/element';
+// React is supplied by the WordPress test runtime rather than bundled here.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act } from 'react';
+
+jest.mock( 'wp-native-client', () => {
+	const execute = jest.fn();
+	return {
+		WPNativeClient: jest.fn().mockImplementation( () => ( { execute } ) ),
+		mockExecute: execute,
+	};
+} );
+jest.mock( 'wp-native-client/wordpress', () => ( {
+	WpApiFetchTransport: jest.fn(),
+} ) );
+jest.mock( '@extrachill/components', () => ( {
+	BlockShell: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	BlockShellInner: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	BlockShellHeader: ( { title }: { title: string } ) => <h1>{ title }</h1>,
+	Panel: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	PanelHeader: ( { description }: { description: string } ) => (
+		<p>{ description }</p>
+	),
+	ActionRow: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	FieldGroup: ( { children }: { children: React.ReactNode } ) => (
+		<div>{ children }</div>
+	),
+	ResponsiveTabs: ( {
+		renderPanel,
+	}: {
+		renderPanel: ( id: string ) => React.ReactNode;
+	} ) => <div>{ renderPanel( 'notifications' ) }</div>,
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	ComboboxControl: () => <div />,
+} ) );
+jest.mock( '@extrachill/components/styles/components.scss', () => ( {} ) );
+
+import { UserSettingsApp } from '../../src/blocks/user-settings/view';
+
+const { mockExecute } = jest.requireMock( 'wp-native-client' ) as {
+	mockExecute: jest.Mock;
+};
+
+function settings( hasLocalScene: boolean ) {
+	return {
+		user_id: 7,
+		first_name: 'Chris',
+		last_name: 'Huber',
+		display_name: 'Chubes',
+		display_name_options: [ 'Chubes' ],
+		email: 'chris@example.com',
+		pending_email: null,
+		local_scene: hasLocalScene
+			? {
+					term_id: 88,
+					name: 'Charleston',
+					slug: 'charleston-sc',
+					url: 'https://events.example.com/location/charleston-sc/',
+					coordinates: null,
+			  }
+			: null,
+		local_scene_visibility: 'public',
+		concert_history_visibility: 'public',
+		event_attendance_visibility: 'public',
+	};
+}
+
+async function renderSettings( hasLocalScene = true, subscribed = false ) {
+	mockExecute.mockImplementation( ( ability: string ) => {
+		if ( ability === 'extrachill/get-user-settings' ) {
+			return Promise.resolve( settings( hasLocalScene ) );
+		}
+		if ( ability === 'extrachill/get-user-profile' ) {
+			return Promise.resolve( {
+				artist_access: { status: 'none', type: '' },
+			} );
+		}
+		if ( ability === 'extrachill/get-notification-preferences' ) {
+			return Promise.resolve( {
+				user_id: 7,
+				emails_enabled: true,
+				auto_subscribe_replies: true,
+			} );
+		}
+		if ( ability === 'extrachill/entity-subscription-status' ) {
+			return Promise.resolve( { subscribed } );
+		}
+		return Promise.resolve( { success: true, subscribed: true } );
+	} );
+
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render(
+			<UserSettingsApp
+				artistSiteUrl="https://artist.example.com"
+				hasArtists={ false }
+				canCreateArtists={ false }
+				userId={ 7 }
+			/>
+		);
+	} );
+	return { container, root };
+}
+
+describe( 'Local Scene digest settings', () => {
+	beforeAll( () => {
+		(
+			globalThis as typeof globalThis & {
+				IS_REACT_ACT_ENVIRONMENT: boolean;
+			}
+		 ).IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterEach( () => {
+		mockExecute.mockReset();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'loads and explicitly subscribes the saved Local Scene', async () => {
+		const { container, root } = await renderSettings();
+		const digest = container.querySelector< HTMLInputElement >(
+			'#ec-local-scene-digest'
+		);
+		const save = Array.from( container.querySelectorAll( 'button' ) ).find(
+			( button ) => button.textContent === 'Save Preferences'
+		);
+
+		expect( digest?.checked ).toBe( false );
+		expect( container.textContent ).toContain(
+			'Weekly Charleston Local Scene digest'
+		);
+		expect( container.textContent ).toContain(
+			'Email delivery also requires Email notifications above.'
+		);
+		expect( mockExecute ).toHaveBeenCalledWith(
+			'extrachill/entity-subscription-status',
+			{
+				entity_type: 'local_scene_digest',
+				taxonomy: 'location',
+				slug: 'charleston-sc',
+			}
+		);
+
+		act( () => digest?.click() );
+		await act( async () => save?.click() );
+
+		expect( mockExecute ).toHaveBeenCalledWith(
+			'extrachill/entity-subscribe',
+			{
+				entity_type: 'local_scene_digest',
+				taxonomy: 'location',
+				slug: 'charleston-sc',
+			}
+		);
+
+		act( () => root.unmount() );
+	} );
+
+	it( 'links to Account Details without creating consent when no scene exists', async () => {
+		const { container, root } = await renderSettings( false );
+
+		expect(
+			container.querySelector( '#ec-local-scene-digest' )
+		).toBeNull();
+		expect(
+			container.querySelector< HTMLAnchorElement >(
+				'a[href="#tab-account-details"]'
+			)
+		).not.toBeNull();
+		expect( mockExecute ).not.toHaveBeenCalledWith(
+			'extrachill/entity-subscription-status',
+			expect.anything()
+		);
+
+		act( () => root.unmount() );
+	} );
+
+	it( 'unsubscribes an existing archive-created consent row', async () => {
+		const { container, root } = await renderSettings( true, true );
+		const digest = container.querySelector< HTMLInputElement >(
+			'#ec-local-scene-digest'
+		);
+		const save = Array.from( container.querySelectorAll( 'button' ) ).find(
+			( button ) => button.textContent === 'Save Preferences'
+		);
+
+		expect( digest?.checked ).toBe( true );
+		act( () => digest?.click() );
+		await act( async () => save?.click() );
+
+		expect( mockExecute ).toHaveBeenCalledWith(
+			'extrachill/entity-unsubscribe',
+			{
+				entity_type: 'local_scene_digest',
+				taxonomy: 'location',
+				slug: 'charleston-sc',
+			}
+		);
+
+		act( () => root.unmount() );
+	} );
+} );

--- a/tests/test-local-scene-digest-settings.php
+++ b/tests/test-local-scene-digest-settings.php
@@ -1,0 +1,27 @@
+<?php
+/** Standalone contract test for the Community digest entity mapping. */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$GLOBALS['_test_filters'] = array();
+
+function add_filter( $hook, $callback ) {
+	$GLOBALS['_test_filters'][ $hook ][] = $callback;
+}
+
+require __DIR__ . '/../inc/core/local-scene-digest-settings.php';
+
+$callback = $GLOBALS['_test_filters']['extrachill_users_entity_subscription_entities'][0] ?? null;
+$result   = is_callable( $callback ) ? $callback( array( 'artist' => 'artist' ) ) : array();
+$passed   = isset( $result['local_scene_digest'] )
+	&& 'location' === $result['local_scene_digest']
+	&& 'artist' === $result['artist'];
+
+if ( ! $passed ) {
+	fwrite( STDERR, "FAIL: Community did not register the Local Scene digest entity mapping.\n" );
+	exit( 1 );
+}
+
+echo "PASS: Community registers the shared Local Scene digest entity mapping.\n";


### PR DESCRIPTION
## Summary
- add the saved Local Scene's weekly digest consent to the canonical Community Notifications settings tab
- use the existing network-wide entity-subscription status, subscribe, and unsubscribe abilities instead of introducing preference storage
- register the Events-owned digest identity on Community and guide users without a saved scene to Account Details
- retain the master Email notifications setting as an additional email-delivery gate

## Consent behavior
- saving or changing Local Scene does not subscribe the user
- the checkbox reflects consent created from either Community settings or the Events archive
- unchecking removes both weekly email and in-app digest consent for that scene
- Events archive and signed email unsubscribe surfaces continue operating on the same row

## Verification
- `npm run test:js` (12 tests passed)
- `npm run build`
- targeted `wp-scripts lint-js`
- `php tests/test-local-scene-digest-settings.php`
- Homeboy PHPCS and PHPStan scoped lint
- `git diff --check`

Closes #229