### PR TITLE
Resolve bbPress validation dependency to the real plugin

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -2,7 +2,11 @@
   "auto_cleanup": false,
   "changelog_target": "docs/CHANGELOG.md",
   "extensions": {
-    "wordpress": {}
+    "wordpress": {
+      "settings": {
+        "validation_dependencies": "/var/www/extrachill.com/wp-content/plugins/bbpress"
+      }
+    }
   },
   "extract_command": "unzip -o {{artifact}} && rm {{artifact}}",
   "id": "extrachill-community",


### PR DESCRIPTION
Unblocks the `v1.24.0` release preflight. Upstream fix tracked at Extra-Chill/homeboy-extensions#2474.

## Problem

The release `preflight.test` gate fataled:

```
Failed to activate extra plugin bbpress/bbpress.php: The plugin does not have a valid header.
in /internal/eval.php:284
```

This plugin declares `Requires Plugins: bbpress`, which the WordPress extension auto-discovers as a validation dependency. Resolution checks **direct path first**, anchoring relative slugs to the component root — so `bbpress` matched *this repo's own* `bbpress/` directory.

That directory is a bbPress **theme-compat template override**, the standard convention for overriding bbPress templates from a plugin or theme. Its `bbpress.php` is a page template, not a plugin:

```php
<?php
/*
 * Template Name: bbPress Template
 */
get_header();
```

Sandbox recipe evidence confirms the wrong mount:

```json
{ "slug": "bbpress", "pluginFile": "bbpress/bbpress.php",
  "target": "/wordpress/wp-content/plugins/bbpress", "loadAs": "plugin" }
```

## Second, quieter symptom

The same misresolution was silently degrading PHPStan. The lint runner logged:

```
Resolved dependency 'bbpress' via direct path: /var/lib/datamachine/workspace/extrachill-community/bbpress
```

Since the template directory defines no bbPress symbols, analysis ran against an effectively absent dependency. This is worse than the fatal — lint *appeared* to work while emitting findings that were artifacts of the missing plugin.

## Fix

Point `validation_dependencies` at the installed bbPress plugin explicitly. Settings-declared dependencies take priority over header auto-discovery, so this bypasses the shadowing.

## Verification

```
Resolved dependency '/var/www/extrachill.com/wp-content/plugins/bbpress' via direct path:
  /var/www/extrachill.com/wp-content/plugins/bbpress
```

- `homeboy review lint extrachill-community --changed-since v1.23.0` → **passed**, 0 findings.
- `npm run test:js` → 4 suites, 18 tests passing.

## On the PHPStan stub

I re-tested whether `phpstan.neon` + `tests/phpstan-bbpress-stubs.php` (added in #246) were merely papering over this misresolution. With the real plugin correctly resolved, removing them still produces **6 `property.notFound` errors** — bbPress stores loop state in a `private $data` array behind `__get()`/`__set()` and ships no `@property` annotations, so PHPStan cannot see those properties even with the genuine source present. The stub is independently justified and stays.

## Upstream

The general fix belongs in homeboy-extensions: the direct-path branch should require a candidate directory to be plugin-shaped (a root PHP file with a `Plugin Name:` header) before accepting it, and otherwise continue down the resolution chain. Filed as Extra-Chill/homeboy-extensions#2474. This PR is the consumer-side unblock.