### PR TITLE
Fix fullscreen homepage post composer

### DIFF
--- a/inc/home/assets/css/new-topic-modal.css
+++ b/inc/home/assets/css/new-topic-modal.css
@@ -91,6 +91,22 @@ body.new-topic-modal-open {
     overflow: hidden;
 }
 
+/* A transformed ancestor contains fixed descendants, so release the modal's
+ * desktop geometry while the embedded editor owns the viewport. */
+.blocks-everywhere-editor-is-fullscreen .new-topic-modal {
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	max-width: none;
+	max-height: none;
+	transform: none;
+	overflow: visible;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
 .new-topic-modal .bbp-topic-form {
     margin: 0;
 }

--- a/inc/home/assets/js/new-topic-modal.js
+++ b/inc/home/assets/js/new-topic-modal.js
@@ -1,7 +1,7 @@
 /**
  * New Topic Modal
  *
- * Handles modal open/close, editor reinitialization, and accessibility.
+ * Handles modal open/close and accessibility.
  */
 ( function () {
 	'use strict';
@@ -12,130 +12,10 @@
 		return;
 	}
 
-	const discussionTrigger = document.getElementById(
-		'new-topic-modal-trigger'
-	);
-	const shareMusicTrigger = document.getElementById(
-		'share-music-modal-trigger'
-	);
+	const modalTrigger = document.getElementById( 'new-topic-modal-trigger' );
 	const closeButton = modal.querySelector( '.new-topic-modal-close' );
 
-	const modalTitle = document.getElementById( 'new-topic-modal-title' );
-	const modalDescription = document.getElementById(
-		'new-topic-modal-description'
-	);
-
-	let editorInitialized = false;
 	let activeTrigger = null;
-	let originalForumId = null;
-
-	function getForumSelectWrapper() {
-		const forumSelect = document.getElementById( 'bbp_forum_id' );
-		if ( ! forumSelect ) {
-			return null;
-		}
-
-		return forumSelect.closest( 'p' );
-	}
-
-	function setForumId( forumId ) {
-		const forumSelect = document.getElementById( 'bbp_forum_id' );
-		if ( ! forumSelect ) {
-			return;
-		}
-
-		if ( originalForumId === null ) {
-			originalForumId = forumSelect.value;
-		}
-
-		forumSelect.value = String( forumId );
-		forumSelect.dispatchEvent( new Event( 'change', { bubbles: true } ) );
-	}
-
-	function showForumDropdown() {
-		const wrapper = getForumSelectWrapper();
-		if ( ! wrapper ) {
-			return;
-		}
-
-		wrapper.style.display = '';
-	}
-
-	function hideForumDropdown() {
-		const wrapper = getForumSelectWrapper();
-		if ( ! wrapper ) {
-			return;
-		}
-
-		wrapper.style.display = 'none';
-	}
-
-	function setTopicTitlePlaceholder( placeholder ) {
-		const titleInput = document.getElementById( 'bbp_topic_title' );
-		if ( ! titleInput ) {
-			return;
-		}
-
-		titleInput.setAttribute( 'placeholder', placeholder );
-	}
-
-	function setTopicContentPlaceholder( placeholder ) {
-		const textarea = document.getElementById( 'bbp_topic_content' );
-		if ( ! textarea ) {
-			return;
-		}
-
-		textarea.setAttribute( 'placeholder', placeholder );
-	}
-
-	function setModalText( title, description ) {
-		if ( modalTitle ) {
-			modalTitle.textContent = title;
-		}
-
-		if ( modalDescription ) {
-			modalDescription.textContent = description || '';
-		}
-	}
-
-	function applyMode( triggerEl ) {
-		const mode =
-			triggerEl && triggerEl.dataset
-				? triggerEl.dataset.modalMode
-				: 'discussion';
-
-		if ( mode === 'share_music' ) {
-			setModalText(
-				'Share Music',
-				'Drop a link to share music with the community.'
-			);
-			setTopicTitlePlaceholder( 'What are you sharing?' );
-			setTopicContentPlaceholder(
-				'Paste a link and give us the scoop...'
-			);
-
-			const forumId = triggerEl.dataset.forumId;
-			if ( forumId ) {
-				setForumId( forumId );
-				hideForumDropdown();
-			}
-
-			return;
-		}
-
-		setModalText(
-			'Create Discussion',
-			'Start a new topic in the community.'
-		);
-		setTopicTitlePlaceholder( 'Title' );
-		setTopicContentPlaceholder( '' );
-
-		showForumDropdown();
-
-		if ( originalForumId !== null ) {
-			setForumId( originalForumId );
-		}
-	}
 
 	function showModal( triggerEl ) {
 		activeTrigger = triggerEl;
@@ -143,12 +23,6 @@
 		modal.classList.add( 'is-open' );
 		overlay.classList.add( 'is-open' );
 		document.body.classList.add( 'new-topic-modal-open' );
-
-		if ( ! editorInitialized ) {
-			initializeEditor();
-		}
-
-		applyMode( activeTrigger );
 
 		const firstInput = modal.querySelector(
 			'input[type="text"], textarea'
@@ -178,16 +52,14 @@
 		activeTrigger = null;
 	}
 
-	function initializeEditor() {
-		// The topic content editor is provided by Blocks Everywhere (Gutenberg),
-		// which initializes itself on the textarea. Nothing else to do here; this
-		// guard simply records that the editor has been accounted for.
-		editorInitialized = true;
-	}
-
 	function trapFocus( e ) {
 		if ( e.key !== 'Tab' ) {
-			if ( e.key === 'Escape' ) {
+			if (
+				e.key === 'Escape' &&
+				! document.documentElement.classList.contains(
+					'blocks-everywhere-editor-is-fullscreen'
+				)
+			) {
 				closeModal();
 			}
 			return;
@@ -213,12 +85,8 @@
 		}
 	}
 
-	if ( discussionTrigger ) {
-		discussionTrigger.addEventListener( 'click', openModal );
-	}
-
-	if ( shareMusicTrigger ) {
-		shareMusicTrigger.addEventListener( 'click', openModal );
+	if ( modalTrigger ) {
+		modalTrigger.addEventListener( 'click', openModal );
 	}
 
 	if ( closeButton ) {
@@ -228,6 +96,6 @@
 	overlay.addEventListener( 'click', closeModal );
 
 	if ( modal.dataset.autoOpen === 'true' ) {
-		showModal( discussionTrigger );
+		showModal( modalTrigger );
 	}
 } )();

--- a/inc/home/new-topic-button.php
+++ b/inc/home/new-topic-button.php
@@ -2,10 +2,10 @@
 /**
  * New Topic Button
  *
- * Renders the "New Topic" buttons that trigger the topic-creation modal on
+ * Renders the "New Post" button that triggers the topic-creation modal on
  * the community homepage.
  *
- * No-JS fallback: each button's href points at the Music Discussion forum
+ * No-JS fallback: the button's href points at the Music Discussion forum
  * permalink, where bbPress renders a real "new topic" form
  * (bbpress/content-single-forum.php → form/topic). The previous fallback
  * pointed at the homepage ("/"), but the feed-first homepage (#66) no longer
@@ -31,10 +31,6 @@ $new_topic_fallback_url = ( $music_discussion_forum instanceof WP_Post )
 
 <div class="community-section-header">
 	<div class="community-home-topic-actions">
-		<a href="<?php echo esc_url( $new_topic_fallback_url ); ?>" id="new-topic-modal-trigger" class="button-1 button-medium" data-modal-mode="discussion"><?php esc_html_e( 'Create Discussion', 'extra-chill-community' ); ?></a>
-
-		<?php if ( $music_discussion_forum instanceof WP_Post ) : ?>
-			<a href="<?php echo esc_url( get_permalink( $music_discussion_forum ) ); ?>" id="share-music-modal-trigger" class="button-2 button-medium" data-modal-mode="share_music" data-forum-id="<?php echo esc_attr( (string) $music_discussion_forum->ID ); ?>"><?php esc_html_e( 'Share Music', 'extra-chill-community' ); ?></a>
-		<?php endif; ?>
+		<a href="<?php echo esc_url( $new_topic_fallback_url ); ?>" id="new-topic-modal-trigger" class="button-1 button-medium"><?php esc_html_e( 'New Post', 'extra-chill-community' ); ?></a>
 	</div>
 </div>

--- a/inc/home/new-topic-modal.php
+++ b/inc/home/new-topic-modal.php
@@ -22,8 +22,8 @@ $discussion_continuation = extrachill_community_can_continue_discussion_composer
 <div id="new-topic-modal" class="new-topic-modal" role="dialog" aria-modal="true" aria-labelledby="new-topic-modal-title" data-auto-open="<?php echo $discussion_continuation ? 'true' : 'false'; ?>">
 	<div class="new-topic-modal-content">
 		<button type="button" class="new-topic-modal-close" aria-label="<?php esc_attr_e( 'Close modal', 'extra-chill-community' ); ?>">&times;</button>
-		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'Create Discussion', 'extra-chill-community' ); ?></h2>
-		<p id="new-topic-modal-description" class="new-topic-modal-description"></p>
+		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'New Post', 'extra-chill-community' ); ?></h2>
+		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Start a new post in the community.', 'extra-chill-community' ); ?></p>
 		<?php bbp_get_template_part( 'form', 'topic' ); ?>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- replace the separate Create Discussion and Share Music actions with one New Post composer
- remove mode-specific forum selection and placeholder JavaScript
- let Blocks Everywhere escape the transformed modal in fullscreen mode without Escape also closing the composer

## Testing
- `php -l inc/home/new-topic-button.php`
- `php -l inc/home/new-topic-modal.php`
- `node --check inc/home/assets/js/new-topic-modal.js`
- `wp-scripts lint-js inc/home/assets/js/new-topic-modal.js`
- all standalone `tests/test-*.php` suites
- `git diff --check`

The Homeboy umbrella review was skipped by its resource-policy gate because the host was above the safe non-interactive load threshold. The existing modal stylesheet also has a pre-existing spaces-vs-tabs lint baseline outside the changed rule.

Closes #22