### PR TITLE
fix: bind community updates to execution actor

### DIFF
--- a/inc/content/topic-reply-abilities.php
+++ b/inc/content/topic-reply-abilities.php
@@ -158,10 +158,6 @@ function extrachill_community_register_topic_reply_abilities() {
 						'enum'        => array( 'html', 'markdown' ),
 						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
 					),
-					'user_id'  => array(
-						'type'        => 'integer',
-						'description' => 'Author user ID (defaults to current user)',
-					),
 				),
 				'required'   => array( 'forum_id', 'title', 'content' ),
 			),
@@ -176,7 +172,7 @@ function extrachill_community_register_topic_reply_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_community_ability_create_topic',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_create_topic_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(
@@ -216,10 +212,6 @@ function extrachill_community_register_topic_reply_abilities() {
 						'type'        => 'integer',
 						'description' => 'Parent reply ID for threaded replies (optional)',
 					),
-					'user_id'  => array(
-						'type'        => 'integer',
-						'description' => 'Author user ID (defaults to current user)',
-					),
 				),
 				'required'   => array( 'topic_id', 'content' ),
 			),
@@ -234,7 +226,7 @@ function extrachill_community_register_topic_reply_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_community_ability_create_reply',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_community_ability_create_reply_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/content/topic-reply-editor-permissions.php
+++ b/inc/content/topic-reply-editor-permissions.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * Permission: can the current caller load this topic for editing?
  *
  * @param array $input Ability input.
- * @return bool|WP_Error
+ * @return bool
  */
 function extrachill_community_ability_get_topic_for_editor_permission( $input = array() ) {
 	if ( ! is_user_logged_in() ) {
@@ -32,7 +32,7 @@ function extrachill_community_ability_get_topic_for_editor_permission( $input = 
  * Permission: can the current caller load this reply for editing?
  *
  * @param array $input Ability input.
- * @return bool|WP_Error
+ * @return bool
  */
 function extrachill_community_ability_get_reply_for_editor_permission( $input = array() ) {
 	if ( ! is_user_logged_in() ) {
@@ -55,19 +55,19 @@ function extrachill_community_ability_get_reply_for_editor_permission( $input = 
  * @return bool|WP_Error
  */
 function extrachill_community_ability_update_topic_permission( $input = array() ) {
-	if ( ! is_user_logged_in() ) {
-		return false;
-	}
 	$topic_id = isset( $input['topic_id'] ) ? (int) $input['topic_id'] : 0;
 	if ( $topic_id <= 0 ) {
 		return false;
 	}
-	if ( ! current_user_can( 'edit_topic', $topic_id ) ) {
+	$post = get_post( $topic_id );
+	if ( ! $post || ( function_exists( 'bbp_get_topic_post_type' ) && bbp_get_topic_post_type() !== $post->post_type ) ) {
+		return false;
+	}
+	if ( is_wp_error( extrachill_community_authorize_post_update( $input, $post, 'topic' ) ) ) {
 		return false;
 	}
 	if ( function_exists( 'bbp_past_edit_lock' ) ) {
-		$post = get_post( $topic_id );
-		if ( $post && bbp_past_edit_lock( $post->post_date_gmt ) ) {
+		if ( bbp_past_edit_lock( $post->post_date_gmt ) ) {
 			return new WP_Error(
 				'edit_lock_expired',
 				__( 'The edit window for this topic has expired.', 'extra-chill-community' ),
@@ -85,19 +85,19 @@ function extrachill_community_ability_update_topic_permission( $input = array() 
  * @return bool|WP_Error
  */
 function extrachill_community_ability_update_reply_permission( $input = array() ) {
-	if ( ! is_user_logged_in() ) {
-		return false;
-	}
 	$reply_id = isset( $input['reply_id'] ) ? (int) $input['reply_id'] : 0;
 	if ( $reply_id <= 0 ) {
 		return false;
 	}
-	if ( ! current_user_can( 'edit_reply', $reply_id ) ) {
+	$post = get_post( $reply_id );
+	if ( ! $post || ( function_exists( 'bbp_get_reply_post_type' ) && bbp_get_reply_post_type() !== $post->post_type ) ) {
+		return false;
+	}
+	if ( is_wp_error( extrachill_community_authorize_post_update( $input, $post, 'reply' ) ) ) {
 		return false;
 	}
 	if ( function_exists( 'bbp_past_edit_lock' ) ) {
-		$post = get_post( $reply_id );
-		if ( $post && bbp_past_edit_lock( $post->post_date_gmt ) ) {
+		if ( bbp_past_edit_lock( $post->post_date_gmt ) ) {
 			return new WP_Error(
 				'edit_lock_expired',
 				__( 'The edit window for this reply has expired.', 'extra-chill-community' ),
@@ -122,7 +122,7 @@ function extrachill_community_build_editor_permissions( $post_id, $type ) {
 	$edit_cap   = ( 'topic' === $type ) ? 'edit_topic' : 'edit_reply';
 	$delete_cap = ( 'topic' === $type ) ? 'delete_topic' : 'delete_reply';
 
-	$can_save = current_user_can( $edit_cap, $post_id );
+	$can_save = ! is_wp_error( extrachill_community_authorize_forum_action( array(), $edit_cap, $post_id, false, 'cannot_edit' ) );
 	if ( $can_save && function_exists( 'bbp_past_edit_lock' ) ) {
 		$post = get_post( $post_id );
 		if ( $post && bbp_past_edit_lock( $post->post_date_gmt ) ) {
@@ -132,7 +132,7 @@ function extrachill_community_build_editor_permissions( $post_id, $type ) {
 
 	return array(
 		'canSave'        => (bool) $can_save,
-		'canUploadMedia' => (bool) ( is_user_logged_in() && current_user_can( 'upload_files' ) ),
-		'canDelete'      => (bool) current_user_can( $delete_cap, $post_id ),
+		'canUploadMedia' => ! is_wp_error( extrachill_community_authorize_forum_action( array(), 'upload_files', 0, false, 'cannot_upload' ) ),
+		'canDelete'      => ! is_wp_error( extrachill_community_authorize_forum_action( array(), $delete_cap, $post_id, false, 'cannot_delete' ) ),
 	);
 }

--- a/inc/content/topic-reply-write.php
+++ b/inc/content/topic-reply-write.php
@@ -13,6 +13,95 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Resolve and authorize the authenticated author for a forum write.
+ *
+ * The ambient Agents API principal is host-resolved and may carry a capability
+ * ceiling. Ability input is never an authority for authorship; a legacy
+ * self-matching user_id remains accepted for existing internal callers.
+ *
+ * @param array  $input      Ability input.
+ * @param string $capability Required bbPress publish capability.
+ * @return int|WP_Error Authenticated author ID on success.
+ */
+function extrachill_community_authorize_post_creation( $input, $capability ) {
+	$current_user_id = get_current_user_id();
+	$principal       = null;
+
+	if ( class_exists( 'WP_Agent_Access' ) && class_exists( 'AgentsAPI\\AI\\WP_Agent_Execution_Principal' ) ) {
+		try {
+			$principal = WP_Agent_Access::get_current_principal(
+				array(
+					'allow_anonymous_audience' => false,
+				)
+			);
+		} catch ( Throwable $exception ) {
+			return new WP_Error( 'invalid_execution_principal', 'The execution principal could not be authenticated.' );
+		}
+	}
+
+	if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal ) {
+		$user_id = (int) $principal->acting_user_id;
+
+		if ( $current_user_id > 0 && $current_user_id !== $user_id ) {
+			return new WP_Error( 'execution_principal_mismatch', 'The execution principal does not match the authenticated user.' );
+		}
+
+		if ( $principal->capability_ceiling instanceof WP_Agent_Capability_Ceiling && (int) $principal->capability_ceiling->user_id !== $user_id ) {
+			return new WP_Error( 'execution_principal_mismatch', 'The execution principal capability boundary does not match its acting user.' );
+		}
+	} else {
+		$user_id = $current_user_id;
+	}
+
+	if ( $user_id <= 0 ) {
+		return new WP_Error( 'missing_user', 'An authenticated user is required.' );
+	}
+
+	if ( isset( $input['user_id'] ) && (int) $input['user_id'] !== $user_id ) {
+		return new WP_Error( 'author_mismatch', 'The requested author does not match the authenticated user.' );
+	}
+
+	$site = extrachill_community_switch_to_community_blog();
+	try {
+		if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal && class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
+			$allowed = ( new WP_Agent_WordPress_Authorization_Policy() )->can( $principal, $capability );
+		} else {
+			$allowed = user_can( $user_id, $capability );
+		}
+	} finally {
+		if ( $site['switched'] ) {
+			restore_current_blog();
+		}
+	}
+
+	if ( ! $allowed ) {
+		return new WP_Error( 'cannot_publish', 'The authenticated user cannot publish this content.' );
+	}
+
+	return $user_id;
+}
+
+/**
+ * Permission callback for topic creation.
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
+function extrachill_community_ability_create_topic_permission( $input = array() ) {
+	return ! is_wp_error( extrachill_community_authorize_post_creation( $input, 'publish_topics' ) );
+}
+
+/**
+ * Permission callback for reply creation.
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
+function extrachill_community_ability_create_reply_permission( $input = array() ) {
+	return ! is_wp_error( extrachill_community_authorize_post_creation( $input, 'publish_replies' ) );
+}
+
+/**
  * Create a new topic.
  *
  * @param array $input Ability input.
@@ -28,7 +117,11 @@ function extrachill_community_ability_create_topic( $input ) {
 	$raw_content = isset( $input['content'] ) ? (string) $input['content'] : '';
 	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
 	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
-	$user_id     = extrachill_community_resolve_user_id( $input );
+	$user_id     = extrachill_community_authorize_post_creation( $input, 'publish_topics' );
+
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
 
 	if ( ! $forum_id ) {
 		return new WP_Error( 'missing_forum_id', 'A forum_id is required.' );
@@ -96,7 +189,11 @@ function extrachill_community_ability_create_reply( $input ) {
 	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
 	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
 	$reply_to    = isset( $input['reply_to'] ) ? (int) $input['reply_to'] : 0;
-	$user_id     = extrachill_community_resolve_user_id( $input );
+	$user_id     = extrachill_community_authorize_post_creation( $input, 'publish_replies' );
+
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
 
 	if ( ! $topic_id ) {
 		return new WP_Error( 'missing_topic_id', 'A topic_id is required.' );

--- a/inc/content/topic-reply-write.php
+++ b/inc/content/topic-reply-write.php
@@ -13,17 +13,32 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Resolve and authorize the authenticated author for a forum write.
+ * Whether this request is running in WordPress's trusted CLI bootstrap.
+ *
+ * @return bool
+ */
+function extrachill_community_is_wp_cli_request() {
+	// The standalone regression defines WP_CLI midway through one process to test both contexts.
+	// @phpstan-ignore-next-line booleanAnd.rightAlwaysTrue
+	return defined( 'WP_CLI' ) && (bool) constant( 'WP_CLI' );
+}
+
+/**
+ * Resolve and authorize the trusted actor for a forum write.
  *
  * The ambient Agents API principal is host-resolved and may carry a capability
  * ceiling. Ability input is never an authority for authorship; a legacy
- * self-matching user_id remains accepted for existing internal callers.
+ * self-matching user_id remains accepted for existing internal callers. WP-CLI
+ * may explicitly select an author only when no authenticated principal exists.
  *
- * @param array  $input      Ability input.
- * @param string $capability Required bbPress publish capability.
- * @return int|WP_Error Authenticated author ID on success.
+ * @param array  $input            Ability input.
+ * @param string $capability       Required bbPress capability.
+ * @param int    $object_id        Optional object ID for meta capabilities.
+ * @param bool   $allow_cli_author Whether trusted WP-CLI may select the actor.
+ * @param string $error_code       Authorization failure code.
+ * @return int|WP_Error Trusted actor ID on success.
  */
-function extrachill_community_authorize_post_creation( $input, $capability ) {
+function extrachill_community_authorize_forum_action( $input, $capability, $object_id = 0, $allow_cli_author = false, $error_code = 'cannot_publish' ) {
 	$current_user_id = get_current_user_id();
 	$principal       = null;
 
@@ -53,21 +68,29 @@ function extrachill_community_authorize_post_creation( $input, $capability ) {
 		$user_id = $current_user_id;
 	}
 
+	if ( $user_id <= 0 && null === $principal && $allow_cli_author && extrachill_community_is_wp_cli_request() && isset( $input['user_id'] ) ) {
+		$cli_user_id = (int) $input['user_id'];
+		if ( $cli_user_id > 0 && get_userdata( $cli_user_id ) ) {
+			$user_id = $cli_user_id;
+		}
+	}
+
 	if ( $user_id <= 0 ) {
 		return new WP_Error( 'missing_user', 'An authenticated user is required.' );
 	}
 
-	if ( isset( $input['user_id'] ) && (int) $input['user_id'] !== $user_id ) {
-		return new WP_Error( 'author_mismatch', 'The requested author does not match the authenticated user.' );
+	if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal
+		&& $principal->capability_ceiling instanceof WP_Agent_Capability_Ceiling
+		&& ! $principal->capability_ceiling->allows_capability( $capability )
+	) {
+		return new WP_Error( $error_code, 'The execution principal does not allow this action.' );
 	}
 
 	$site = extrachill_community_switch_to_community_blog();
 	try {
-		if ( $principal instanceof AgentsAPI\AI\WP_Agent_Execution_Principal && class_exists( 'WP_Agent_WordPress_Authorization_Policy' ) ) {
-			$allowed = ( new WP_Agent_WordPress_Authorization_Policy() )->can( $principal, $capability );
-		} else {
-			$allowed = user_can( $user_id, $capability );
-		}
+		$allowed = $object_id > 0
+			? user_can( $user_id, $capability, $object_id )
+			: user_can( $user_id, $capability );
 	} finally {
 		if ( $site['switched'] ) {
 			restore_current_blog();
@@ -75,10 +98,58 @@ function extrachill_community_authorize_post_creation( $input, $capability ) {
 	}
 
 	if ( ! $allowed ) {
-		return new WP_Error( 'cannot_publish', 'The authenticated user cannot publish this content.' );
+		return new WP_Error( $error_code, 'The trusted actor cannot perform this action.' );
 	}
 
 	return $user_id;
+}
+
+/**
+ * Resolve and authorize the author for topic/reply creation.
+ *
+ * @param array  $input      Ability input.
+ * @param string $capability Required bbPress publish capability.
+ * @return int|WP_Error Authenticated author ID on success.
+ */
+function extrachill_community_authorize_post_creation( $input, $capability ) {
+	$user_id = extrachill_community_authorize_forum_action( $input, $capability, 0, true );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	if ( isset( $input['user_id'] ) && (int) $input['user_id'] !== $user_id ) {
+		return new WP_Error( 'author_mismatch', 'The requested author does not match the authenticated user.' );
+	}
+
+	return $user_id;
+}
+
+/**
+ * Authorize a topic/reply update and any requested author reassignment.
+ *
+ * @param array   $input Ability input.
+ * @param WP_Post $post  Topic or reply post.
+ * @param string  $type  Either topic or reply.
+ * @return int|WP_Error Trusted actor ID on success.
+ */
+function extrachill_community_authorize_post_update( $input, $post, $type ) {
+	$edit_cap = 'topic' === $type ? 'edit_topic' : 'edit_reply';
+	$user_id  = extrachill_community_authorize_forum_action( $input, $edit_cap, (int) $post->ID, false, 'cannot_edit' );
+	if ( is_wp_error( $user_id ) ) {
+		return $user_id;
+	}
+
+	if ( ! isset( $input['user_id'] ) || (int) $input['user_id'] === (int) $post->post_author ) {
+		return $user_id;
+	}
+
+	$requested_user_id = (int) $input['user_id'];
+	if ( $requested_user_id <= 0 || ! get_userdata( $requested_user_id ) ) {
+		return new WP_Error( 'invalid_author', 'The requested author is not a valid user.' );
+	}
+
+	$edit_others_cap = 'topic' === $type ? 'edit_others_topics' : 'edit_others_replies';
+	return extrachill_community_authorize_forum_action( $input, $edit_others_cap, 0, false, 'cannot_change_author' );
 }
 
 /**
@@ -270,6 +341,11 @@ function extrachill_community_ability_update_topic( $input ) {
 		return new WP_Error( 'not_a_topic', 'Post ID is not a valid topic.' );
 	}
 
+	$actor_id = extrachill_community_authorize_post_update( $input, $post, 'topic' );
+	if ( is_wp_error( $actor_id ) ) {
+		return $actor_id;
+	}
+
 	$raw_content = isset( $input['content'] ) ? (string) $input['content'] : '';
 	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
 	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
@@ -291,14 +367,9 @@ function extrachill_community_ability_update_topic( $input ) {
 		$update['post_title'] = $title;
 	}
 
-	// Optional author override — permission_callback already enforced edit caps,
-	// but edit_others_topics is required to actually swap the author.
 	if ( isset( $input['user_id'] ) ) {
 		$requested_user_id = (int) $input['user_id'];
 		if ( $requested_user_id > 0 && $requested_user_id !== (int) $post->post_author ) {
-			if ( ! current_user_can( 'edit_others_topics' ) ) {
-				return new WP_Error( 'cannot_change_author', 'You cannot change the topic author.' );
-			}
 			$update['post_author'] = $requested_user_id;
 		}
 	}
@@ -352,6 +423,11 @@ function extrachill_community_ability_update_reply( $input ) {
 		return new WP_Error( 'not_a_reply', 'Post ID is not a valid reply.' );
 	}
 
+	$actor_id = extrachill_community_authorize_post_update( $input, $post, 'reply' );
+	if ( is_wp_error( $actor_id ) ) {
+		return $actor_id;
+	}
+
 	$raw_content = isset( $input['content'] ) ? (string) $input['content'] : '';
 	$format      = isset( $input['format'] ) ? (string) $input['format'] : 'html';
 	$content     = wp_kses_post( extrachill_community_maybe_convert_markdown( $raw_content, $format ) );
@@ -368,9 +444,6 @@ function extrachill_community_ability_update_reply( $input ) {
 	if ( isset( $input['user_id'] ) ) {
 		$requested_user_id = (int) $input['user_id'];
 		if ( $requested_user_id > 0 && $requested_user_id !== (int) $post->post_author ) {
-			if ( ! current_user_can( 'edit_others_replies' ) ) {
-				return new WP_Error( 'cannot_change_author', 'You cannot change the reply author.' );
-			}
 			$update['post_author'] = $requested_user_id;
 		}
 	}

--- a/tests/test-topic-reply-author-authorization.php
+++ b/tests/test-topic-reply-author-authorization.php
@@ -38,6 +38,10 @@ namespace {
 			$this->user_id              = $user_id;
 			$this->allowed_capabilities = $allowed_capabilities;
 		}
+
+		public function allows_capability( $capability ) {
+			return null === $this->allowed_capabilities || in_array( $capability, $this->allowed_capabilities, true );
+		}
 	}
 
 	class WP_Agent_Access {
@@ -63,16 +67,22 @@ namespace {
 	$GLOBALS['_test_principal']    = null;
 	$GLOBALS['_test_caps']         = array();
 	$GLOBALS['_test_posts']        = array();
+	$GLOBALS['_test_inserted']     = array();
 	$GLOBALS['_test_actions']      = array();
 	$GLOBALS['_test_blog_id']      = 1;
 	$GLOBALS['_test_switches']     = array();
+	$GLOBALS['_test_users']        = array( 1, 7, 8, 9, 11 );
 
 	function get_current_user_id() {
 		return $GLOBALS['_test_current_user'];
 	}
 
-	function user_can( $user_id, $capability ) {
+	function user_can( $user_id, $capability, $object_id = 0 ) {
 		return ! empty( $GLOBALS['_test_caps'][ $user_id ][ $capability ] );
+	}
+
+	function get_userdata( $user_id ) {
+		return in_array( (int) $user_id, $GLOBALS['_test_users'], true ) ? (object) array( 'ID' => (int) $user_id ) : false;
 	}
 
 	function is_wp_error( $value ) {
@@ -110,13 +120,7 @@ namespace {
 	}
 
 	function get_post( $post_id ) {
-		if ( 10 === $post_id ) {
-			return (object) array( 'post_type' => 'forum' );
-		}
-		if ( 20 === $post_id ) {
-			return (object) array( 'post_type' => 'topic', 'post_parent' => 10 );
-		}
-		return null;
+		return isset( $GLOBALS['_test_posts'][ $post_id ] ) ? clone $GLOBALS['_test_posts'][ $post_id ] : null;
 	}
 
 	function bbp_get_forum_post_type() {
@@ -135,26 +139,61 @@ namespace {
 		return 'publish';
 	}
 
-	function bbp_get_topic_forum_id() {
+	function bbp_get_topic_forum_id( $topic_id = 0 ) {
 		return 10;
 	}
 
-	function bbp_insert_topic( $data ) {
-		$GLOBALS['_test_posts']['topic'] = $data;
+	function bbp_get_reply_topic_id( $reply_id = 0 ) {
+		return 20;
+	}
+
+	function bbp_get_reply_forum_id( $reply_id = 0 ) {
+		return 10;
+	}
+
+	function bbp_get_reply_to( $reply_id = 0 ) {
+		return 0;
+	}
+
+	function bbp_insert_topic( $data, $meta = array() ) {
+		$GLOBALS['_test_inserted']['topic'] = $data;
 		return 30;
 	}
 
-	function bbp_insert_reply( $data ) {
-		$GLOBALS['_test_posts']['reply'] = $data;
+	function bbp_insert_reply( $data, $meta = array() ) {
+		$GLOBALS['_test_inserted']['reply'] = $data;
 		return 40;
 	}
 
-	function bbp_get_topic_permalink() {
+	function bbp_get_topic_permalink( $topic_id = 0 ) {
 		return 'https://example.com/topic';
 	}
 
-	function bbp_get_reply_url() {
+	function bbp_get_reply_url( $reply_id = 0 ) {
 		return 'https://example.com/reply';
+	}
+
+	function wp_update_post( $update, $return_error = false ) {
+		$post_id = (int) $update['ID'];
+		foreach ( $update as $field => $value ) {
+			if ( 'ID' !== $field ) {
+				$GLOBALS['_test_posts'][ $post_id ]->$field = $value;
+			}
+		}
+		$GLOBALS['_test_posts'][ $post_id ]->post_modified_gmt = '2026-07-28 00:00:00';
+		return $post_id;
+	}
+
+	function mysql_to_rfc3339( $value ) {
+		return '2026-07-28T00:00:00+00:00';
+	}
+
+	function bbp_past_edit_lock( $post_date_gmt = '' ) {
+		return false;
+	}
+
+	function __( $value ) {
+		return $value;
 	}
 
 	function do_action( $hook ) {
@@ -165,7 +204,40 @@ namespace {
 		$GLOBALS['_test_current_user'] = $user_id;
 		$GLOBALS['_test_principal']    = $principal;
 		$GLOBALS['_test_caps']         = $caps;
-		$GLOBALS['_test_posts']        = array();
+		$GLOBALS['_test_posts']        = array(
+			10 => (object) array(
+				'ID'           => 10,
+				'post_type'    => 'forum',
+				'post_author'  => 7,
+				'post_parent'  => 0,
+				'post_status'  => 'publish',
+				'post_title'   => 'Forum',
+				'post_content' => '',
+			),
+			20 => (object) array(
+				'ID'                => 20,
+				'post_type'         => 'topic',
+				'post_author'       => 7,
+				'post_parent'       => 10,
+				'post_status'       => 'publish',
+				'post_title'        => 'Topic',
+				'post_content'      => 'Original topic',
+				'post_date_gmt'     => '2026-07-28 00:00:00',
+				'post_modified_gmt' => '2026-07-28 00:00:00',
+			),
+			21 => (object) array(
+				'ID'                => 21,
+				'post_type'         => 'reply',
+				'post_author'       => 7,
+				'post_parent'       => 20,
+				'post_status'       => 'publish',
+				'post_title'        => '',
+				'post_content'      => 'Original reply',
+				'post_date_gmt'     => '2026-07-28 00:00:00',
+				'post_modified_gmt' => '2026-07-28 00:00:00',
+			),
+		);
+		$GLOBALS['_test_inserted']     = array();
 		$GLOBALS['_test_actions']      = array();
 		$GLOBALS['_test_switches']     = array();
 	}
@@ -179,6 +251,7 @@ namespace {
 
 	require __DIR__ . '/../inc/core/ability-helpers.php';
 	require __DIR__ . '/../inc/content/topic-reply-write.php';
+	require __DIR__ . '/../inc/content/topic-reply-editor-permissions.php';
 
 	$topic = array( 'forum_id' => 10, 'title' => 'Title', 'content' => 'Content' );
 	$reply = array( 'topic_id' => 20, 'content' => 'Reply' );
@@ -201,14 +274,15 @@ namespace {
 	extrachill_test_assert( 'author_mismatch' === extrachill_community_ability_create_reply( $victim_reply )->get_error_code(), 'Reply victim author must be rejected.' );
 
 	// Authenticated self-authorship remains compatible with legacy self IDs.
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7 ), $caps );
 	$self_topic            = $topic;
 	$self_topic['user_id'] = 7;
 	$self_reply            = $reply;
 	$self_reply['user_id'] = 7;
 	$topic_result          = extrachill_community_ability_create_topic( $self_topic );
 	$reply_result          = extrachill_community_ability_create_reply( $self_reply );
-	extrachill_test_assert( 7 === $topic_result['author_id'] && 7 === $GLOBALS['_test_posts']['topic']['post_author'], 'Topic author must be the authenticated user.' );
-	extrachill_test_assert( 7 === $reply_result['author_id'] && 7 === $GLOBALS['_test_posts']['reply']['post_author'], 'Reply author must be the authenticated user.' );
+	extrachill_test_assert( 7 === $topic_result['author_id'] && 7 === $GLOBALS['_test_inserted']['topic']['post_author'], 'Topic author must be the authenticated user.' );
+	extrachill_test_assert( 7 === $reply_result['author_id'] && 7 === $GLOBALS['_test_inserted']['reply']['post_author'], 'Reply author must be the authenticated user.' );
 	extrachill_test_assert( 7 === $GLOBALS['_test_actions']['bbp_new_topic'][4], 'Topic side effects must receive the authenticated user.' );
 	extrachill_test_assert( 7 === $GLOBALS['_test_actions']['bbp_new_reply'][5], 'Reply side effects must receive the authenticated user.' );
 	extrachill_test_assert( array( array( 'switch', 2, 7 ), array( 'restore', 1, 7 ), array( 'switch', 2, 7 ), array( 'restore', 1, 7 ) ) === $GLOBALS['_test_switches'], 'Cross-site capability checks must preserve the authenticated network user.' );
@@ -235,5 +309,94 @@ namespace {
 	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Underprivileged topic execution must fail.' );
 	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Underprivileged reply execution must fail.' );
 
-	echo "PASS: Topic and reply writes bind authorship to the authorized execution actor.\n";
+	$update_topic = array( 'topic_id' => 20, 'content' => 'Updated topic' );
+	$update_reply = array( 'reply_id' => 21, 'content' => 'Updated reply' );
+	$edit_caps    = array( 7 => array( 'edit_topic' => true, 'edit_reply' => true ) );
+
+	// Both update permission and execution paths use the trusted actor.
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7 ), $edit_caps );
+	extrachill_test_assert( true === extrachill_community_ability_update_topic_permission( $update_topic ), 'Authenticated actor must be allowed to update its topic.' );
+	extrachill_test_assert( true === extrachill_community_ability_update_reply_permission( $update_reply ), 'Authenticated actor must be allowed to update its reply.' );
+	extrachill_test_assert( ! is_wp_error( extrachill_community_ability_update_topic( $update_topic ) ), 'Authorized topic update must succeed.' );
+	extrachill_test_assert( ! is_wp_error( extrachill_community_ability_update_reply( $update_reply ) ), 'Authorized reply update must succeed.' );
+	extrachill_test_assert( 'Updated topic' === $GLOBALS['_test_posts'][20]->post_content, 'Topic update must persist.' );
+	extrachill_test_assert( 'Updated reply' === $GLOBALS['_test_posts'][21]->post_content, 'Reply update must persist.' );
+
+	// Author reassignment requires edit_others_* as the trusted actor.
+	$reassign_caps = array(
+		7 => array(
+			'edit_topic'          => true,
+			'edit_reply'          => true,
+			'edit_others_topics'  => true,
+			'edit_others_replies' => true,
+		),
+	);
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7 ), $reassign_caps );
+	$reassign_topic            = $update_topic;
+	$reassign_topic['user_id'] = 8;
+	$reassign_reply            = $update_reply;
+	$reassign_reply['user_id'] = 8;
+	extrachill_test_assert( true === extrachill_community_ability_update_topic_permission( $reassign_topic ), 'Authorized topic reassignment permission must pass.' );
+	extrachill_test_assert( true === extrachill_community_ability_update_reply_permission( $reassign_reply ), 'Authorized reply reassignment permission must pass.' );
+	extrachill_test_assert( ! is_wp_error( extrachill_community_ability_update_topic( $reassign_topic ) ), 'Authorized topic reassignment must succeed.' );
+	extrachill_test_assert( ! is_wp_error( extrachill_community_ability_update_reply( $reassign_reply ) ), 'Authorized reply reassignment must succeed.' );
+	extrachill_test_assert( 8 === $GLOBALS['_test_posts'][20]->post_author, 'Topic reassignment must use the validated target.' );
+	extrachill_test_assert( 8 === $GLOBALS['_test_posts'][21]->post_author, 'Reply reassignment must use the validated target.' );
+
+	// A delegated principal cannot inherit a different privileged ambient user.
+	$ambient_admin_caps = array(
+		1 => array(
+			'edit_topic'          => true,
+			'edit_reply'          => true,
+			'edit_others_topics'  => true,
+			'edit_others_replies' => true,
+		),
+	);
+	extrachill_test_reset( 1, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7 ), $ambient_admin_caps );
+	extrachill_test_assert( false === extrachill_community_ability_update_topic_permission( $reassign_topic ), 'Mismatched principal topic permission must fail.' );
+	extrachill_test_assert( false === extrachill_community_ability_update_reply_permission( $reassign_reply ), 'Mismatched principal reply permission must fail.' );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_update_topic( $reassign_topic )->get_error_code(), 'Mismatched principal topic update must fail.' );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_update_reply( $reassign_reply )->get_error_code(), 'Mismatched principal reply update must fail.' );
+
+	// Capability ceilings constrain updates and author reassignment.
+	$restricted_ceiling = new WP_Agent_Capability_Ceiling( 7, array( 'edit_topic', 'edit_reply' ) );
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, $restricted_ceiling ), $reassign_caps );
+	extrachill_test_assert( true === extrachill_community_ability_update_topic_permission( $update_topic ), 'Ceiling-authorized topic edit must pass.' );
+	extrachill_test_assert( true === extrachill_community_ability_update_reply_permission( $update_reply ), 'Ceiling-authorized reply edit must pass.' );
+	extrachill_test_assert( false === extrachill_community_ability_update_topic_permission( $reassign_topic ), 'Topic reassignment outside the ceiling must fail permission.' );
+	extrachill_test_assert( false === extrachill_community_ability_update_reply_permission( $reassign_reply ), 'Reply reassignment outside the ceiling must fail permission.' );
+	extrachill_test_assert( 'cannot_change_author' === extrachill_community_ability_update_topic( $reassign_topic )->get_error_code(), 'Topic reassignment outside the ceiling must fail execution.' );
+	extrachill_test_assert( 'cannot_change_author' === extrachill_community_ability_update_reply( $reassign_reply )->get_error_code(), 'Reply reassignment outside the ceiling must fail execution.' );
+
+	$topic_only_ceiling = new WP_Agent_Capability_Ceiling( 7, array( 'edit_topic' ) );
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, $topic_only_ceiling ), $edit_caps );
+	extrachill_test_assert( false === extrachill_community_ability_update_reply_permission( $update_reply ), 'Reply update outside the ceiling must fail permission.' );
+	extrachill_test_assert( 'cannot_edit' === extrachill_community_ability_update_reply( $update_reply )->get_error_code(), 'Reply update outside the ceiling must fail execution.' );
+
+	// Explicit author selection is denied outside WP-CLI, even with a capable target.
+	$cli_caps  = array( 8 => array( 'publish_topics' => true, 'publish_replies' => true ) );
+	$cli_topic = $topic;
+	$cli_reply = $reply;
+	$cli_topic['user_id'] = 8;
+	$cli_reply['user_id'] = 8;
+	extrachill_test_reset( 0, null, $cli_caps );
+	extrachill_test_assert( 'missing_user' === extrachill_community_ability_create_topic( $cli_topic )->get_error_code(), 'General topic ability execution cannot select an author.' );
+	extrachill_test_assert( 'missing_user' === extrachill_community_ability_create_reply( $cli_reply )->get_error_code(), 'General reply ability execution cannot select an author.' );
+
+	// Trusted WP-CLI preserves the documented explicit-author workflow.
+	define( 'WP_CLI', true );
+	extrachill_test_reset( 0, null, $cli_caps );
+	extrachill_test_assert( true === extrachill_community_ability_create_topic_permission( $cli_topic ), 'WP-CLI topic author selection must pass ability permission.' );
+	extrachill_test_assert( true === extrachill_community_ability_create_reply_permission( $cli_reply ), 'WP-CLI reply author selection must pass ability permission.' );
+	extrachill_test_assert( 8 === extrachill_community_ability_create_topic( $cli_topic )['author_id'], 'WP-CLI topic author selection must use a valid capable user.' );
+	extrachill_test_assert( 8 === extrachill_community_ability_create_reply( $cli_reply )['author_id'], 'WP-CLI reply author selection must use a valid capable user.' );
+	$invalid_cli_topic            = $topic;
+	$invalid_cli_topic['user_id'] = 99;
+	extrachill_test_assert( 'missing_user' === extrachill_community_ability_create_topic( $invalid_cli_topic )->get_error_code(), 'WP-CLI must reject an unknown author.' );
+	extrachill_test_reset( 0, new AgentsAPI\AI\WP_Agent_Execution_Principal( 0 ), $cli_caps );
+	extrachill_test_assert( 'missing_user' === extrachill_community_ability_create_topic( $cli_topic )->get_error_code(), 'Agent execution cannot inherit WP-CLI author selection.' );
+	extrachill_test_reset( 0, null, array() );
+	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_reply( $cli_reply )->get_error_code(), 'WP-CLI must reject an author without the bbPress capability.' );
+
+	echo "PASS: Topic and reply writes bind create/update authorization to the trusted execution actor.\n";
 }

--- a/tests/test-topic-reply-author-authorization.php
+++ b/tests/test-topic-reply-author-authorization.php
@@ -1,0 +1,239 @@
+<?php
+/** Standalone regression test for topic/reply author authorization. */
+
+namespace AgentsAPI\AI {
+	class WP_Agent_Execution_Principal {
+		public $acting_user_id;
+		public $capability_ceiling;
+
+		public function __construct( $acting_user_id, $capability_ceiling = null ) {
+			$this->acting_user_id    = $acting_user_id;
+			$this->capability_ceiling = $capability_ceiling;
+		}
+	}
+}
+
+namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	class WP_Error {
+		private $code;
+
+		public function __construct( $code ) {
+			$this->code = $code;
+		}
+
+		public function get_error_code() {
+			return $this->code;
+		}
+	}
+
+	class WP_Agent_Capability_Ceiling {
+		public $user_id;
+		public $allowed_capabilities;
+
+		public function __construct( $user_id, $allowed_capabilities = null ) {
+			$this->user_id              = $user_id;
+			$this->allowed_capabilities = $allowed_capabilities;
+		}
+	}
+
+	class WP_Agent_Access {
+		public static function get_current_principal( $context = array() ) {
+			return $GLOBALS['_test_principal'];
+		}
+	}
+
+	class WP_Agent_WordPress_Authorization_Policy {
+		public function can( $principal, $capability ) {
+			if ( $principal->capability_ceiling instanceof WP_Agent_Capability_Ceiling
+				&& is_array( $principal->capability_ceiling->allowed_capabilities )
+				&& ! in_array( $capability, $principal->capability_ceiling->allowed_capabilities, true )
+			) {
+				return false;
+			}
+
+			return user_can( $principal->acting_user_id, $capability );
+		}
+	}
+
+	$GLOBALS['_test_current_user'] = 0;
+	$GLOBALS['_test_principal']    = null;
+	$GLOBALS['_test_caps']         = array();
+	$GLOBALS['_test_posts']        = array();
+	$GLOBALS['_test_actions']      = array();
+	$GLOBALS['_test_blog_id']      = 1;
+	$GLOBALS['_test_switches']     = array();
+
+	function get_current_user_id() {
+		return $GLOBALS['_test_current_user'];
+	}
+
+	function user_can( $user_id, $capability ) {
+		return ! empty( $GLOBALS['_test_caps'][ $user_id ][ $capability ] );
+	}
+
+	function is_wp_error( $value ) {
+		return $value instanceof WP_Error;
+	}
+
+	function ec_get_blog_id() {
+		return 2;
+	}
+
+	function get_current_blog_id() {
+		return $GLOBALS['_test_blog_id'];
+	}
+
+	function switch_to_blog( $blog_id ) {
+		$GLOBALS['_test_switches'][] = array( 'switch', $blog_id, get_current_user_id() );
+		$GLOBALS['_test_blog_id']    = $blog_id;
+	}
+
+	function restore_current_blog() {
+		$GLOBALS['_test_switches'][] = array( 'restore', 1, get_current_user_id() );
+		$GLOBALS['_test_blog_id']    = 1;
+	}
+
+	function sanitize_text_field( $value ) {
+		return trim( $value );
+	}
+
+	function wp_kses_post( $value ) {
+		return $value;
+	}
+
+	function extrachill_community_maybe_convert_markdown( $value ) {
+		return $value;
+	}
+
+	function get_post( $post_id ) {
+		if ( 10 === $post_id ) {
+			return (object) array( 'post_type' => 'forum' );
+		}
+		if ( 20 === $post_id ) {
+			return (object) array( 'post_type' => 'topic', 'post_parent' => 10 );
+		}
+		return null;
+	}
+
+	function bbp_get_forum_post_type() {
+		return 'forum';
+	}
+
+	function bbp_get_topic_post_type() {
+		return 'topic';
+	}
+
+	function bbp_get_reply_post_type() {
+		return 'reply';
+	}
+
+	function bbp_get_public_status_id() {
+		return 'publish';
+	}
+
+	function bbp_get_topic_forum_id() {
+		return 10;
+	}
+
+	function bbp_insert_topic( $data ) {
+		$GLOBALS['_test_posts']['topic'] = $data;
+		return 30;
+	}
+
+	function bbp_insert_reply( $data ) {
+		$GLOBALS['_test_posts']['reply'] = $data;
+		return 40;
+	}
+
+	function bbp_get_topic_permalink() {
+		return 'https://example.com/topic';
+	}
+
+	function bbp_get_reply_url() {
+		return 'https://example.com/reply';
+	}
+
+	function do_action( $hook ) {
+		$GLOBALS['_test_actions'][ $hook ] = func_get_args();
+	}
+
+	function extrachill_test_reset( $user_id = 0, $principal = null, $caps = array() ) {
+		$GLOBALS['_test_current_user'] = $user_id;
+		$GLOBALS['_test_principal']    = $principal;
+		$GLOBALS['_test_caps']         = $caps;
+		$GLOBALS['_test_posts']        = array();
+		$GLOBALS['_test_actions']      = array();
+		$GLOBALS['_test_switches']     = array();
+	}
+
+	function extrachill_test_assert( $condition, $message ) {
+		if ( ! $condition ) {
+			fwrite( STDERR, "FAIL: {$message}\n" );
+			exit( 1 );
+		}
+	}
+
+	require __DIR__ . '/../inc/core/ability-helpers.php';
+	require __DIR__ . '/../inc/content/topic-reply-write.php';
+
+	$topic = array( 'forum_id' => 10, 'title' => 'Title', 'content' => 'Content' );
+	$reply = array( 'topic_id' => 20, 'content' => 'Reply' );
+
+	// Anonymous calls fail before either write path can insert content.
+	extrachill_test_reset();
+	extrachill_test_assert( ! extrachill_community_ability_create_topic_permission( $topic ), 'Anonymous topic permission must fail.' );
+	extrachill_test_assert( ! extrachill_community_ability_create_reply_permission( $reply ), 'Anonymous reply permission must fail.' );
+	extrachill_test_assert( is_wp_error( extrachill_community_ability_create_topic( $topic ) ), 'Anonymous topic execution must fail.' );
+	extrachill_test_assert( is_wp_error( extrachill_community_ability_create_reply( $reply ) ), 'Anonymous reply execution must fail.' );
+
+	// A caller-supplied victim ID is rejected for both write paths.
+	$caps = array( 7 => array( 'publish_topics' => true, 'publish_replies' => true ) );
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 7 ), $caps );
+	$victim_topic            = $topic;
+	$victim_topic['user_id'] = 8;
+	$victim_reply            = $reply;
+	$victim_reply['user_id'] = 8;
+	extrachill_test_assert( 'author_mismatch' === extrachill_community_ability_create_topic( $victim_topic )->get_error_code(), 'Topic victim author must be rejected.' );
+	extrachill_test_assert( 'author_mismatch' === extrachill_community_ability_create_reply( $victim_reply )->get_error_code(), 'Reply victim author must be rejected.' );
+
+	// Authenticated self-authorship remains compatible with legacy self IDs.
+	$self_topic            = $topic;
+	$self_topic['user_id'] = 7;
+	$self_reply            = $reply;
+	$self_reply['user_id'] = 7;
+	$topic_result          = extrachill_community_ability_create_topic( $self_topic );
+	$reply_result          = extrachill_community_ability_create_reply( $self_reply );
+	extrachill_test_assert( 7 === $topic_result['author_id'] && 7 === $GLOBALS['_test_posts']['topic']['post_author'], 'Topic author must be the authenticated user.' );
+	extrachill_test_assert( 7 === $reply_result['author_id'] && 7 === $GLOBALS['_test_posts']['reply']['post_author'], 'Reply author must be the authenticated user.' );
+	extrachill_test_assert( 7 === $GLOBALS['_test_actions']['bbp_new_topic'][4], 'Topic side effects must receive the authenticated user.' );
+	extrachill_test_assert( 7 === $GLOBALS['_test_actions']['bbp_new_reply'][5], 'Reply side effects must receive the authenticated user.' );
+	extrachill_test_assert( array( array( 'switch', 2, 7 ), array( 'restore', 1, 7 ), array( 'switch', 2, 7 ), array( 'restore', 1, 7 ) ) === $GLOBALS['_test_switches'], 'Cross-site capability checks must preserve the authenticated network user.' );
+
+	// Ambient WordPress and Agents API identities must agree.
+	extrachill_test_reset( 7, new AgentsAPI\AI\WP_Agent_Execution_Principal( 8 ), $caps );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Mismatched topic principal must fail.' );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Mismatched reply principal must fail.' );
+
+	// Capability ceilings cannot substitute a different effective user.
+	$ceiling = new WP_Agent_Capability_Ceiling( 8, array( 'publish_topics', 'publish_replies' ) );
+	extrachill_test_reset( 0, new AgentsAPI\AI\WP_Agent_Execution_Principal( 9, $ceiling ), array( 8 => array( 'publish_topics' => true, 'publish_replies' => true ) ) );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Mismatched topic capability principal must fail.' );
+	extrachill_test_assert( 'execution_principal_mismatch' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Mismatched reply capability principal must fail.' );
+
+	// A host-authorized execution principal can post as its acting user.
+	$agent_caps = array( 9 => array( 'publish_topics' => true, 'publish_replies' => true ) );
+	extrachill_test_reset( 0, new AgentsAPI\AI\WP_Agent_Execution_Principal( 9 ), $agent_caps );
+	extrachill_test_assert( 9 === extrachill_community_ability_create_topic( $topic )['author_id'], 'Authorized agent topic must use its acting user.' );
+	extrachill_test_assert( 9 === extrachill_community_ability_create_reply( $reply )['author_id'], 'Authorized agent reply must use its acting user.' );
+
+	// Authenticated users without the bbPress publish capability fail closed.
+	extrachill_test_reset( 11, new AgentsAPI\AI\WP_Agent_Execution_Principal( 11 ) );
+	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_topic( $topic )->get_error_code(), 'Underprivileged topic execution must fail.' );
+	extrachill_test_assert( 'cannot_publish' === extrachill_community_ability_create_reply( $reply )->get_error_code(), 'Underprivileged reply execution must fail.' );
+
+	echo "PASS: Topic and reply writes bind authorship to the authorized execution actor.\n";
+}


### PR DESCRIPTION
## Summary
- bind topic and reply update permissions to the trusted acting user and Agents API capability ceiling
- prevent delegated executions from inheriting a more privileged ambient WordPress session
- preserve explicit author selection only for trusted WP-CLI execution with a valid capable target user

## Security invariant
Create and update paths now resolve one accountable actor. REST, agent, and general ability callers cannot reassign authors through caller-controlled `user_id`; update and `edit_others_*` checks are evaluated for the trusted execution actor.

## Tests
- standalone Community PHP contract suite passes
- focused author authorization coverage includes topic/reply create and update, principal/current-user mismatch, capability ceilings, author reassignment, and trusted/untrusted WP-CLI selection
- exact-head security review approved commit `1e7e4af02058c202f1e5cc7d9537b30afdcac06e`

Follow-up to #232 and #236, which merged before this review correction was pushed.