### PR TITLE
fix: prevent community author spoofing

### DIFF
--- a/inc/content/topic-reply-abilities.php
+++ b/inc/content/topic-reply-abilities.php
@@ -158,10 +158,6 @@ function extrachill_community_register_topic_reply_abilities() {
 						'enum'        => array( 'html', 'markdown' ),
 						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
 					),
-					'user_id'  => array(
-						'type'        => 'integer',
-						'description' => 'Author user ID (defaults to current user)',
-					),
 				),
 				'required'   => array( 'forum_id', 'title', 'content' ),
 			),
@@ -176,7 +172,7 @@ function extrachill_community_register_topic_reply_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_community_ability_create_topic',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_create_topic_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -216,10 +212,6 @@ function extrachill_community_register_topic_reply_abilities() {
 						'type'        => 'integer',
 						'description' => 'Parent reply ID for threaded replies (optional)',
 					),
-					'user_id'  => array(
-						'type'        => 'integer',
-						'description' => 'Author user ID (defaults to current user)',
-					),
 				),
 				'required'   => array( 'topic_id', 'content' ),
 			),
@@ -234,7 +226,7 @@ function extrachill_community_register_topic_reply_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_community_ability_create_reply',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_create_reply_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/content/topic-reply-write.php
+++ b/inc/content/topic-reply-write.php
@@ -13,6 +13,95 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Resolve and authorize the authenticated author for a forum write.
+ *
+ * The ambient Agents API principal is host-resolved and may carry a capability
+ * ceiling. Ability input is never an authority for authorship; a legacy
+ * self-matching user_id remains accepted for existing internal callers.
+ *
+ * @param array  $input      Ability input.
+ * @param string $capability Required bbPress publish capability.
+ * @return int|WP_Error Authenticated author ID on success.
+ */
+function extrachill_community_authorize_post_creation( $input, $capability ) {
+	$current_user_id = get_current_user_id();
+	$principal       = null;
+
+	if ( class_exists( 'WP_Agent_Access' ) && class_exists( 'AgentsAPI\\AI\\WP_Agent_Execution_Principal' ) ) {
+		try {
+			$principal = WP_Agent_Access::get_current_principal(
+				array(
+					'allow_anonymous_audience' => false,
+				)
+			);
+		} catch ( Throwable $exception ) {
+			return new WP_Error( 'invalid_execution_principal', 'The execution principal could not be authenticated.' );
+		}
+	}
+
+	if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+		$user_id = (int) $principal->acting_user_id;
+
+		if ( $current_user_id > 0 && $current_user_id !== $user_id ) {
+			return new WP_Error( 'execution_principal_mismatch', 'The execution principal does not match the authenticated user.' );
+		}
+
+		if ( $principal->capability_ceiling instanceof WP_Agent_Capability_Ceiling && (int) $principal->capability_ceiling->user_id !== $user_id ) {
+			return new WP_Error( 'execution_principal_mismatch', 'The execution principal capability boundary does not match its acting user.' );
+		}
+	} else {
+		$user_id = $current_user_id;
+	}
+
+	if ( $user_id <= 0 ) {
+		return new WP_Error( 'missing_user', 'An authenticated user is required.' );
+	}
+
+	if ( isset( $input['user_id'] ) && (int) $input['user_id'] !== $user_id ) {
+		return new WP_Error( 'author_mismatch', 'The requested author does not match the authenticated user.' );
+	}
+
+	$site = extrachill_community_switch_to_community_blog();
+	try {
+		if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal && class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
+			$allowed = ( new WP_Agent_WordPress_Authorization_Policy() )->can( $principal, $capability );
+		} else {
+			$allowed = user_can( $user_id, $capability );
+		}
+	} finally {
+		if ( $site['switched'] ) {
+			restore_current_blog();
+		}
+	}
+
+	if ( ! $allowed ) {
+		return new WP_Error( 'cannot_publish', 'The authenticated user cannot publish this content.' );
+	}
+
+	return $user_id;
+}
+
+/**
+ * Permission callback for topic creation.
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
+function extrachill_community_ability_create_topic_permission( $input = array() ) {
+	return ! is_wp_error( extrachill_community_authorize_post_creation( $input, 'publish_topics' ) );
+}
+
+/**
+ * Permission callback for reply creation.
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
+function extrachill_community_ability_create_reply_permission( $input = array() ) {
+	return ! is_wp_error( extrachill_community_authorize_post_creation( $input, 'publish_replies' ) );
+}
+
+/**
  * Create a new topic.
  *
  * @param array $input Ability input.
@@ -28,7 +117,11 @@ function extrachill_community_ability_create_topic( $input ) {
 	$raw_content = isset( $input['content'] ) ? (string) $input['content'] : '';
 	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
 	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
-	$user_id     = extrachill_community_resolve_user_id( $input );
+	$user_id     = extrachill_community_authorize_post_creation( $input, 'publish_topics' );
+
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
 
 	if ( ! $forum_id ) {
 		return new WP_Error( 'missing_forum_id', 'A forum_id is required.' );
@@ -96,7 +189,11 @@ function extrachill_community_ability_create_reply( $input ) {
 	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
 	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
 	$reply_to    = isset( $input['reply_to'] ) ? (int) $input['reply_to'] : 0;
-	$user_id     = extrachill_community_resolve_user_id( $input );
+	$user_id     = extrachill_community_authorize_post_creation( $input, 'publish_replies' );
+
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
 
 	if ( ! $topic_id ) {
 		return new WP_Error( 'missing_topic_id', 'A topic_id is required.' );

--- a/tests/test-topic-reply-author-authorization.php
+++ b/tests/test-topic-reply-author-authorization.php
@@ -1,0 +1,239 @@
+<?php
+/** Standalone regression test for topic/reply author authorization. */
+
+namespace AgentsAPI\AI {
+	class WP_Agent_Execution_Principal {
+		public $acting_user_id;
+		public $capability_ceiling;
+
+		public function __construct( $acting_user_id, $capability_ceiling = null ) {
+			$this->acting_user_id    = $acting_user_id;
+			$this->capability_ceiling = $capability_ceiling;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {
+		private $code;
+
+		public function __construct( $code ) {
+			$this->code = $code;
+		}
+
+		public function get_error_code() {
+			return $this->code;
+		}
+	}
+
+	class WP_Agent_Capability_Ceiling {
+		public $user_id;
+		public $allowed_capabilities;
+
+		public function __construct( $user_id, $allowed_capabilities = null ) {
+			$this->user_id              = $user_id;
+			$this->allowed_capabilities = $allowed_capabilities;
+		}
+	}
+
+	class WP_Agent_Access {
+		public static function get_current_principal( $context = array() ) {
+			return $GLOBALS['_test_principal'];
+		}
+	}
+
+	class WP_Agent_WordPress_Authorization_Policy {
+		public function can( $principal, $capability ) {
+			if ( $principal->capability_ceiling instanceof WP_Agent_Capability_Ceiling
+				&& is_array( $principal->capability_ceiling->allowed_capabilities )
+				&& ! in_array( $capability, $principal->capability_ceiling->allowed_capabilities, true )
+			) {
+				return false;
+			}
+
+			return user_can( $principal->acting_user_id, $capability );
+		}
+	}
+
+	$GLOBALS['_test_current_user'] = 0;
+	$GLOBALS['_test_principal']    = null;
+	$GLOBALS['_test_caps']         = array();
+	$GLOBALS['_test_posts']        = array();
+	$GLOBALS['_test_actions']      = array();
+	$GLOBALS['_test_blog_id']      = 1;
+	$GLOBALS['_test_switches']     = array();
+
+	function get_current_user_id() {
+		return $GLOBALS['_test_current_user'];
+	}
+
+	function user_can( $user_id, $capability ) {
+		return ! empty( $GLOBALS['_test_caps'][ $user_id ][ $capability ] );
+	}
+
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+
+	function ec_get_blog_id() {
+		return 2;
+	}
+
+	function get_current_blog_id() {
+		return $GLOBALS['_test_blog_id'];
+	}
+
+	function switch_to_blog( $blog_id ) {
+		$GLOBALS['_test_switches'][] = array( 'switch', $blog_id, get_current_user_id() );
+		$GLOBALS['_test_blog_id']    = $blog_id;
+	}
+
+	function restore_current_blog() {
+		$GLOBALS['_test_switches'][] = array( 'restore', 1, get_current_user_id() );
+		$GLOBALS['_test_blog_id']    = 1;
+	}
+
+	function sanitize_text_field( $value ) {
+		return trim( $value );
+	}
+
+	function wp_kses_post( $value ) {
+		return $value;
+	}
+
+	function extrachill_community_maybe_convert_markdown( $value ) {
+		return $value;
+	}
+
+	function get_post( $post_id ) {
+		if ( 10 === $post_id ) {
+			return (object) array( 'post_type' => 'forum' );
+		}
+		if ( 20 === $post_id ) {
+			return (object) array( 'post_type' => 'topic', 'post_parent' => 10 );
+		}
+		return null;
+	}
+
+	function bbp_get_forum_post_type() {
+		return 'forum';
+	}
+
+	function bbp_get_topic_post_type() {
+		return 'topic';
+	}
+
+	function bbp_get_reply_post_type() {
+		return 'reply';
+	}
+
+	function bbp_get_public_status_id() {
+		return 'publish';
+	}
+
+	function bbp_get_topic_forum_id() {
+		return 10;
+	}
+
+	function bbp_insert_topic( $data ) {
+		$GLOBALS['_test_posts']['topic'] = $data;
+		return 30;
+	}
+
+	function bbp_insert_reply( $data ) {
+		$GLOBALS['_test_posts']['reply'] = $data;
+		return 40;
+	}
+
+	function bbp_get_topic_permalink() {
+		return 'https://example.com/topic';
+	}
+
+	function bbp_get_reply_url() {
+		return 'https://example.com/reply';
+	}
+
+	function do_action( $hook ) {
+		$GLOBALS['_test_actions'][ $hook ] = func_get_args();
+	}
+
+	function extrachill_test_reset( $user_id = 0, $principal = null, $caps = array() ) {
+		$GLOBALS['_test_current_user'] = $user_id;
+		$GLOBALS['_test_principal']    = $principal;
+		$GLOBALS['_test_caps']         = $caps;
+		$GLOBALS['_test_posts']        = array();
+		$GLOBALS['_test_actions']      = array();
+		$GLOBALS['_test_switches']     = array();
+	}
+
+	function extrachill_test_assert( $condition, $message ) {
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$message}\n" );
+			exit( 1 );
+		}
+	}
+
+	require __DIR__ . '/../inc/core/ability-helpers.php';
+	require __DIR__ . '/../inc/content/topic-reply-write.php';
+
+	$topic = array( 'forum_id' => 10, 'title' => 'Title', 'content' => 'Content' );
+	$reply = array( 'topic_id' => 20, 'content' => 'Reply' );
+
+	// Anonymous calls fail before either write path can insert content.
+	extrachill_test_reset();
+	extrachill_test_assert( ! extrachill_community_ability_create_topic_permission( $topic ), 'Anonymous topic permission must fail.' );
+	extrachill_test_assert( ! extrachill_community_ability_create_reply_permission( $reply ), 'Anonymous reply permission must fail.' );
+	extrachill_test_assert( is_wp_error( extrachill_community_ability_create_topic( $topic ) ), 'Anonymous topic execution must fail.' );
+	extrachill_test_assert( is_wp_error( extrachill_community_ability_create_reply( $reply ) ), 'Anonymous reply execution must fail.' );
+
+	// A caller-supplied victim ID is rejected for both write paths.
+	$caps = array( 7 => array( 'publish_topics' => true, 'publish_replies' => true ) );
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7 ), $caps );
+	$victim_topic            = $topic;
+	$victim_topic['user_id'] = 8;
+	$victim_reply            = $reply;
+	$victim_reply['user_id'] = 8;
+	extrachill_test_assert( 'author_mismatch' === extrachill_community_ability_create_topic( $victim_topic )->get_error_code(), 'Topic victim author must be rejected.' );
+	extrachill_test_assert( 'author_mismatch' === extrachill_community_ability_create_reply( $victim_reply )->get_error_code(), 'Reply victim author must be rejected.' );
+
+	// Authenticated self-authorship remains compatible with legacy self IDs.
+	$self_topic            = $topic;
+	$self_topic['user_id'] = 7;
+	$self_reply            = $reply;
+	$self_reply['user_id'] = 7;
+	$topic_result          = extrachill_community_ability_create_topic( $self_topic );
+	$reply_result          = extrachill_community_ability_create_reply( $self_reply );
+	extrachill_test_assert( 7 === $topic_result['author_id'] && 7 === $GLOBALS['_test_posts']['topic']['post_author'], 'Topic author must be the authenticated user.' );
+	extrachill_test_assert( 7 === $reply_result['author_id'] && 7 === $GLOBALS['_test_posts']['reply']['post_author'], 'Reply author must be the authenticated user.' );
+	extrachill_test_assert( 7 === $GLOBALS['_test_actions']['bbp_new_topic'][4], 'Topic side effects must receive the authenticated user.' );
+	extrachill_test_assert( 7 === $GLOBALS['_test_actions']['bbp_new_reply'][5], 'Reply side effects must receive the authenticated user.' );
+	extrachill_test_assert( array( array( 'switch', 2, 7 ), array( 'restore', 1, 7 ), array( 'switch', 2, 7 ), array( 'restore', 1, 7 ) ) === $GLOBALS['_test_switches'], 'Cross-site capability checks must preserve the authenticated network user.' );
+
+	// Ambient WordPress and Agents API identities must agree.
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 8 ), $caps );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Mismatched topic principal must fail.' );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Mismatched reply principal must fail.' );
+
+	// Capability ceilings cannot substitute a different effective user.
+	$ceiling = new WP_Agent_Capability_Ceiling( 8, array( 'publish_topics', 'publish_replies' ) );
+	extrachill_test_reset( 0, new AgentsAPI\AI\WP_Agent_Execution_Principal( 9, $ceiling ), array( 8 => array( 'publish_topics' => true, 'publish_replies' => true ) ) );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Mismatched topic capability principal must fail.' );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Mismatched reply capability principal must fail.' );
+
+	// A host-authorized execution principal can post as its acting user.
+	$agent_caps = array( 9 => array( 'publish_topics' => true, 'publish_replies' => true ) );
+	extrachill_test_reset( 0, new AgentsAPI\AI\WP_Agent_Execution_Principal( 9 ), $agent_caps );
+	extrachill_test_assert( 9 === extrachill_community_ability_create_topic( $topic )['author_id'], 'Authorized agent topic must use its acting user.' );
+	extrachill_test_assert( 9 === extrachill_community_ability_create_reply( $reply )['author_id'], 'Authorized agent reply must use its acting user.' );
+
+	// Authenticated users without the bbPress publish capability fail closed.
+	extrachill_test_reset( 11, new AgentsAPI\AI\WP_Agent_Execution_Principal( 11 ) );
+	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Underprivileged topic execution must fail.' );
+	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Underprivileged reply execution must fail.' );
+
+	echo "PASS: Topic and reply writes bind authorship to the authorized execution actor.\n";
+}


### PR DESCRIPTION
## Summary
- bind create and update topic/reply operations to the authenticated WordPress user or host-resolved Agents API `acting_user_id`
- intersect publish, object-level edit, and author-reassignment capabilities with the execution principal capability ceiling
- preserve explicit author selection only for trusted WP-CLI execution with no principal, a valid target user, and the required bbPress publish capability
- remove the advertised create-time author override while retaining compatibility for authenticated callers that pass a self-matching `user_id`

## Authorization invariant
Every forum write resolves one trusted actor from ambient authentication before checking capabilities. A principal must agree with any ambient WordPress user and its capability-ceiling user; ceiling allowlists constrain publish, edit, delete/upload envelope, and `edit_others_*` checks. Caller input cannot select another create author outside trusted WP-CLI, and update author reassignment requires the resolved actor's applicable `edit_others_*` capability within its ceiling.

## Compatibility
Authenticated human and authorized agent create/update flows remain supported. Existing REST/internal create callers may continue sending their own current `user_id`. Existing privileged update callers may reassign authors only when the resolved actor can edit the object and has the applicable `edit_others_*` capability. Normal WP-CLI creation with current user `0` may still select `--user`, but only when no execution principal exists and the selected network user exists and can publish that bbPress content; REST, agent, and general ability execution cannot use this exception.

## Tests
- `for test_file in tests/test-*.php; do php \"$test_file\" || exit 1; done` (pass)
- `php tests/test-topic-reply-author-authorization.php` (pass)
- focused coverage includes anonymous create calls, victim IDs, authenticated self-authorship, topic/reply update permission and execution, author reassignment, privileged ambient/principal mismatch, capability-ceiling restrictions, valid/invalid WP-CLI authors, and agent denial of the CLI exception
- Homeboy PR audit (pass, 0 introduced findings)
- Homeboy PHPCS (pass, 0 errors; two existing custom bbPress read-capability warnings)
- Homeboy umbrella lint re-reports seven pre-existing whole-file update-response ternary findings; its PHPUnit runner reports zero tests because this repository uses standalone PHP contract scripts
- npm lint remains unavailable because the repository has neither installed `wp-scripts` nor a lockfile for reproducible dependency hydration

Closes #232