### PR TITLE
Resolve release lint findings from merged topic classification

### DIFF
--- a/bbpress/form-topic.php
+++ b/bbpress/form-topic.php
@@ -146,14 +146,14 @@ if ( ! bbp_is_single_forum() ) : ?>
 
 					<?php endif; ?>
 
-					<?php if ( bbp_is_subscriptions_active() && ! bbp_is_anonymous() && ( ! bbp_is_topic_edit() || ( bbp_is_topic_edit() && ! bbp_is_topic_anonymous() ) ) ) : ?>
+					<?php if ( bbp_is_subscriptions_active() && ! bbp_is_anonymous() && ( ! bbp_is_topic_edit() || ! bbp_is_topic_anonymous() ) ) : ?>
 
 						<?php do_action( 'bbp_theme_before_topic_form_subscriptions' ); ?>
 
 						<p>
 							<input name="bbp_topic_subscription" id="bbp_topic_subscription" type="checkbox" value="bbp_subscribe" <?php bbp_form_topic_subscribed(); ?> />
 
-							<?php if ( bbp_is_topic_edit() && ( bbp_get_topic_author_id() !== bbp_get_current_user_id() ) ) : ?>
+							<?php if ( bbp_is_topic_edit() && ( (int) bbp_get_topic_author_id() !== (int) bbp_get_current_user_id() ) ) : ?>
 
 								<label for="bbp_topic_subscription"><?php esc_html_e( 'Notify the author of follow-up replies via email', 'extra-chill-community' ); ?></label>
 

--- a/inc/content/editor/composer-term-picker.php
+++ b/inc/content/editor/composer-term-picker.php
@@ -133,7 +133,7 @@ add_action( 'init', 'extrachill_community_publish_discussion_composer_contract',
  * and the slug must resolve to an existing REST-enabled topic term.
  *
  * @param array<string,mixed>|null $query Query values, or null for the request.
- * @return array{taxonomy:string,term:object}|null Valid continuation state.
+ * @return array{taxonomy:string,term:WP_Term}|null Valid continuation state.
  */
 function extrachill_community_get_discussion_composer_state( $query = null ) {
 	$contract = extrachill_community_discussion_composer_contract();
@@ -171,7 +171,7 @@ function extrachill_community_get_discussion_composer_state( $query = null ) {
 	}
 
 	$term = get_term_by( 'slug', $slug, $taxonomy );
-	if ( ! $term || is_wp_error( $term ) ) {
+	if ( ! $term instanceof WP_Term ) {
 		return null;
 	}
 
@@ -383,7 +383,7 @@ function extrachill_community_enqueue_term_picker() {
 			'extrachill-community-term-picker',
 			EXTRACHILL_COMMUNITY_PLUGIN_URL . $style_rel,
 			array(),
-			filemtime( $style_path )
+			(string) filemtime( $style_path )
 		);
 	}
 }

--- a/inc/core/taxonomy-location.php
+++ b/inc/core/taxonomy-location.php
@@ -170,7 +170,7 @@ function extrachill_community_append_location_links_to_description( $description
 	}
 
 	$forum_id       = bbp_get_forum_id();
-	$has_subforums  = ! empty( bbp_forum_get_subforums( $forum_id ) );
+	$has_subforums  = ! empty( bbp_forum_get_subforums( array( 'post_parent' => $forum_id ) ) );
 	$location_terms = get_the_terms( $forum_id, 'location' );
 	$button_html    = '';
 

--- a/scripts/smoke-artist-topic-taxonomy.php
+++ b/scripts/smoke-artist-topic-taxonomy.php
@@ -7,7 +7,7 @@
  * @package ExtraChillCommunity
  */
 
-if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+if ( ! defined( 'ABSPATH' ) || ! defined( 'WP_CLI' ) ) {
 	exit( 1 );
 }
 
@@ -32,9 +32,10 @@ if ( false !== has_action( 'bbp_new_topic', 'extrachill_community_save_topic_art
 	WP_CLI::error( 'Artist persistence must be registered for edits only.' );
 }
 
-$query                   = new WP_Query();
-$query->is_tax           = true;
-$query->queried_object   = (object) array( 'taxonomy' => 'artist' );
+$artist_term           = new WP_Term( (object) array( 'taxonomy' => 'artist' ) );
+$query                 = new WP_Query();
+$query->is_tax         = true;
+$query->queried_object = $artist_term;
 $previous_wp_query     = $GLOBALS['wp_query'];
 $previous_wp_the_query = $GLOBALS['wp_the_query'];
 // phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- Smoke script intentionally swaps the main query to simulate an artist archive request, then restores it below.


### PR DESCRIPTION
Refs #244

## Summary

After #246 cleared the original 106 findings, #242 and #237 merged and pulled additional files into the release scope, carrying 9 fresh PHPStan level 7 findings that block the `v1.24.0` preflight gate.

Lint now passes with 0 findings.

## Findings fixed

**`bbpress/form-topic.php` — a real latent bug.** `bbp_get_topic_author_id() !== bbp_get_current_user_id()` compared a string against an int with a strict operator, so it was *always* true and the author-specific subscription label could never render. Both sides are now cast to `int`. Also dropped a redundant nested `bbp_is_topic_edit()` inside a branch that had already proven it.

**`inc/content/editor/composer-term-picker.php`** — the continuation state docblock declared `term:object`, erasing the `WP_Term` type and making `$term->slug` unprovable at two call sites. Tightened to `term:WP_Term` and replaced `! $term || is_wp_error( $term )` with `! $term instanceof WP_Term` — `get_term_by()` returns `WP_Term|array|false` and never a `WP_Error`, so the old check was impossible by construction. Also cast `filemtime()` for `wp_enqueue_style( $ver )`, which rejects `int|false`.

**`inc/core/taxonomy-location.php`** — `bbp_forum_get_subforums()` is typed `array $args` but accepts a numeric id at runtime via an internal `is_numeric()` branch. Passing the documented `array( 'post_parent' => $forum_id )` shape is both correct and clearer than casting.

**`scripts/smoke-artist-topic-taxonomy.php`** — assigned an anonymous `stdClass` to `WP_Query::$queried_object`, which is typed `WP_Post|WP_Post_Type|WP_Term|WP_User|null`. Now constructs a real `WP_Term`. Also removed a `! WP_CLI` negation that PHPStan proved always false given the preceding `defined()` guard.

## Verification

- `homeboy review lint extrachill-community --changed-since v1.23.0` → **passed**, 0 findings, 0 producer errors.
- `npm run test:js` → **4 suites, 18 tests, all passing**.

Note: #245 (the `discussion-composer.test.tsx` failure I filed while working #244) was fixed upstream by #242 and is now closed — the suite is fully green.