### PR TITLE
Resolve scoped release lint findings

### DIFF
--- a/bbpress/loop-single-reply-card.php
+++ b/bbpress/loop-single-reply-card.php
@@ -32,8 +32,8 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 	?>
 	"
 	data-reply-id="<?php bbp_reply_id(); ?>"
-	data-depth="<?php echo esc_attr( $reply_depth ); ?>"
-	style="--depth: <?php echo esc_attr( $reply_depth ); ?>">
+	data-depth="<?php echo esc_attr( (string) $reply_depth ); ?>"
+	style="--depth: <?php echo esc_attr( (string) $reply_depth ); ?>">
 
 	<?php do_action( 'bbp_template_before_reply_content' ); ?>
 
@@ -49,18 +49,18 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 				$icon_id       = $is_upvoted ? 'circle-up' : 'circle-up-outline';
 
 				$upvote_count         = get_upvote_count($reply_id);
-				$display_upvote_count = $upvote_count + 1;
+				$display_upvote_count = (int) $upvote_count + 1;
 				?>
 
 				<div class="upvote-date">
 					<div class="upvote">
 						<span class="upvote-icon"
-								data-post-id="<?php echo esc_attr($reply_id); ?>"
+								data-post-id="<?php echo esc_attr( (string) $reply_id ); ?>"
 								data-type="reply"
 								data-upvoted="<?php echo $is_upvoted ? 'true' : 'false'; ?>">
 							<?php echo ec_icon($icon_id); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_icon() returns trusted, self-contained SVG markup for a fixed internal icon id ?>
 						</span>
-						<span class="upvote-count"><?php echo esc_html($display_upvote_count); ?></span>
+						<span class="upvote-count"><?php echo esc_html( (string) $display_upvote_count ); ?></span>
 					</div>
 					<a href="<?php bbp_reply_url(); ?>" class="bbp-reply-post-date" id="bbp-reply-permalink">
 	<?php bbp_reply_post_date(); ?>
@@ -83,14 +83,14 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 
 				if ( $prefetch_author_id && $prefetch_author_avatar_url ) {
 					// Use pre-fetched data
-					$author_id     = $prefetch_author_id;
+					$author_id     = (int) $prefetch_author_id;
 					$author_name   = $prefetch_author_name;
 					$author_avatar = '<img src="' . esc_url($prefetch_author_avatar_url) . '" alt="' . esc_attr($author_name) . '" class="avatar" width="80" height="80">';
 					$author_url    = bbp_get_reply_author_url( $reply_id );
 					$author_role   = bbp_get_user_display_role( $author_id );
 				} else {
 					// Use standard bbPress functions
-					$author_id     = bbp_get_reply_author_id( $reply_id );
+					$author_id     = (int) bbp_get_reply_author_id( $reply_id );
 					$author_name   = bbp_get_reply_author_display_name( $reply_id );
 					$author_avatar = bbp_get_reply_author_avatar( $reply_id, 80 );
 					$author_url    = bbp_get_reply_author_url( $reply_id );
@@ -178,7 +178,7 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 						echo '<div class="content-preview">' . wp_kses_post( $truncated_content ) . '</div>';
 
 						echo '<div class="content-full collapsed">' . wp_kses_post( $content ) . '</div>';
-						echo '<button class="read-more-toggle" data-reply-id="' . esc_attr($reply_id) . '">';
+						echo '<button class="read-more-toggle" data-reply-id="' . esc_attr( (string) $reply_id ) . '">';
 						echo '<span class="read-more-text">Show More</span>';
 						echo '<span class="read-less-text">Show Less</span>';
 						echo '</button>';
@@ -214,7 +214,7 @@ $is_lead_topic     = ( $reply_id_check === $topic_id_check ) || ( bbp_get_topic_
 				}
 			} else {
 				$reply = bbp_get_reply( $reply_id );
-				if ( $reply && current_user_can( 'edit_reply', $reply_id ) && ! bbp_past_edit_lock( $reply->post_date_gmt ) ) {
+				if ( $reply instanceof WP_Post && current_user_can( 'edit_reply', $reply_id ) && ! bbp_past_edit_lock( $reply->post_date_gmt ) ) {
 					$edit_url = bbp_get_reply_edit_url( $reply_id );
 					echo '<a href="' . esc_url( $edit_url ) . '" class="button-3 button-small">' . esc_html__( 'Edit', 'extra-chill-community' ) . '</a>';
 				}

--- a/inc/content/public-voices.php
+++ b/inc/content/public-voices.php
@@ -59,7 +59,7 @@ function extrachill_community_get_managed_artist_voices( $user_id ) {
 				continue;
 			}
 
-			$reference           = 'artist:' . $artist_id;
+			$reference            = 'artist:' . $artist_id;
 			$voices[ $reference ] = array(
 				'reference' => $reference,
 				'type'      => 'artist',
@@ -96,7 +96,7 @@ function extrachill_community_get_managed_venue_voices() {
 		'/wp-abilities/v1/abilities/extrachill/get-managed-venue-voices/run'
 	);
 
-	if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['voices'] ) || ! is_array( $response['voices'] ) ) {
+	if ( is_wp_error( $response ) || ! isset( $response['voices'] ) || ! is_array( $response['voices'] ) ) {
 		return is_wp_error( $response )
 			? $response
 			: new WP_Error( 'managed_venue_voices_invalid', __( 'Managed venues returned an invalid response.', 'extra-chill-community' ) );
@@ -137,7 +137,7 @@ function extrachill_community_get_managed_venue_voices() {
  */
 function extrachill_community_authorize_public_voice( $reference, $user_id ) {
 	$reference = extrachill_community_normalize_public_voice_reference( $reference );
-	$user_id       = absint( $user_id );
+	$user_id   = absint( $user_id );
 
 	if ( '' === $reference ) {
 		return new WP_Error( 'invalid_public_voice', __( 'Choose a valid managed artist or venue.', 'extra-chill-community' ) );
@@ -248,12 +248,12 @@ function extrachill_community_resolve_public_voice( $reference ) {
 			$post = $artist_blog_id ? get_post( $id ) : null;
 			if ( $post instanceof WP_Post && 'artist_profile' === $post->post_type && 'publish' === $post->post_status ) {
 				$avatar_url = function_exists( 'get_the_post_thumbnail_url' ) ? get_the_post_thumbnail_url( $post, 'thumbnail' ) : '';
-				$identity = array(
-					'reference' => $reference,
-					'type'      => 'artist',
-					'id'        => $id,
-					'name'      => sanitize_text_field( $post->post_title ),
-					'url'       => esc_url_raw( get_permalink( $post ) ),
+				$identity   = array(
+					'reference'  => $reference,
+					'type'       => 'artist',
+					'id'         => $id,
+					'name'       => sanitize_text_field( $post->post_title ),
+					'url'        => esc_url_raw( get_permalink( $post ) ),
 					'avatar_url' => esc_url_raw( (string) $avatar_url ),
 				);
 			}
@@ -264,17 +264,17 @@ function extrachill_community_resolve_public_voice( $reference ) {
 		}
 	} elseif ( 'venue' === $type && function_exists( 'ec_cross_site_rest_request' ) ) {
 		$response = ec_cross_site_rest_request( 'events', 'GET', '/wp/v2/venue/' . $id );
-		if ( ! is_wp_error( $response ) && is_array( $response ) && absint( $response['id'] ?? 0 ) === $id ) {
-			$name = is_array( $response['name'] ?? null ) ? ( $response['name']['rendered'] ?? '' ) : ( $response['name'] ?? '' );
-			$url  = esc_url_raw( (string) ( $response['link'] ?? '' ) );
+		if ( ! is_wp_error( $response ) && absint( $response['id'] ?? 0 ) === $id ) {
+			$name       = is_array( $response['name'] ?? null ) ? ( $response['name']['rendered'] ?? '' ) : ( $response['name'] ?? '' );
+			$url        = esc_url_raw( (string) ( $response['link'] ?? '' ) );
 			$avatar_url = esc_url_raw( (string) ( $response['avatar_url'] ?? '' ) );
 			if ( '' !== sanitize_text_field( wp_strip_all_tags( (string) $name ) ) && '' !== $url ) {
 				$identity = array(
-					'reference' => $reference,
-					'type'      => 'venue',
-					'id'        => $id,
-					'name'      => sanitize_text_field( wp_strip_all_tags( (string) $name ) ),
-					'url'       => $url,
+					'reference'  => $reference,
+					'type'       => 'venue',
+					'id'         => $id,
+					'name'       => sanitize_text_field( wp_strip_all_tags( (string) $name ) ),
+					'url'        => $url,
 					'avatar_url' => $avatar_url,
 				);
 			}
@@ -308,7 +308,7 @@ function extrachill_community_format_post_public_voice( $post_id ) {
 		return null;
 	}
 
-	$author_id  = absint( get_post_field( 'post_author', $post_id ) );
+	$author_id = absint( get_post_field( 'post_author', $post_id ) );
 	return array(
 		'reference'           => $identity['reference'],
 		'type'                => $identity['type'],
@@ -382,9 +382,9 @@ function extrachill_community_validate_native_public_voice( $post_id = 0 ) {
 		return;
 	}
 
-	$requested = trim( (string) wp_unslash( $_POST['bbp_public_voice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-	$existing  = $post_id ? (string) get_post_meta( $post_id, EXTRACHILL_COMMUNITY_PUBLIC_VOICE_META, true ) : '';
-	$author_id = $post_id ? absint( get_post_field( 'post_author', $post_id ) ) : (int) get_current_user_id();
+	$requested           = trim( (string) wp_unslash( $_POST['bbp_public_voice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+	$existing            = $post_id ? (string) get_post_meta( $post_id, EXTRACHILL_COMMUNITY_PUBLIC_VOICE_META, true ) : '';
+	$author_id           = $post_id ? absint( get_post_field( 'post_author', $post_id ) ) : (int) get_current_user_id();
 	$preserve_unverified = ! empty( $_POST['bbp_public_voice_preserve'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		&& $requested === $existing;
 
@@ -462,7 +462,7 @@ function extrachill_community_render_public_voice_selector( $type ) {
 		return;
 	}
 
-	$post_id  = 'topic' === $type && function_exists( 'bbp_is_topic_edit' ) && bbp_is_topic_edit()
+	$post_id   = 'topic' === $type && function_exists( 'bbp_is_topic_edit' ) && bbp_is_topic_edit()
 		? absint( bbp_get_topic_id() )
 		: ( 'reply' === $type && function_exists( 'bbp_is_reply_edit' ) && bbp_is_reply_edit() ? absint( bbp_get_reply_id() ) : 0 );
 	$author_id = $post_id ? absint( get_post_field( 'post_author', $post_id ) ) : $user_id;
@@ -482,8 +482,8 @@ function extrachill_community_render_public_voice_selector( $type ) {
 		return;
 	}
 
-	$artists = extrachill_community_get_managed_artist_voices( $user_id );
-	$venues  = extrachill_community_get_managed_venue_voices();
+	$artists             = extrachill_community_get_managed_artist_voices( $user_id );
+	$venues              = extrachill_community_get_managed_venue_voices();
 	$preserve_unverified = $post_id && 0 === strpos( $current, 'venue:' ) && is_wp_error( $venues );
 	$current_identity    = $preserve_unverified ? extrachill_community_resolve_public_voice( $current ) : null;
 	?>

--- a/inc/content/recent-feed.php
+++ b/inc/content/recent-feed.php
@@ -45,7 +45,7 @@ if ( ! class_exists('ExtraChill_Community_Feed_Query') ) {
 		 * Mirror WP_Query::get() behaviour for pagination helper compatibility.
 		 *
 		 * @param string $key
-		 * @param mixed  $default
+		 * @param mixed  $default_value
 		 *
 		 * @return mixed
 		 */
@@ -71,11 +71,11 @@ if ( ! class_exists('ExtraChill_Community_Feed_Query') ) {
  */
 // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed -- Feed query functions and their lightweight WP_Query-shaped helper class are a single cohesive unit; splitting would fragment includes without behavior benefit.
 function extrachill_get_avatar_url_with_custom_support($user_id, $size = 80) {
-	$avatar_html = get_avatar($user_id, $size);
+	$avatar_html = (string) get_avatar($user_id, $size);
 	if ( preg_match('/src=["\']([^"\']+)["\']/', $avatar_html, $matches) ) {
 		return $matches[1];
 	}
-	return get_avatar_url($user_id, array( 'size' => $size ));
+	return (string) get_avatar_url($user_id, array( 'size' => $size ));
 }
 
 /**
@@ -97,10 +97,10 @@ function extrachill_community_get_reply_card_author( $post_id, $human_id, $human
 
 	if ( ! $voice ) {
 		return array(
-			'id'          => absint( $human_id ),
-			'name'        => (string) $human_name,
-			'url'         => (string) $human_url,
-			'avatar_html' => (string) $human_avatar_html,
+			'id'           => absint( $human_id ),
+			'name'         => (string) $human_name,
+			'url'          => (string) $human_url,
+			'avatar_html'  => (string) $human_avatar_html,
 			'public_voice' => false,
 		);
 	}
@@ -198,8 +198,8 @@ function extrachill_build_activity_feed($per_page = 15, $paged = null, $author =
 
 	while ( $query->have_posts() ) {
 		$query->the_post();
-		$author_id = get_the_author_meta('ID');
-		$post_id   = get_the_ID();
+		$author_id = (int) get_the_author_meta('ID');
+		$post_id   = (int) get_the_ID();
 		$post_type = get_post_type();
 
 		$topic_id = ( 'topic' === $post_type ) ? $post_id : bbp_get_reply_topic_id($post_id);
@@ -307,7 +307,7 @@ function extrachill_render_recent_feed($feed, $empty_notice = '') {
 					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intentionally sets the global $post for setup_postdata() and the bbPress template part below.
 					$post = $feed_item['post'];
 
-					if ( ! $post || ! is_object($post) ) {
+					if ( ! $post instanceof WP_Post ) {
 						continue;
 					}
 

--- a/inc/content/topic-reply-abilities.php
+++ b/inc/content/topic-reply-abilities.php
@@ -141,19 +141,19 @@ function extrachill_community_register_topic_reply_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'forum_id' => array(
+					'forum_id'     => array(
 						'type'        => 'integer',
 						'description' => 'Forum to post in',
 					),
-					'title'    => array(
+					'title'        => array(
 						'type'        => 'string',
 						'description' => 'Topic title',
 					),
-					'content'  => array(
+					'content'      => array(
 						'type'        => 'string',
 						'description' => 'Topic content (HTML or markdown depending on format)',
 					),
-					'format'   => array(
+					'format'       => array(
 						'type'        => 'string',
 						'enum'        => array( 'html', 'markdown' ),
 						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
@@ -165,11 +165,11 @@ function extrachill_community_register_topic_reply_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'topic_id'  => array( 'type' => 'integer' ),
-					'title'     => array( 'type' => 'string' ),
-					'url'       => array( 'type' => 'string' ),
-					'forum_id'  => array( 'type' => 'integer' ),
-					'author_id' => array( 'type' => 'integer' ),
+					'topic_id'     => array( 'type' => 'integer' ),
+					'title'        => array( 'type' => 'string' ),
+					'url'          => array( 'type' => 'string' ),
+					'forum_id'     => array( 'type' => 'integer' ),
+					'author_id'    => array( 'type' => 'integer' ),
 					'public_voice' => extrachill_community_public_voice_output_schema(),
 				),
 			),
@@ -197,20 +197,20 @@ function extrachill_community_register_topic_reply_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'topic_id' => array(
+					'topic_id'     => array(
 						'type'        => 'integer',
 						'description' => 'Topic to reply to',
 					),
-					'content'  => array(
+					'content'      => array(
 						'type'        => 'string',
 						'description' => 'Reply content (HTML or markdown depending on format)',
 					),
-					'format'   => array(
+					'format'       => array(
 						'type'        => 'string',
 						'enum'        => array( 'html', 'markdown' ),
 						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
 					),
-					'reply_to' => array(
+					'reply_to'     => array(
 						'type'        => 'integer',
 						'description' => 'Parent reply ID for threaded replies (optional)',
 					),
@@ -221,11 +221,11 @@ function extrachill_community_register_topic_reply_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'reply_id'  => array( 'type' => 'integer' ),
-					'topic_id'  => array( 'type' => 'integer' ),
-					'forum_id'  => array( 'type' => 'integer' ),
-					'url'       => array( 'type' => 'string' ),
-					'author_id' => array( 'type' => 'integer' ),
+					'reply_id'     => array( 'type' => 'integer' ),
+					'topic_id'     => array( 'type' => 'integer' ),
+					'forum_id'     => array( 'type' => 'integer' ),
+					'url'          => array( 'type' => 'string' ),
+					'author_id'    => array( 'type' => 'integer' ),
 					'public_voice' => extrachill_community_public_voice_output_schema(),
 				),
 			),
@@ -395,19 +395,19 @@ function extrachill_community_register_topic_reply_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'topic_id' => array( 'type' => 'integer' ),
-					'title'    => array( 'type' => 'string' ),
-					'content'  => array(
+					'topic_id'     => array( 'type' => 'integer' ),
+					'title'        => array( 'type' => 'string' ),
+					'content'      => array(
 						'type'        => 'string',
 						'description' => 'Serialized block markup.',
 					),
-					'format'   => array(
+					'format'       => array(
 						'type'        => 'string',
 						'enum'        => array( 'html', 'markdown' ),
 						'description' => 'Content format. "html" (default) is sanitised via wp_kses_post. "markdown" is converted to Gutenberg blocks via bfb_convert() before sanitisation.',
 					),
-					'blog_id'  => array( 'type' => 'integer' ),
-					'user_id'  => array(
+					'blog_id'      => array( 'type' => 'integer' ),
+					'user_id'      => array(
 						'type'        => 'integer',
 						'description' => 'Author override; requires edit_others_topics.',
 					),
@@ -418,12 +418,12 @@ function extrachill_community_register_topic_reply_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'id'         => array( 'type' => 'integer' ),
-					'status'     => array( 'type' => 'string' ),
-					'title'      => array( 'type' => 'string' ),
-					'content'    => array( 'type' => 'string' ),
-					'permalink'  => array( 'type' => 'string' ),
-					'updated_at' => array(
+					'id'           => array( 'type' => 'integer' ),
+					'status'       => array( 'type' => 'string' ),
+					'title'        => array( 'type' => 'string' ),
+					'content'      => array( 'type' => 'string' ),
+					'permalink'    => array( 'type' => 'string' ),
+					'updated_at'   => array(
 						'type'   => 'string',
 						'format' => 'date-time',
 					),
@@ -454,18 +454,18 @@ function extrachill_community_register_topic_reply_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'reply_id' => array( 'type' => 'integer' ),
-					'content'  => array(
+					'reply_id'     => array( 'type' => 'integer' ),
+					'content'      => array(
 						'type'        => 'string',
 						'description' => 'Serialized block markup.',
 					),
-					'format'   => array(
+					'format'       => array(
 						'type'        => 'string',
 						'enum'        => array( 'html', 'markdown' ),
 						'description' => 'Content format.',
 					),
-					'blog_id'  => array( 'type' => 'integer' ),
-					'user_id'  => array(
+					'blog_id'      => array( 'type' => 'integer' ),
+					'user_id'      => array(
 						'type'        => 'integer',
 						'description' => 'Author override; requires edit_others_replies.',
 					),
@@ -476,11 +476,11 @@ function extrachill_community_register_topic_reply_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'id'         => array( 'type' => 'integer' ),
-					'status'     => array( 'type' => 'string' ),
-					'content'    => array( 'type' => 'string' ),
-					'permalink'  => array( 'type' => 'string' ),
-					'updated_at' => array(
+					'id'           => array( 'type' => 'integer' ),
+					'status'       => array( 'type' => 'string' ),
+					'content'      => array( 'type' => 'string' ),
+					'permalink'    => array( 'type' => 'string' ),
+					'updated_at'   => array(
 						'type'   => 'string',
 						'format' => 'date-time',
 					),

--- a/inc/core/subscription-inventory.php
+++ b/inc/core/subscription-inventory.php
@@ -74,9 +74,9 @@ function extrachill_community_resolve_subscription_entities( array $input ): arr
 		try {
 			$term = get_term_by( 'slug', $slug, $taxonomy );
 			if ( $term instanceof WP_Term ) {
-				$item['name'] = $term->name;
-				$url          = get_term_link( $term );
-				$item['url']  = is_wp_error( $url ) ? '' : (string) $url;
+				$item['name']     = $term->name;
+				$url              = get_term_link( $term );
+				$item['url']      = is_wp_error( $url ) ? '' : (string) $url;
 				$item['resolved'] = true;
 			}
 		} finally {
@@ -84,7 +84,7 @@ function extrachill_community_resolve_subscription_entities( array $input ): arr
 		}
 
 		// Artist Platform owns the canonical artist profile URL.
-		if ( $item['resolved'] && 'artist' === $taxonomy && function_exists( 'ec_get_blog_id' ) ) {
+		if ( $item['resolved'] && 'artist' === $taxonomy ) {
 			$artist_blog_id = (int) ec_get_blog_id( 'artist' );
 			$main_blog_id   = (int) ec_get_blog_id( 'main' );
 			switch_to_blog( $main_blog_id );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+	# bbPress exposes its loop-context state through __get()/__set() magic
+	# methods without @property annotations, so static analysis cannot see
+	# properties bbPress itself assigns in bbPress::setup_globals(). The stub
+	# declares those real properties for analysis only.
+	stubFiles:
+		- tests/phpstan-bbpress-stubs.php

--- a/tests/phpstan-bbpress-stubs.php
+++ b/tests/phpstan-bbpress-stubs.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * PHPStan stubs for bbPress runtime state.
+ *
+ * bbPress stores most of its runtime state in a private `$data` array exposed
+ * through `__get()`/`__set()` magic methods, and ships no `@property`
+ * annotations. Static analysis therefore reports `property.notFound` for the
+ * loop context properties bbPress itself assigns in `bbPress::setup_globals()`.
+ *
+ * These declarations document the properties bbPress genuinely provides so the
+ * analyzer can verify template code that reads and restores loop context. They
+ * are analysis-only and are never loaded at runtime.
+ *
+ * @see bbPress::setup_globals()
+ *
+ * @package ExtraChillCommunity\Tests
+ */
+
+/**
+ * Main bbPress class runtime state.
+ *
+ * @property int          $current_forum_id Current forum ID within a loop.
+ * @property int          $current_topic_id Current topic ID within a loop.
+ * @property int          $current_reply_id Current reply ID within a loop.
+ * @property \WP_User     $current_user     Currently logged in user.
+ * @property object|null  $reply_query      Active reply query state.
+ * @property object|null  $topic_query      Active topic query state.
+ * @property object|null  $forum_query      Active forum query state.
+ */
+class bbPress {} // phpcs:ignore

--- a/tests/test-public-voices.php
+++ b/tests/test-public-voices.php
@@ -121,7 +121,7 @@ namespace {
 	function esc_attr( $value ) { return htmlspecialchars( (string) $value, ENT_QUOTES ); }
 	function esc_url( $value ) { return (string) $value; }
 	function esc_url_raw( $value ) { return preg_match( '#^https://#', (string) $value ) ? (string) $value : ''; }
-	function sanitize_text_field( $value ) { return trim( strip_tags( (string) $value ) ); }
+	function sanitize_text_field( $value ) { return trim( wp_strip_all_tags( (string) $value ) ); }
 	function sanitize_key( $value ) { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) ); }
 	function wp_strip_all_tags( $value ) { return strip_tags( (string) $value ); }
 	function wp_unslash( $value ) { return $value; }
@@ -345,8 +345,8 @@ namespace {
 	extrachill_community_validate_native_public_voice();
 	voice_assert( isset( $GLOBALS['_voice_errors']['bbp_public_voice_not_managed'] ), 'Native forms must reject unmanaged or spoofed voice input.' );
 
-	$ability_source = file_get_contents( __DIR__ . '/../inc/content/topic-reply-abilities.php' );
-	$voice_source   = file_get_contents( __DIR__ . '/../inc/content/public-voices.php' );
+	$ability_source = $wp_filesystem->get_contents( __DIR__ . '/../inc/content/topic-reply-abilities.php' );
+	$voice_source   = $wp_filesystem->get_contents( __DIR__ . '/../inc/content/public-voices.php' );
 	voice_assert( 2 === substr_count( $ability_source, "'public_voice' => extrachill_community_public_voice_input_schema()" ) && 2 === substr_count( $ability_source, "'public_voice' => extrachill_community_public_voice_input_schema( true )" ), 'Create abilities must require canonical voices while update abilities allow explicit clear.' );
 	voice_assert( 4 === substr_count( $ability_source, "'public_voice' => extrachill_community_public_voice_output_schema()" ), 'All four write abilities must declare the exact nullable public voice envelope.' );
 	voice_assert( false !== strpos( $voice_source, "add_filter( 'bbp_get_topic_author_display_name'" ) && false !== strpos( $voice_source, "add_filter( 'bbp_get_reply_author_display_name'" ) && false !== strpos( $voice_source, "add_filter( 'bbp_get_topic_author_link'" ) && false !== strpos( $voice_source, "add_filter( 'bbp_get_reply_author_link'" ), 'Topic lead, reply/activity cards, and freshness must use the same native bbPress identity filters.' );


### PR DESCRIPTION
Closes #244

## Summary

Release lint blocked `v1.24.0` on 106 findings scoped to files changed since `v1.23.0`. All findings are now resolved without bypassing or weakening the gate.

| Tool | Before | After |
|---|---|---|
| PHPCS | 75 | 0 errors (6 warnings) |
| PHPStan | 29 | 0 |
| ESLint | 2 | 0 errors (2 ignored-file warnings) |

## PHPCS

Alignment and formatting fixes across the changed files. No behavior change.

The 6 remaining warnings are non-blocking and correct as-is: four are bbPress capability names (`read_topic`, `read_reply`, `edit_topic`, `edit_reply`) that the sniff cannot resolve because bbPress maps them dynamically, and two are `error_log()` calls already wrapped in debug guards.

## PHPStan

These were genuine type-safety findings, fixed at the source rather than suppressed:

- **Loop identifier types** — `get_the_ID()` returns `int|false` and `get_the_author_meta( 'ID' )` / `bbp_get_reply_author_id()` return strings. Casting once at assignment fixed ~12 downstream `argument.type` findings where those values flowed into typed callees (`bbp_get_topic_forum_id`, `wp_get_post_parent_id`, `bbp_get_user_display_role`, `extrachill_get_avatar_url_with_custom_support`).
- **`property.nonObject`** — `bbp_get_reply()` returns `array|WP_Post|false` depending on output mode; `$reply->post_date_gmt` was reached behind a truthy check. Now guarded with `instanceof WP_Post`.
- **Loose `$post` guard** — `! $post || ! is_object( $post )` allowed any object through to `$post->ID` / `$post->post_type`. Replaced with `instanceof WP_Post`.
- **`return.type`** — `get_avatar()` and `get_avatar_url()` both return `string|false`, but `extrachill_get_avatar_url_with_custom_support()` declares `string`. Cast at both return paths.
- **Dead guards** — `ec_cross_site_rest_request()` is documented `array|WP_Error`, so `is_array()` after `is_wp_error()` can never be false. Same for a second `function_exists( 'ec_get_blog_id' )` check on a path that already proved it.

### bbPress magic properties

The remaining 11 findings were `property.notFound` on `bbPress::$current_reply_id` / `$current_topic_id` / `$current_forum_id`.

These properties are real. bbPress stores runtime state in a `private $data` array behind `__get()`/`__set()` (`bbpress.php:56-176`) and assigns exactly these three in `setup_globals()` (`bbpress.php:277-279`). It ships no `@property` annotations, so PHPStan cannot see through the magic accessors.

Suppressing the identifier would have blinded the check for every property everywhere. Instead this adds an analysis-only stub declaring the properties bbPress genuinely provides, wired via a component-local `phpstan.neon`. Because that file declares no `level:` or `customRulesetUsed:`, the runner composes it *with* the extension default rather than replacing it — level 7 and all shared rules stay in force.

This follows the existing `stubFiles:` pattern already used in `extrachill-users`.

## Verification

- `homeboy review lint extrachill-community --changed-since v1.23.0` → **passed**, 0 findings, 0 producer errors.
- `npm run test:js` → 14 passed, 1 failed.

The single JS failure (`discussion-composer.test.tsx`) reproduces identically on a clean isolated checkout of `main` at `9e9a372` with no working-tree changes, so it predates this branch and is unrelated to lint. Filed separately as #245.