### PR TITLE
fix: replace local topic taxonomy pickers with network classification

### DIFF
--- a/bbpress/form-topic.php
+++ b/bbpress/form-topic.php
@@ -93,17 +93,6 @@ if ( ! bbp_is_single_forum() ) : ?>
 
 					<?php endif; ?>
 
-					<?php
-					// Composer term-picker (issue #59): curated, pick-from-
-					// existing taxonomy tagging. The React picker mounts via the
-					// bbp_theme_before_topic_form_location action
-					// (extrachill_community_render_term_picker_mounts) and submits
-					// the chosen EXISTING term IDs as bbp_topic_location[]. No
-					// freeform creation, so the network's curated taxonomy tree
-					// never drifts. Hooks preserved so plugins can still target
-					// this slot; the minimal #57 <select> it supersedes is gone.
-					?>
-
 					<?php do_action( 'bbp_theme_before_topic_form_location' ); ?>
 
 					<?php do_action( 'bbp_theme_after_topic_form_location' ); ?>

--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -1,21 +1,16 @@
 <?php
 /**
- * Composer Term-Picker
+ * Topic Taxonomy Correction
  *
- * Curated, pick-from-existing taxonomy tagging for the bbPress topic composer.
+ * Optional network-aware taxonomy correction for existing bbPress topics.
  *
- * Users tag their post with EXISTING curated network taxonomy terms (location
- * festival, and artist) via an autocomplete React picker. The
- * picker searches terms through the WP REST API (NO AJAX, per the system-wide
- * rule) and submits the chosen term IDs as a hidden `${field}[]` array that the
- * server-side save handler assigns on bbp_new_topic / bbp_edit_topic.
+ * New topics rely on the network-owned asynchronous classifier and do not show
+ * taxonomy fields. Existing topics retain a collapsed correction UI that
+ * searches approved network identities, projects missing terms locally, and
+ * submits the returned local IDs through the existing edit handlers.
  *
- * Curated only: the picker NEVER creates terms. Typing a non-matching string
- * mints nothing, so the network's shared taxonomy tree never drifts.
- *
- * Taxonomy-parameterized: the picker is driven by a config array (one entry per
- * taxonomy). Enabling another taxonomy is a config addition here, not a new
- * component.
+ * Community consumes the network abilities directly. It does not load or wait
+ * on Data Machine, and an unavailable ability runtime never blocks editing.
  *
  * @package ExtraChillCommunity
  * @since 1.9.0
@@ -26,14 +21,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Taxonomies the composer term-picker offers, in render order.
+ * Taxonomies the topic correction UI offers, in render order.
  *
- * Each taxonomy must be registered for `topic` and REST-enabled. No React
- * change is required to add a future taxonomy.
+ * Each taxonomy must be registered for `topic`.
  *
  * Each entry:
  * - taxonomy     Taxonomy slug.
- * - rest_base    REST base for /wp/v2/<rest_base> term search.
  * - label        Visible field label.
  * - placeholder  Search input placeholder.
  * - field        POST field name; values submit as `${field}[]`.
@@ -44,21 +37,18 @@ function extrachill_community_term_picker_taxonomies() {
 	$taxonomies = array(
 		array(
 			'taxonomy'    => 'location',
-			'rest_base'   => 'location',
 			'label'       => __( 'Location', 'extra-chill-community' ),
 			'placeholder' => __( 'Search locations (e.g. Charleston)…', 'extra-chill-community' ),
 			'field'       => 'bbp_topic_location',
 		),
 		array(
 			'taxonomy'    => 'festival',
-			'rest_base'   => 'festival',
 			'label'       => __( 'Festival', 'extra-chill-community' ),
 			'placeholder' => __( 'Search festivals (e.g. Bonnaroo)…', 'extra-chill-community' ),
 			'field'       => 'bbp_topic_festival',
 		),
 		array(
 			'taxonomy'    => 'artist',
-			'rest_base'   => 'artist',
 			'label'       => __( 'Artist', 'extra-chill-community' ),
 			'placeholder' => __( 'Search artists…', 'extra-chill-community' ),
 			'field'       => 'bbp_topic_artist',
@@ -283,89 +273,75 @@ function extrachill_community_maybe_redirect_discussion_composer_login() {
 add_action( 'template_redirect', 'extrachill_community_maybe_redirect_discussion_composer_login' );
 
 /**
- * Build the localized config the React picker consumes.
+ * Build the localized config the edit-only correction UI consumes.
  *
- * Filters out taxonomies that are not actually registered/REST-enabled, and
- * seeds each taxonomy's `selected` terms when editing an existing topic.
+ * New-topic forms intentionally receive no taxonomy config. Existing local
+ * assignments seed the controls with the local IDs required by wp_set_object_terms().
  *
  * @param int $topic_id Topic ID (0 on the create flow).
  * @return array<string,mixed> Localizable config.
  */
 function extrachill_community_term_picker_config( $topic_id = 0 ) {
-	$taxonomies   = array();
-	$continuation = 0 === (int) $topic_id && extrachill_community_can_continue_discussion_composer()
-		? extrachill_community_get_discussion_composer_state()
-		: null;
+	$taxonomies = array();
+	$topic_id   = absint( $topic_id );
+
+	if ( 0 === $topic_id ) {
+		return array(
+			'restUrl'    => esc_url_raw( rest_url() ),
+			'restNonce'  => wp_create_nonce( 'wp_rest' ),
+			'topicId'    => 0,
+			'taxonomies' => array(),
+		);
+	}
 
 	foreach ( extrachill_community_term_picker_taxonomies() as $entry ) {
 		$taxonomy = $entry['taxonomy'];
 
 		$tax_object = get_taxonomy( $taxonomy );
-		if ( ! $tax_object || empty( $tax_object->show_in_rest ) ) {
+		if ( ! $tax_object || ! is_object_in_taxonomy( 'topic', $taxonomy ) ) {
 			continue;
 		}
 
 		$selected = array();
-		if ( $topic_id > 0 ) {
-			$terms = get_the_terms( $topic_id, $taxonomy );
-			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
-				foreach ( $terms as $term ) {
-					$selected[] = array(
-						'id'     => (int) $term->term_id,
-						'name'   => $term->name,
-						'parent' => (int) $term->parent,
-					);
-				}
+		$terms    = get_the_terms( $topic_id, $taxonomy );
+		if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+			foreach ( $terms as $term ) {
+				$selected[] = array(
+					'id'   => (int) $term->term_id,
+					'name' => $term->name,
+					'slug' => $term->slug,
+				);
 			}
-		} elseif ( $continuation && $taxonomy === $continuation['taxonomy'] ) {
-			$selected[] = array(
-				'id'     => (int) $continuation['term']->term_id,
-				'name'   => $continuation['term']->name,
-				'parent' => (int) $continuation['term']->parent,
-			);
 		}
 
-		$rest_base = ! empty( $tax_object->rest_base ) ? $tax_object->rest_base : $taxonomy;
-
 		$taxonomies[] = array(
-			'taxonomy'     => $taxonomy,
-			'restBase'     => $rest_base,
-			'label'        => $entry['label'],
-			'placeholder'  => $entry['placeholder'],
-			'hierarchical' => (bool) $tax_object->hierarchical,
-			'field'        => $entry['field'],
-			'selected'     => $selected,
+			'taxonomy'    => $taxonomy,
+			'label'       => $entry['label'],
+			'placeholder' => $entry['placeholder'],
+			'field'       => $entry['field'],
+			'selected'    => $selected,
 		);
 	}
 
 	return array(
 		'restUrl'    => esc_url_raw( rest_url() ),
 		'restNonce'  => wp_create_nonce( 'wp_rest' ),
+		'topicId'    => $topic_id,
 		'taxonomies' => $taxonomies,
 	);
 }
 
 /**
- * Enqueue the term-picker script + style on the bbPress topic composer.
+ * Enqueue the correction UI only while editing an existing topic.
  *
- * Guarded to bbPress contexts where the topic form renders (single forum,
- * topic edit, or the homepage New Topic modal). Uses the wp-scripts build
- * artifact and its generated dependency manifest.
+ * Uses the wp-scripts build artifact and its generated dependency manifest.
  */
 function extrachill_community_enqueue_term_picker() {
-	if ( ! function_exists( 'is_bbpress' ) ) {
+	if ( ! function_exists( 'bbp_is_topic_edit' ) || ! bbp_is_topic_edit() ) {
 		return;
 	}
 
-	// Only where the create/edit topic form can appear.
-	$is_topic_form_context = is_bbpress() || is_front_page();
-	if ( ! $is_topic_form_context ) {
-		return;
-	}
-
-	$config = extrachill_community_term_picker_config(
-		( function_exists( 'bbp_is_topic_edit' ) && bbp_is_topic_edit() ) ? bbp_get_topic_id() : 0
-	);
+	$config = extrachill_community_term_picker_config( bbp_get_topic_id() );
 
 	// Nothing to render if no taxonomy resolved.
 	if ( empty( $config['taxonomies'] ) ) {
@@ -414,24 +390,36 @@ function extrachill_community_enqueue_term_picker() {
 add_action( 'wp_enqueue_scripts', 'extrachill_community_enqueue_term_picker', 20 );
 
 /**
- * Render the term-picker mount points inside the topic form.
+ * Render collapsed correction controls on topic edit forms only.
  *
- * One mount div per configured taxonomy; React hydrates each. Output replaces
- * the minimal #57 location <select> (the save handler is generalized to read
- * the picker's array field). Hooked on the same location-form action #57 left
- * in form-topic.php so the picker drops into the established slot.
+ * Automatic network classification owns the create flow. These controls are a
+ * secondary human correction path and remain optional when the ability runtime
+ * is unavailable.
  */
 function extrachill_community_render_term_picker_mounts() {
+	if ( ! function_exists( 'bbp_is_topic_edit' ) || ! bbp_is_topic_edit() ) {
+		return;
+	}
+
+	$mounts = array();
 	foreach ( extrachill_community_term_picker_taxonomies() as $entry ) {
 		$tax_object = get_taxonomy( $entry['taxonomy'] );
-		if ( ! $tax_object || empty( $tax_object->show_in_rest ) ) {
+		if ( ! $tax_object || ! is_object_in_taxonomy( 'topic', $entry['taxonomy'] ) ) {
 			continue;
 		}
 
-		printf(
-			'<div class="ec-term-picker-mount" data-taxonomy="%s"></div>',
-			esc_attr( $entry['taxonomy'] )
-		);
+		$mounts[] = sprintf( '<div class="ec-term-picker-mount" data-taxonomy="%s"></div>', esc_attr( $entry['taxonomy'] ) );
 	}
+
+	if ( empty( $mounts ) ) {
+		return;
+	}
+
+	printf(
+		'<details class="ec-topic-term-corrections"><summary>%s</summary><p class="ec-topic-term-corrections__description">%s</p>%s</details>',
+		esc_html__( 'Correct classifications (optional)', 'extra-chill-community' ),
+		esc_html__( 'Add or remove approved network terms. Your selections are saved as human corrections.', 'extra-chill-community' ),
+		implode( '', $mounts ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each mount is escaped above.
+	);
 }
 add_action( 'bbp_theme_before_topic_form_location', 'extrachill_community_render_term_picker_mounts' );

--- a/inc/core/taxonomy-artist.php
+++ b/inc/core/taxonomy-artist.php
@@ -37,7 +37,7 @@ function extrachill_register_artist_for_bbpress() {
 add_action( 'init', 'extrachill_register_artist_for_bbpress', 20 );
 
 /**
- * Persist existing artist terms selected in the bbPress topic composer.
+ * Persist approved artist terms selected while editing a topic.
  *
  * The picker only submits IDs for existing shared artist terms. Its marker
  * lets an intentionally empty selection clear an edited topic while leaving
@@ -70,7 +70,6 @@ function extrachill_community_save_topic_artist( $topic_id ) {
 	// Empty (or all-invalid) selection clears the artist context.
 	wp_set_object_terms( $topic_id, $term_ids, 'artist' );
 }
-add_action( 'bbp_new_topic', 'extrachill_community_save_topic_artist', 20 );
 add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_artist', 20 );
 
 /**

--- a/inc/core/taxonomy-festival.php
+++ b/inc/core/taxonomy-festival.php
@@ -23,7 +23,7 @@ function extrachill_community_register_festival_for_topics() {
 add_action( 'init', 'extrachill_community_register_festival_for_topics', 20 );
 
 /**
- * Persist existing festival terms selected in the bbPress topic composer.
+ * Persist approved festival terms selected while editing a topic.
  *
  * @param int $topic_id The topic ID.
  */
@@ -53,7 +53,6 @@ function extrachill_community_save_topic_festival( $topic_id ) {
 	// Empty (or all-invalid) selection clears the festival.
 	wp_set_object_terms( $topic_id, $term_ids, 'festival' );
 }
-add_action( 'bbp_new_topic', 'extrachill_community_save_topic_festival', 20 );
 add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_festival', 20 );
 
 /**

--- a/inc/core/taxonomy-location.php
+++ b/inc/core/taxonomy-location.php
@@ -32,7 +32,7 @@ function extrachill_community_register_location_for_forums() {
 add_action( 'init', 'extrachill_community_register_location_for_forums', 20 );
 
 /**
- * Persist a topic's location term(s) on create/edit.
+ * Persist a topic's manually corrected location terms on edit.
  *
  * Reads the composer term-picker's `bbp_topic_location[]` array from the
  * submitted topic form and assigns the matching EXISTING hierarchical location
@@ -86,7 +86,6 @@ function extrachill_community_save_topic_location( $topic_id ) {
 	// Empty (or all-invalid) selection clears the location.
 	wp_set_object_terms( $topic_id, $term_ids, 'location' );
 }
-add_action( 'bbp_new_topic', 'extrachill_community_save_topic_location', 20 );
 add_action( 'bbp_edit_topic', 'extrachill_community_save_topic_location', 20 );
 
 /**

--- a/scripts/smoke-artist-topic-taxonomy.php
+++ b/scripts/smoke-artist-topic-taxonomy.php
@@ -28,8 +28,8 @@ if ( ! $artist_picker || 'bbp_topic_artist' !== $artist_picker['field'] ) {
 	WP_CLI::error( 'Artist topic picker configuration is missing or invalid.' );
 }
 
-if ( 20 !== has_action( 'bbp_new_topic', 'extrachill_community_save_topic_artist' ) || 20 !== has_action( 'bbp_edit_topic', 'extrachill_community_save_topic_artist' ) ) {
-	WP_CLI::error( 'Artist topic persistence hooks are not registered.' );
+if ( false !== has_action( 'bbp_new_topic', 'extrachill_community_save_topic_artist' ) || 20 !== has_action( 'bbp_edit_topic', 'extrachill_community_save_topic_artist' ) ) {
+	WP_CLI::error( 'Artist persistence must be registered for edits only.' );
 }
 
 $query                   = new WP_Query();

--- a/src/term-picker/TermPicker.tsx
+++ b/src/term-picker/TermPicker.tsx
@@ -1,19 +1,11 @@
 /**
- * Composer term-picker — curated, pick-from-existing, no freeform creation.
- *
- * Autocompletes against EXISTING curated network taxonomy terms via the WP
- * REST API (NO AJAX, per the system-wide rule). Users select terms as chips;
- * the picker writes hidden inputs (`${field}[]`) that the bbPress save handler
- * reads on submit. Typing a non-matching string creates NOTHING — the network's
- * curated taxonomy tree never drifts from the composer.
- *
- * The component is taxonomy-parameterized via TaxonomyConfig, so location today
- * and artist/festival/venue later share one implementation.
+ * Edit-only taxonomy correction using network-owned term abilities.
  */
 
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import {
 	useCallback,
 	useEffect,
@@ -21,120 +13,105 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import type { TaxonomyConfig, Term } from './types';
+import type { NetworkTerm, TaxonomyConfig, Term } from './types';
 
 const SEARCH_DEBOUNCE_MS = 250;
 const MAX_SUGGESTIONS = 10;
+const SEARCH_ABILITY = 'extrachill/search-network-terms';
+const PROJECT_ABILITY = 'extrachill/project-network-term';
 
 interface TermPickerProps {
 	config: TaxonomyConfig;
+	topicId: number;
 }
 
-/**
- * Build the REST search path for a taxonomy. Read-only: search only, the
- * picker never hits a write verb on this endpoint.
- * @param restBase
- * @param search
- */
-function buildSearchPath( restBase: string, search: string ): string {
-	const params = new URLSearchParams( {
-		search,
-		per_page: String( MAX_SUGGESTIONS ),
-		_fields: 'id,name,parent',
-		orderby: 'count',
-		order: 'desc',
+interface SearchResponse {
+	terms: NetworkTerm[];
+}
+
+interface ProjectionResponse {
+	taxonomy: string;
+	slug: string;
+	term_id: number;
+}
+
+function abilityPath( name: string ): string {
+	return `/wp-abilities/v1/abilities/${ name }/run`;
+}
+
+export function buildNetworkSearchPath(
+	taxonomy: string,
+	search: string
+): string {
+	const input = {
+		site: 'community',
+		post_type: 'topic',
+		taxonomy,
+		query: search,
+		limit: MAX_SUGGESTIONS,
+	};
+
+	return `${ abilityPath( SEARCH_ABILITY ) }?input=${ encodeURIComponent(
+		JSON.stringify( input )
+	) }`;
+}
+
+export function projectNetworkTerm(
+	topicId: number,
+	term: NetworkTerm
+): Promise< ProjectionResponse > {
+	return apiFetch< ProjectionResponse >( {
+		path: abilityPath( PROJECT_ABILITY ),
+		method: 'POST',
+		data: {
+			input: {
+				site: 'community',
+				post_id: topicId,
+				taxonomy: term.taxonomy,
+				slug: term.slug,
+			},
+		},
 	} );
-	return `/wp/v2/${ restBase }?${ params.toString() }`;
 }
 
-export function TermPicker( { config }: TermPickerProps ) {
+export function TermPicker( { config, topicId }: TermPickerProps ) {
 	const {
 		taxonomy,
-		restBase,
 		label,
 		placeholder,
-		hierarchical,
 		field,
 		selected: initialSelected,
 	} = config;
-
 	const [ query, setQuery ] = useState( '' );
-	const [ suggestions, setSuggestions ] = useState< Term[] >( [] );
+	const [ suggestions, setSuggestions ] = useState< NetworkTerm[] >( [] );
 	const [ selected, setSelected ] = useState< Term[] >( initialSelected );
 	const [ loading, setLoading ] = useState( false );
+	const [ projecting, setProjecting ] = useState( false );
 	const [ open, setOpen ] = useState( false );
 	const [ activeIndex, setActiveIndex ] = useState( -1 );
-
+	const [ unavailable, setUnavailable ] = useState( false );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
-	const debounceRef = useRef< ReturnType< typeof setTimeout > | null >(
-		null
-	);
-	// Parent-id -> name cache so hierarchical suggestions can show "Term, Parent".
-	const parentNameCache = useRef< Map< number, string > >( new Map() );
+	const searchSequence = useRef( 0 );
 
-	const selectedIds = useMemo(
-		() => new Set( selected.map( ( t ) => t.id ) ),
+	const selectedSlugs = useMemo(
+		() => new Set( selected.map( ( term ) => term.slug ) ),
 		[ selected ]
 	);
-
-	/**
-	 * Resolve parent names for hierarchical context (e.g. "Charleston, South
-	 * Carolina"). Read-only REST lookups, cached to avoid repeat fetches.
-	 */
-	const resolveParentNames = useCallback(
-		async ( terms: Term[] ) => {
-			if ( ! hierarchical ) {
-				return;
-			}
-			const missing = Array.from(
-				new Set(
-					terms
-						.map( ( t ) => t.parent )
-						.filter(
-							( id ) =>
-								id > 0 && ! parentNameCache.current.has( id )
-						)
-				)
-			);
-			if ( missing.length === 0 ) {
-				return;
-			}
-			const params = new URLSearchParams( {
-				include: missing.join( ',' ),
-				per_page: String( missing.length ),
-				_fields: 'id,name',
-			} );
-			try {
-				const parents = await apiFetch<
-					Array< { id: number; name: string } >
-				>( {
-					path: `/wp/v2/${ restBase }?${ params.toString() }`,
-				} );
-				parents.forEach( ( p ) =>
-					parentNameCache.current.set( p.id, p.name )
-				);
-				// Force a re-render so freshly resolved parent names appear.
-				setSuggestions( ( prev ) => [ ...prev ] );
-			} catch {
-				// Non-fatal: suggestions still render without parent context.
-			}
-		},
-		[ hierarchical, restBase ]
+	const visibleSuggestions = useMemo(
+		() =>
+			suggestions.filter( ( term ) => ! selectedSlugs.has( term.slug ) ),
+		[ suggestions, selectedSlugs ]
 	);
 
-	// Debounced REST search against existing terms.
 	useEffect( () => {
-		if ( debounceRef.current ) {
-			clearTimeout( debounceRef.current );
-		}
-
 		const trimmed = query.trim();
+		const sequence = ++searchSequence.current;
+
 		if ( trimmed.length < 1 ) {
 			setSuggestions( [] );
 			setLoading( false );
@@ -142,30 +119,42 @@ export function TermPicker( { config }: TermPickerProps ) {
 		}
 
 		setLoading( true );
-		debounceRef.current = setTimeout( () => {
-			apiFetch< Term[] >( { path: buildSearchPath( restBase, trimmed ) } )
-				.then( ( results ) => {
-					setSuggestions( results );
-					setActiveIndex( results.length > 0 ? 0 : -1 );
-					void resolveParentNames( results );
+		setUnavailable( false );
+		const timeout = setTimeout( () => {
+			apiFetch< SearchResponse >( {
+				path: buildNetworkSearchPath( taxonomy, trimmed ),
+				method: 'GET',
+			} )
+				.then( ( response ) => {
+					if ( sequence !== searchSequence.current ) {
+						return;
+					}
+					const terms = Array.isArray( response.terms )
+						? response.terms
+						: [];
+					setSuggestions( terms );
+					setActiveIndex( terms.length > 0 ? 0 : -1 );
 				} )
 				.catch( () => {
+					if ( sequence !== searchSequence.current ) {
+						return;
+					}
 					setSuggestions( [] );
 					setActiveIndex( -1 );
+					setUnavailable( true );
 				} )
-				.finally( () => setLoading( false ) );
+				.finally( () => {
+					if ( sequence === searchSequence.current ) {
+						setLoading( false );
+					}
+				} );
 		}, SEARCH_DEBOUNCE_MS );
 
-		return () => {
-			if ( debounceRef.current ) {
-				clearTimeout( debounceRef.current );
-			}
-		};
-	}, [ query, restBase, resolveParentNames ] );
+		return () => clearTimeout( timeout );
+	}, [ query, taxonomy ] );
 
-	// Close the suggestion list on outside click.
 	useEffect( () => {
-		function onDocClick( event: MouseEvent ) {
+		function closeOnOutsideClick( event: MouseEvent ) {
 			if (
 				wrapperRef.current &&
 				! wrapperRef.current.contains( event.target as Node )
@@ -173,41 +162,51 @@ export function TermPicker( { config }: TermPickerProps ) {
 				setOpen( false );
 			}
 		}
-		document.addEventListener( 'mousedown', onDocClick );
-		return () => document.removeEventListener( 'mousedown', onDocClick );
+
+		document.addEventListener( 'mousedown', closeOnOutsideClick );
+		return () =>
+			document.removeEventListener( 'mousedown', closeOnOutsideClick );
 	}, [] );
 
-	const termLabel = useCallback(
-		( term: Term ): string => {
-			if ( hierarchical && term.parent > 0 ) {
-				const parentName = parentNameCache.current.get( term.parent );
-				if ( parentName ) {
-					return `${ term.name }, ${ parentName }`;
+	const addTerm = useCallback(
+		async ( term: NetworkTerm ) => {
+			setProjecting( true );
+			setUnavailable( false );
+			try {
+				const projection = await projectNetworkTerm( topicId, term );
+				if ( projection.term_id < 1 ) {
+					throw new Error( 'Missing local term ID' );
 				}
+				setSelected( ( current ) =>
+					current.some( ( item ) => item.id === projection.term_id )
+						? current
+						: [
+								...current,
+								{
+									id: projection.term_id,
+									name: term.name,
+									slug: projection.slug,
+								},
+						  ]
+				);
+				setQuery( '' );
+				setSuggestions( [] );
+				setActiveIndex( -1 );
+				setOpen( false );
+			} catch {
+				setUnavailable( true );
+			} finally {
+				setProjecting( false );
 			}
-			return term.name;
 		},
-		[ hierarchical ]
+		[ topicId ]
 	);
-
-	const addTerm = useCallback( ( term: Term ) => {
-		setSelected( ( prev ) =>
-			prev.some( ( t ) => t.id === term.id ) ? prev : [ ...prev, term ]
-		);
-		setQuery( '' );
-		setSuggestions( [] );
-		setActiveIndex( -1 );
-		setOpen( false );
-	}, [] );
 
 	const removeTerm = useCallback( ( id: number ) => {
-		setSelected( ( prev ) => prev.filter( ( t ) => t.id !== id ) );
+		setSelected( ( current ) =>
+			current.filter( ( term ) => term.id !== id )
+		);
 	}, [] );
-
-	const visibleSuggestions = useMemo(
-		() => suggestions.filter( ( t ) => ! selectedIds.has( t.id ) ),
-		[ suggestions, selectedIds ]
-	);
 
 	const onKeyDown = useCallback(
 		( event: React.KeyboardEvent< HTMLInputElement > ) => {
@@ -217,30 +216,30 @@ export function TermPicker( { config }: TermPickerProps ) {
 				}
 				return;
 			}
+
 			switch ( event.key ) {
 				case 'ArrowDown':
 					event.preventDefault();
 					setActiveIndex(
-						( i ) => ( i + 1 ) % visibleSuggestions.length
+						( index ) => ( index + 1 ) % visibleSuggestions.length
 					);
 					break;
 				case 'ArrowUp':
 					event.preventDefault();
 					setActiveIndex(
-						( i ) =>
-							( i - 1 + visibleSuggestions.length ) %
+						( index ) =>
+							( index - 1 + visibleSuggestions.length ) %
 							visibleSuggestions.length
 					);
 					break;
 				case 'Enter':
-					// Only commit an existing suggestion. Never mint a new term
-					// from free text — curated taxonomy, pick-from-existing only.
 					if (
 						activeIndex >= 0 &&
-						activeIndex < visibleSuggestions.length
+						activeIndex < visibleSuggestions.length &&
+						! projecting
 					) {
 						event.preventDefault();
-						addTerm( visibleSuggestions[ activeIndex ] );
+						void addTerm( visibleSuggestions[ activeIndex ] );
 					}
 					break;
 				case 'Escape':
@@ -248,7 +247,7 @@ export function TermPicker( { config }: TermPickerProps ) {
 					break;
 			}
 		},
-		[ open, visibleSuggestions, activeIndex, addTerm, query ]
+		[ activeIndex, addTerm, open, projecting, query, visibleSuggestions ]
 	);
 
 	const listboxId = `ec-term-picker-listbox-${ taxonomy }`;
@@ -260,9 +259,6 @@ export function TermPicker( { config }: TermPickerProps ) {
 			ref={ wrapperRef }
 			data-taxonomy={ taxonomy }
 		>
-			{ /* Hidden inputs the bbPress save handler reads on submit. An empty
-			     marker guarantees the field is present even with zero selections
-			     so the server can clear the relationship. */ }
 			<input type="hidden" name={ `${ field }_submitted` } value="1" />
 			{ selected.map( ( term ) => (
 				<input
@@ -289,7 +285,7 @@ export function TermPicker( { config }: TermPickerProps ) {
 					{ selected.map( ( term ) => (
 						<li key={ term.id } className="ec-term-picker__chip">
 							<span className="ec-term-picker__chip-label">
-								{ termLabel( term ) }
+								{ term.name }
 							</span>
 							<button
 								type="button"
@@ -320,8 +316,9 @@ export function TermPicker( { config }: TermPickerProps ) {
 					aria-expanded={ open && visibleSuggestions.length > 0 }
 					aria-controls={ listboxId }
 					aria-autocomplete="list"
-					onChange={ ( e ) => {
-						setQuery( e.target.value );
+					disabled={ projecting }
+					onChange={ ( event ) => {
+						setQuery( event.target.value );
 						setOpen( true );
 					} }
 					onFocus={ () => {
@@ -332,38 +329,58 @@ export function TermPicker( { config }: TermPickerProps ) {
 					onKeyDown={ onKeyDown }
 				/>
 
-				{ open && query.trim().length > 0 && (
+				{ unavailable && (
+					<p className="ec-term-picker__status" role="status">
+						{ __(
+							'Term suggestions are unavailable. You can still save your topic.',
+							'extra-chill-community'
+						) }
+					</p>
+				) }
+
+				{ open && query.trim().length > 0 && ! unavailable && (
 					<ul
 						id={ listboxId }
 						className="ec-term-picker__suggestions"
 						role="listbox"
 					>
-						{ loading && (
+						{ ( loading || projecting ) && (
 							<li
 								className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
 								role="option"
 								aria-disabled="true"
 							>
-								{ __( 'Searching…', 'extra-chill-community' ) }
-							</li>
-						) }
-						{ ! loading && visibleSuggestions.length === 0 && (
-							<li
-								className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
-								role="option"
-								aria-disabled="true"
-							>
-								{ __(
-									'No matching terms. You can only pick from existing terms.',
-									'extra-chill-community'
-								) }
+								{ projecting
+									? __(
+											'Adding term…',
+											'extra-chill-community'
+									  )
+									: __(
+											'Searching…',
+											'extra-chill-community'
+									  ) }
 							</li>
 						) }
 						{ ! loading &&
+							! projecting &&
+							visibleSuggestions.length === 0 && (
+								<li
+									className="ec-term-picker__suggestion ec-term-picker__suggestion--status"
+									role="option"
+									aria-disabled="true"
+								>
+									{ __(
+										'No approved network terms found.',
+										'extra-chill-community'
+									) }
+								</li>
+							) }
+						{ ! loading &&
+							! projecting &&
 							visibleSuggestions.map( ( term, index ) => (
 								<li
-									key={ term.id }
-									id={ `${ listboxId }-option-${ term.id }` }
+									key={ `${ term.taxonomy }:${ term.slug }` }
+									id={ `${ listboxId }-option-${ term.slug }` }
 									className={
 										'ec-term-picker__suggestion' +
 										( index === activeIndex
@@ -375,13 +392,12 @@ export function TermPicker( { config }: TermPickerProps ) {
 									onMouseEnter={ () =>
 										setActiveIndex( index )
 									}
-									onMouseDown={ ( e ) => {
-										// mousedown (not click) so it fires before input blur.
-										e.preventDefault();
-										addTerm( term );
+									onMouseDown={ ( event ) => {
+										event.preventDefault();
+										void addTerm( term );
 									} }
 								>
-									{ termLabel( term ) }
+									{ term.name }
 								</li>
 							) ) }
 					</ul>

--- a/src/term-picker/index.tsx
+++ b/src/term-picker/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Composer term-picker entry.
+ * Edit-only topic taxonomy correction entry.
  *
  * Mounts a TermPicker into the bbPress topic form for each configured
  * taxonomy. Config is injected via wp_localize_script as
@@ -28,6 +28,7 @@ function init(): void {
 	if (
 		! config ||
 		! Array.isArray( config.taxonomies ) ||
+		config.topicId < 1 ||
 		config.taxonomies.length === 0
 	) {
 		return;
@@ -58,7 +59,9 @@ function init(): void {
 		}
 
 		const root = createRoot( mount );
-		root.render( <TermPicker config={ taxonomyConfig } /> );
+		root.render(
+			<TermPicker config={ taxonomyConfig } topicId={ config.topicId } />
+		);
 	} );
 }
 

--- a/src/term-picker/style.scss
+++ b/src/term-picker/style.scss
@@ -6,19 +6,19 @@
  */
 
 .ec-term-picker {
-	margin-bottom: var( --spacing-md, 16px );
+	margin-bottom: var(--spacing-md, 16px);
 
 	&__label {
 		display: block;
-		margin-bottom: var( --spacing-xs, 4px );
+		margin-bottom: var(--spacing-xs, 4px);
 		font-weight: 600;
 	}
 
 	&__chips {
 		display: flex;
 		flex-wrap: wrap;
-		gap: var( --spacing-xs, 4px );
-		margin: 0 0 var( --spacing-sm, 8px );
+		gap: var(--spacing-xs, 4px);
+		margin: 0 0 var(--spacing-sm, 8px);
 		padding: 0;
 		list-style: none;
 	}
@@ -26,12 +26,12 @@
 	&__chip {
 		display: inline-flex;
 		align-items: center;
-		gap: var( --spacing-xs, 4px );
-		padding: 2px var( --spacing-sm, 8px );
-		background: var( --card-background, #f2f2f2 );
-		border: 1px solid var( --border-color, #ccc );
-		border-radius: var( --border-radius-pill, 999px );
-		font-size: var( --font-size-sm, 0.85rem );
+		gap: var(--spacing-xs, 4px);
+		padding: 2px var(--spacing-sm, 8px);
+		background: var(--card-background, #f2f2f2);
+		border: 1px solid var(--border-color, #ccc);
+		border-radius: var(--border-radius-pill, 999px);
+		font-size: var(--font-size-sm, 0.85rem);
 		line-height: 1.5;
 	}
 
@@ -44,14 +44,14 @@
 		padding: 0;
 		border: 0;
 		background: transparent;
-		color: var( --muted-text, #666 );
+		color: var(--muted-text, #666);
 		font-size: 1.1em;
 		line-height: 1;
 		cursor: pointer;
 
 		&:hover,
 		&:focus {
-			color: var( --error-color, #c00 );
+			color: var(--error-color, #c00);
 		}
 	}
 
@@ -75,25 +75,38 @@
 		max-height: 240px;
 		overflow-y: auto;
 		list-style: none;
-		background: var( --background-color, #fff );
-		border: 1px solid var( --border-color, #ccc );
-		border-radius: var( --border-radius-sm, 4px );
-		box-shadow: 0 4px 12px rgba( 0, 0, 0, 0.12 );
+		background: var(--background-color, #fff);
+		border: 1px solid var(--border-color, #ccc);
+		border-radius: var(--border-radius-sm, 4px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 	}
 
 	&__suggestion {
-		padding: var( --spacing-xs, 4px ) var( --spacing-sm, 8px );
+		padding: var(--spacing-xs, 4px) var(--spacing-sm, 8px);
 		cursor: pointer;
 		line-height: 1.4;
 
 		&.is-active {
-			background: var( --card-background, #eee );
+			background: var(--card-background, #eee);
 		}
 
 		&--status {
-			color: var( --muted-text, #666 );
+			color: var(--muted-text, #666);
 			cursor: default;
 			font-style: italic;
 		}
+	}
+}
+
+.ec-topic-term-corrections {
+	margin-bottom: var(--spacing-md, 16px);
+
+	> summary {
+		font-weight: 600;
+		cursor: pointer;
+	}
+
+	&__description {
+		color: var(--muted-text, #666);
 	}
 }

--- a/src/term-picker/types.ts
+++ b/src/term-picker/types.ts
@@ -1,40 +1,40 @@
 /**
- * Shared types for the composer term-picker.
+ * Shared types for network-aware topic taxonomy correction.
  *
- * The picker is taxonomy-PARAMETERIZED: location is the only taxonomy wired
- * today, but artist / festival / venue can be enabled later purely by adding
- * entries to the localized `taxonomies` config — no new component per taxonomy.
+ * The picker is taxonomy-parameterized so artist, festival, and location share
+ * one network-aware implementation.
  */
 
 /**
- * A single curated network term as returned by the WP REST taxonomy endpoint
- * (e.g. GET /wp/v2/location?search=...). Users may only SELECT these; the
- * picker never creates new terms.
+ * A local term assignment. IDs are always Community-local IDs returned by the
+ * network projection ability.
  */
 export interface Term {
 	id: number;
 	name: string;
-	parent: number;
+	slug: string;
+}
+
+export interface NetworkTerm {
+	taxonomy: string;
+	slug: string;
+	name: string;
+	source: string;
 }
 
 /**
  * Per-taxonomy configuration. One entry per taxonomy the picker offers.
  *
- * `restBase` is the taxonomy's REST base (location -> /wp/v2/location). The
- * picker is read-only against that endpoint: it searches existing terms, it
- * never POSTs new ones.
+ * Search and projection use the network-owned Abilities API contracts. The
+ * submitted field still contains ordinary Community-local term IDs.
  */
 export interface TaxonomyConfig {
 	/** Taxonomy slug, e.g. "location". */
 	taxonomy: string;
-	/** REST base used to build the search URL, e.g. "location". */
-	restBase: string;
 	/** Visible field label, e.g. "Location". */
 	label: string;
 	/** Placeholder shown in the search input. */
 	placeholder: string;
-	/** Hierarchical taxonomies show parent context in suggestions. */
-	hierarchical: boolean;
 	/**
 	 * Name of the POST field the bbPress save handler reads. Values are
 	 * submitted as `${field}[]` so the server can assign multiple terms.
@@ -50,6 +50,7 @@ export interface TaxonomyConfig {
 export interface TermPickerConfig {
 	restUrl: string;
 	restNonce: string;
+	topicId: number;
 	taxonomies: TaxonomyConfig[];
 }
 

--- a/tests/js/discussion-composer.test.tsx
+++ b/tests/js/discussion-composer.test.tsx
@@ -1,10 +1,30 @@
+import apiFetch from '@wordpress/api-fetch';
 import { createRoot } from '@wordpress/element';
 // React is supplied by the WordPress test runtime rather than bundled here.
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { act } from 'react';
 
-import { TermPicker } from '../../src/term-picker/TermPicker';
+import {
+	buildNetworkSearchPath,
+	TermPicker,
+} from '../../src/term-picker/TermPicker';
 import type { TaxonomyConfig } from '../../src/term-picker/types';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockedApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+function changeInput( input: HTMLInputElement, value: string ) {
+	const setter = Object.getOwnPropertyDescriptor(
+		HTMLInputElement.prototype,
+		'value'
+	)?.set;
+	setter?.call( input, value );
+	input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+}
 
 function renderModalMarkup( autoOpen: boolean ) {
 	document.body.innerHTML = `
@@ -20,6 +40,14 @@ function renderModalMarkup( autoOpen: boolean ) {
 		</div>`;
 }
 
+const artistConfig: TaxonomyConfig = {
+	taxonomy: 'artist',
+	label: 'Artist',
+	placeholder: 'Search artists...',
+	field: 'bbp_topic_artist',
+	selected: [ { id: 42, name: 'Phish', slug: 'phish' } ],
+};
+
 describe( 'discussion composer continuation', () => {
 	beforeAll( () => {
 		const reactGlobal = globalThis as typeof globalThis & {
@@ -30,6 +58,8 @@ describe( 'discussion composer continuation', () => {
 
 	afterEach( () => {
 		document.body.innerHTML = '';
+		jest.clearAllMocks();
+		jest.useRealTimers();
 		jest.resetModules();
 	} );
 
@@ -47,14 +77,10 @@ describe( 'discussion composer continuation', () => {
 			document.getElementById( 'new-topic-modal-overlay' )?.classList
 		).toContain( 'is-open' );
 		expect( document.body.classList ).toContain( 'new-topic-modal-open' );
-		const modal = document.getElementById( 'new-topic-modal' );
-		expect( modal?.ownerDocument.activeElement ).toBe(
-			document.getElementById( 'bbp_topic_title' )
-		);
 		expect(
-			document.getElementById( 'new-topic-modal-description' )
-				?.textContent
-		).toBe( 'Start a new topic in the community.' );
+			document.getElementById( 'new-topic-modal' )?.ownerDocument
+				.activeElement
+		).toBe( document.getElementById( 'bbp_topic_title' ) );
 	} );
 
 	it( 'does not auto-open the normal composer without continuation state', () => {
@@ -69,22 +95,15 @@ describe( 'discussion composer continuation', () => {
 		).not.toContain( 'is-open' );
 	} );
 
-	it( 'renders a server-validated initial term through the existing picker', () => {
+	it( 'preserves existing Community-local IDs on edit', () => {
 		const container = document.createElement( 'div' );
 		document.body.appendChild( container );
 		const root = createRoot( container );
-		const config: TaxonomyConfig = {
-			taxonomy: 'artist',
-			restBase: 'artist',
-			label: 'Artist',
-			placeholder: 'Search artists...',
-			hierarchical: false,
-			field: 'bbp_topic_artist',
-			selected: [ { id: 42, name: 'Phish', parent: 0 } ],
-		};
 
 		act( () => {
-			root.render( <TermPicker config={ config } /> );
+			root.render(
+				<TermPicker config={ artistConfig } topicId={ 91 } />
+			);
 		} );
 
 		const selectedInput = container.querySelector< HTMLInputElement >(
@@ -94,5 +113,143 @@ describe( 'discussion composer continuation', () => {
 		expect( container.textContent ).toContain( 'Phish' );
 
 		act( () => root.unmount() );
+	} );
+
+	it( 'routes search through the network ability and assigns projected local IDs', async () => {
+		jest.useFakeTimers();
+		mockedApiFetch
+			.mockResolvedValueOnce( {
+				terms: [
+					{
+						taxonomy: 'artist',
+						slug: 'kid-lake',
+						name: 'Kid Lake',
+						source: 'main',
+					},
+				],
+			} as never )
+			.mockResolvedValueOnce( {
+				taxonomy: 'artist',
+				slug: 'kid-lake',
+				term_id: 77,
+			} as never );
+
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		act( () => {
+			root.render(
+				<TermPicker
+					config={ { ...artistConfig, selected: [] } }
+					topicId={ 91 }
+				/>
+			);
+		} );
+
+		const input = container.querySelector< HTMLInputElement >(
+			'.ec-term-picker__input'
+		);
+		await act( async () => {
+			if ( input ) {
+				changeInput( input, 'Kid Lake' );
+			}
+			jest.advanceTimersByTime( 250 );
+			await Promise.resolve();
+		} );
+
+		expect( mockedApiFetch ).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining( {
+				method: 'GET',
+				path: expect.stringContaining(
+					'/wp-abilities/v1/abilities/extrachill/search-network-terms/run?input='
+				),
+			} )
+		);
+		expect( mockedApiFetch.mock.calls[ 0 ][ 0 ].path ).not.toContain(
+			'/wp/v2/'
+		);
+
+		const suggestion = container.querySelector< HTMLElement >(
+			'.ec-term-picker__suggestion:not(.ec-term-picker__suggestion--status)'
+		);
+		await act( async () => {
+			suggestion?.dispatchEvent(
+				new MouseEvent( 'mousedown', { bubbles: true } )
+			);
+			await Promise.resolve();
+		} );
+
+		expect( mockedApiFetch ).toHaveBeenNthCalledWith( 2, {
+			path: '/wp-abilities/v1/abilities/extrachill/project-network-term/run',
+			method: 'POST',
+			data: {
+				input: {
+					site: 'community',
+					post_id: 91,
+					taxonomy: 'artist',
+					slug: 'kid-lake',
+				},
+			},
+		} );
+		expect(
+			container.querySelector< HTMLInputElement >(
+				'input[name="bbp_topic_artist[]"]'
+			)?.value
+		).toBe( '77' );
+
+		act( () => root.unmount() );
+	} );
+
+	it( 'degrades without blocking when the network runtime is absent', async () => {
+		jest.useFakeTimers();
+		mockedApiFetch.mockRejectedValueOnce(
+			new Error( 'Ability not found' )
+		);
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		act( () => {
+			root.render(
+				<TermPicker config={ artistConfig } topicId={ 91 } />
+			);
+		} );
+
+		const input = container.querySelector< HTMLInputElement >(
+			'.ec-term-picker__input'
+		);
+		await act( async () => {
+			if ( input ) {
+				changeInput( input, 'Missing' );
+			}
+			jest.advanceTimersByTime( 250 );
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain(
+			'Term suggestions are unavailable. You can still save your topic.'
+		);
+		expect( container.textContent ).not.toContain( 'No matching terms' );
+		expect(
+			container.querySelector< HTMLInputElement >(
+				'input[name="bbp_topic_artist[]"]'
+			)?.value
+		).toBe( '42' );
+
+		act( () => root.unmount() );
+	} );
+
+	it( 'encodes the complete approved-network search contract', () => {
+		const path = buildNetworkSearchPath( 'festival', 'High Water' );
+		const input = JSON.parse(
+			decodeURIComponent( path.split( '?input=' )[ 1 ] )
+		);
+		expect( input ).toEqual( {
+			site: 'community',
+			post_type: 'topic',
+			taxonomy: 'festival',
+			query: 'High Water',
+			limit: 10,
+		} );
 	} );
 } );

--- a/tests/test-discussion-composer-continuation.php
+++ b/tests/test-discussion-composer-continuation.php
@@ -37,6 +37,9 @@ function sanitize_title( $value ) {
 function wp_unslash( $value ) {
 	return $value;
 }
+function absint( $value ) {
+	return abs( (int) $value );
+}
 function get_taxonomy( $taxonomy ) {
 	if ( ! in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true ) ) {
 		return false;
@@ -174,13 +177,12 @@ check(
 
 $_GET = $valid_query;
 $config = extrachill_community_term_picker_config();
-$artist = array_values( array_filter( $config['taxonomies'], fn( $entry ) => 'artist' === $entry['taxonomy'] ) )[0];
-check( 'authorized continuation preselects the existing picker term', 42 === $artist['selected'][0]['id'] );
+check( 'create composer never receives taxonomy correction fields', array() === $config['taxonomies'] );
+check( 'create composer config has no topic target', 0 === $config['topicId'] );
 
 $GLOBALS['_test_can_publish'] = false;
 $config                       = extrachill_community_term_picker_config();
-$artist                       = array_values( array_filter( $config['taxonomies'], fn( $entry ) => 'artist' === $entry['taxonomy'] ) )[0];
-check( 'topic permissions gate preselection', array() === $artist['selected'] );
+check( 'unauthorized continuation also has no create taxonomy fields', array() === $config['taxonomies'] );
 
 function render_topic_modal() {
 	ob_start();

--- a/tests/test-topic-term-correction.php
+++ b/tests/test-topic-term-correction.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Focused tests for edit-only network taxonomy correction.
+ *
+ * Run: php tests/test-topic-term-correction.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['_test_actions']       = array();
+$GLOBALS['_test_is_topic_edit'] = false;
+
+function add_action( $hook, $callback, $priority = 10 ) {
+	$GLOBALS['_test_actions'][ $hook ][ $priority ][] = $callback;
+}
+function apply_filters( $hook, $value ) {
+	return $value;
+}
+function __( $text ) {
+	return $text;
+}
+function esc_html__( $text ) {
+	return $text;
+}
+function esc_attr( $text ) {
+	return htmlspecialchars( $text, ENT_QUOTES );
+}
+function absint( $value ) {
+	return abs( (int) $value );
+}
+function rest_url() {
+	return 'https://community.example/wp-json/';
+}
+function esc_url_raw( $url ) {
+	return $url;
+}
+function wp_create_nonce() {
+	return 'nonce';
+}
+function get_taxonomy( $taxonomy ) {
+	return in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true )
+		? (object) array( 'show_in_rest' => true )
+		: false;
+}
+function is_object_in_taxonomy( $post_type, $taxonomy ) {
+	return 'topic' === $post_type && in_array( $taxonomy, array( 'artist', 'festival', 'location' ), true );
+}
+function get_the_terms( $topic_id, $taxonomy ) {
+	if ( 91 !== $topic_id || 'artist' !== $taxonomy ) {
+		return array();
+	}
+
+	return array(
+		(object) array(
+			'term_id' => 17,
+			'name'    => 'Kid Lake',
+			'slug'    => 'kid-lake',
+		),
+	);
+}
+function is_wp_error() {
+	return false;
+}
+function bbp_is_topic_edit() {
+	return $GLOBALS['_test_is_topic_edit'];
+}
+
+require dirname( __DIR__ ) . '/inc/content/editor/composer-term-picker.php';
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+$create_config = extrachill_community_term_picker_config( 0 );
+check( 'create composer has no taxonomy controls', array() === $create_config['taxonomies'] );
+
+ob_start();
+extrachill_community_render_term_picker_mounts();
+$create_markup = ob_get_clean();
+check( 'create composer renders no correction markup', '' === $create_markup );
+
+$GLOBALS['_test_is_topic_edit'] = true;
+$edit_config                    = extrachill_community_term_picker_config( 91 );
+$artist                         = array_values( array_filter( $edit_config['taxonomies'], static fn( $entry ) => 'artist' === $entry['taxonomy'] ) )[0];
+check( 'edit config carries the existing topic ID', 91 === $edit_config['topicId'] );
+check( 'edit config preserves local IDs for assignment', 17 === $artist['selected'][0]['id'] );
+check( 'edit config preserves the network identity slug', 'kid-lake' === $artist['selected'][0]['slug'] );
+check( 'edit config does not expose a local taxonomy REST base', ! isset( $artist['restBase'] ) );
+
+ob_start();
+extrachill_community_render_term_picker_mounts();
+$edit_markup = ob_get_clean();
+check( 'edit correction is collapsed by default', false !== strpos( $edit_markup, '<details class="ec-topic-term-corrections">' ) );
+check( 'closed-topic edit uses the same edit-only correction path', false !== strpos( $edit_markup, 'Correct classifications (optional)' ) );
+check( 'all three correction mounts render only on edit', 3 === substr_count( $edit_markup, 'ec-term-picker-mount' ) );
+
+check(
+	'correction assets remain registered for conditional enqueue',
+	in_array( 'extrachill_community_enqueue_term_picker', $GLOBALS['_test_actions']['wp_enqueue_scripts'][20] ?? array(), true )
+);
+check(
+	'correction mounts retain the bbPress edit form hook',
+	in_array( 'extrachill_community_render_term_picker_mounts', $GLOBALS['_test_actions']['bbp_theme_before_topic_form_location'][10] ?? array(), true )
+);
+
+$source = file_get_contents( dirname( __DIR__ ) . '/src/term-picker/TermPicker.tsx' );
+check( 'client has no local taxonomy REST search path', false === strpos( $source, '/wp/v2/' ) );
+check( 'obsolete local-only empty result message is gone', false === strpos( $source, 'No matching terms' ) );
+
+$community_source = file_get_contents( dirname( __DIR__ ) . '/inc/content/editor/composer-term-picker.php' );
+check( 'Community does not schedule classification directly', false === strpos( $community_source, 'classify-post-terms' ) );
+foreach ( array( 'artist', 'festival', 'location' ) as $taxonomy ) {
+	$taxonomy_source = file_get_contents( dirname( __DIR__ ) . '/inc/core/taxonomy-' . $taxonomy . '.php' );
+	check( "{$taxonomy} correction does not run during topic creation", false === strpos( $taxonomy_source, "add_action( 'bbp_new_topic'" ) );
+	check( "{$taxonomy} correction remains available during topic edit", false !== strpos( $taxonomy_source, "add_action( 'bbp_edit_topic'" ) );
+}
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All topic term correction tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- remove artist, festival, and location fields from new-topic composers so publication relies on the network-owned asynchronous classification lifecycle
- retain a collapsed, edit-only correction section that searches `extrachill/search-network-terms`, projects approved identities through `extrachill/project-network-term`, and submits the returned Community-local IDs
- remove create-time taxonomy persistence hooks and obsolete local REST configuration while preserving taxonomy registration, archives, existing assignments, and edit handlers

## Behavior
Automatic classification remains owned by `extrachill-network`: Community neither imports Data Machine nor schedules or waits for its task. New topics publish through ordinary bbPress/WordPress status transitions without taxonomy work.

Existing and closed topics expose **Correct classifications (optional)** only on edit. Search uses approved network identities instead of Blog 2 term tables. Selecting an identity projects it into Community when needed, then assigns the ordinary local term ID on form submission. These manual assignments remain outside classifier-owned provenance and therefore retain human precedence under the network contract.

If the network ability runtime, search, or projection is unavailable, the correction UI reports that suggestions are unavailable while leaving existing hidden local IDs and normal topic editing intact. Topic creation never depends on the correction bundle or AI availability.

## Removed Obsolete Paths
- create-flow picker config, continuation preselection, and homepage/single-forum enqueue behavior
- local `/wp/v2/<taxonomy>` search and hierarchical parent lookup
- local REST base/hierarchy configuration
- `bbp_new_topic` taxonomy save hooks for artist, festival, and location
- local-only “No matching terms” messaging

The standalone picker bundle remains because it is the edit-only correction consumer. Taxonomy registration and archive behavior are unchanged.

## Verification
Passed:
- PHP syntax for all changed PHP files
- all standalone PHP test scripts
- `npm run test:js -- --runInBand` (18 tests)
- `npm run lint:js`
- focused stylesheet lint for `src/term-picker/style.scss`
- `npm run build`
- `git diff --check`
- Homeboy changed-since audit: zero introduced findings

Known repository/tooling baselines:
- repository-wide CSS lint reports 1,281 pre-existing style errors; the changed stylesheet passes focused lint
- `tsc --noEmit` reports existing block-editor declaration and unrelated block typing failures outside the term-picker source
- Homeboy's isolated PHPStan context does not load bbPress/theme runtime functions and reports 49 file-scoped findings; PHPCS and ESLint introduce no errors (the unchanged bbPress `moderate` capability warning remains)
- Homeboy's PHPUnit adapter reports zero discovered tests for this standalone-script/Jest repository; native PHP and JS suites pass directly

Closes #241