### PR TITLE
refactor: migrate community notifications to receipts

### DIFF
--- a/docs/social/notifications.md
+++ b/docs/social/notifications.md
@@ -21,8 +21,8 @@ Receive notifications when other users reply to your forum topics.
 ### Mention Notifications
 Receive notifications when users mention you with @username in forum content.
 
-### Future Types
-Notification system extensible for additional event types via `extrachill_notify` action hook.
+### Additional Types
+Topic subscriptions and festival or artist discussions also create notifications.
 
 ## Notification Components
 
@@ -59,31 +59,29 @@ Notifications are marked as read when the user loads the `/notifications` page.
 
 ## Data Storage
 
-### User Meta
-All notifications stored in `extrachill_notifications` user meta as serialized array.
+### Network Table
+Notifications are stored in the network-wide notifications table owned by Extra Chill Users.
 
 ### Notification Structure
 ```php
 [
-    'actor_id' => 123,
-    'actor_display_name' => 'Username',
-    'actor_profile_link' => 'https://community.extrachill.com/users/username',
-    'type' => 'reply',
-    'link' => 'https://community.extrachill.com/forums/topic/...',
-    'topic_title' => 'Topic Title',
-    'time' => '2025-10-06 12:00:00',
-    'read' => false
+    'actor_id'        => 123,
+    'type'            => 'reply',
+    'title'           => 'Topic Title',
+    'link'            => 'https://community.extrachill.com/forums/topic/...',
+    'item_id'         => 456,
+    'producer'        => 'extrachill-community/replies',
+    'idempotency_key' => 'reply:789',
 ]
 ```
 
-### Notification Cache
-Global cache variable `$extrachill_notifications_cache` prevents duplicate database queries during single page load.
+The producer and idempotency key pair prevents duplicate rows when a bbPress hook is replayed.
 
-## Action Hooks
+## Notification Service
 
 ### Notification Trigger
 ```php
-do_action('extrachill_notify', $user_ids, $notification_data);
+ec_users_notify_with_receipts( $user_ids, $notification_data );
 ```
 
 **Parameters**:
@@ -92,21 +90,20 @@ do_action('extrachill_notify', $user_ids, $notification_data);
   - `actor_id` (int): User ID who triggered notification
   - `type` (string): Notification type identifier
   - `link` (string): URL to notification target
-  - `topic_title` (string): Title/subject of notification
+  - `title` (string): Title/subject of notification
+  - `item_id` (int): Related topic, reply, or content ID
+  - `producer` (string): Feature-owned producer namespace
+  - `idempotency_key` (string): Stable key derived from the triggering content ID
 
-### Handler Registration
-Notification handler registered on `extrachill_notify` action hook with automatic actor enrichment.
+The receipt reports inserted, existing, and failed deliveries per recipient. Entity-topic post-meta claims are released only when a receipt explicitly reports a failed delivery.
 
 ## Performance Optimization
 
-### Single Query Per Page
-Notifications cached in global variable after first database query.
-
 ### Unread Count Calculation
-Unread count calculated from cached array without additional queries.
+Unread counts are cached by Extra Chill Users and invalidated when rows are inserted.
 
 ### Scheduled Cleanup
-Old notifications removed via cron to prevent meta table bloat.
+Old notifications are removed via cron to prevent table bloat.
 
 ## Usage Patterns
 

--- a/inc/social/notifications/capture-festival-topics.php
+++ b/inc/social/notifications/capture-festival-topics.php
@@ -11,6 +11,8 @@ defined( 'ABSPATH' ) || exit;
  * Community's stable entity-subscription producer identifier.
  */
 const EXTRACHILL_COMMUNITY_TOPIC_NOTIFICATION_PRODUCER    = 'extrachill-community';
+const EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER = 'extrachill-community/festival-topics';
+const EXTRACHILL_COMMUNITY_ARTIST_NOTIFICATION_PRODUCER   = 'extrachill-community/artist-topics';
 const EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META   = '_extrachill_community_festival_topic_notified';
 const EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META     = '_extrachill_community_artist_topic_notified';
 
@@ -36,7 +38,7 @@ add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrach
  * @return void
  */
 function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
-	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 		return;
 	}
 
@@ -82,21 +84,27 @@ function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
 	}
 
 	// Claim before delivery so concurrent bbPress hooks cannot duplicate notices.
-	// The claim remains when delivery inserts no rows, making retries at-most-once.
+	// Release the claim only when the receipt explicitly reports a failure.
 	if ( ! add_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META, current_time( 'mysql', true ), true ) ) {
 		return;
 	}
 
-	ec_users_notify(
+	$receipt = ec_users_notify_with_receipts(
 		$recipients,
 		array(
-			'actor_id' => $author_id,
-			'type'     => 'festival_discussion',
-			'title'    => get_the_title( $topic_id ),
-			'link'     => function_exists( 'bbp_get_topic_permalink' ) ? bbp_get_topic_permalink( $topic_id ) : get_permalink( $topic_id ),
-			'item_id'  => $topic_id,
+			'actor_id'        => $author_id,
+			'type'            => 'festival_discussion',
+			'title'           => get_the_title( $topic_id ),
+			'link'            => function_exists( 'bbp_get_topic_permalink' ) ? bbp_get_topic_permalink( $topic_id ) : get_permalink( $topic_id ),
+			'item_id'         => $topic_id,
+			'producer'        => EXTRACHILL_COMMUNITY_FESTIVAL_NOTIFICATION_PRODUCER,
+			'idempotency_key' => 'topic:' . $topic_id,
 		)
 	);
+
+	if ( is_array( $receipt ) && 0 < absint( $receipt['failed'] ?? 0 ) ) {
+		delete_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META );
+	}
 }
 add_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscribers', 30 );
 
@@ -110,7 +118,7 @@ add_action( 'bbp_new_topic', 'extrachill_community_notify_festival_topic_subscri
  * @return void
  */
 function extrachill_community_notify_artist_topic_subscribers( $topic_id ) {
-	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify' ) ) {
+	if ( ! function_exists( 'extrachill_users_entity_subscription_recipients' ) || ! function_exists( 'ec_users_notify_with_receipts' ) ) {
 		return;
 	}
 
@@ -155,20 +163,26 @@ function extrachill_community_notify_artist_topic_subscribers( $topic_id ) {
 	}
 
 	// Claim before delivery so concurrent bbPress hooks cannot duplicate notices.
-	// The claim remains when delivery inserts no rows, making retries at-most-once.
+	// Release the claim only when the receipt explicitly reports a failure.
 	if ( ! add_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META, current_time( 'mysql', true ), true ) ) {
 		return;
 	}
 
-	ec_users_notify(
+	$receipt = ec_users_notify_with_receipts(
 		$recipients,
 		array(
-			'actor_id' => $author_id,
-			'type'     => 'artist_discussion',
-			'title'    => get_the_title( $topic_id ),
-			'link'     => function_exists( 'bbp_get_topic_permalink' ) ? bbp_get_topic_permalink( $topic_id ) : get_permalink( $topic_id ),
-			'item_id'  => $topic_id,
+			'actor_id'        => $author_id,
+			'type'            => 'artist_discussion',
+			'title'           => get_the_title( $topic_id ),
+			'link'            => function_exists( 'bbp_get_topic_permalink' ) ? bbp_get_topic_permalink( $topic_id ) : get_permalink( $topic_id ),
+			'item_id'         => $topic_id,
+			'producer'        => EXTRACHILL_COMMUNITY_ARTIST_NOTIFICATION_PRODUCER,
+			'idempotency_key' => 'topic:' . $topic_id,
 		)
 	);
+
+	if ( is_array( $receipt ) && 0 < absint( $receipt['failed'] ?? 0 ) ) {
+		delete_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META );
+	}
 }
 add_action( 'bbp_new_topic', 'extrachill_community_notify_artist_topic_subscribers', 30 );

--- a/inc/social/notifications/capture-mentions.php
+++ b/inc/social/notifications/capture-mentions.php
@@ -25,6 +25,10 @@ if ( ! defined('ABSPATH') ) {
  * @param int   $reply_author   Reply author ID (0 for topics)
  */
 function extrachill_capture_mention_notifications($post_id, $topic_id, $forum_id, $anonymous_data, $reply_author = 0) {
+	if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+		return;
+	}
+
 	// Get content based on context (topic or reply)
 	$content = ( 0 === $reply_author ) ? bbp_get_topic_content($post_id) : bbp_get_reply_content($post_id);
 
@@ -44,15 +48,19 @@ function extrachill_capture_mention_notifications($post_id, $topic_id, $forum_id
 
 		// Validate user exists, is active, and isn't mentioning themselves
 		if ( $user && ! bbp_is_user_inactive($user->ID) && $user->ID !== $action_author_id ) {
-			// Send mention notification
-			do_action('extrachill_notify', $user->ID, array(
-				'actor_id'    => $action_author_id,
-				'type'        => 'mention',
-				'topic_title' => get_the_title($actual_topic_id_for_context),
-				'link'        => ( 0 === $reply_author ) ? get_permalink($actual_item_id_for_context) : bbp_get_reply_url($actual_item_id_for_context),
-				'post_id'     => $actual_topic_id_for_context,
-				'item_id'     => $actual_item_id_for_context,
-			));
+			// Send mention notification.
+			ec_users_notify_with_receipts(
+				$user->ID,
+				array(
+					'actor_id'        => $action_author_id,
+					'type'            => 'mention',
+					'title'           => get_the_title($actual_topic_id_for_context),
+					'link'            => ( 0 === $reply_author ) ? get_permalink($actual_item_id_for_context) : bbp_get_reply_url($actual_item_id_for_context),
+					'item_id'         => $actual_item_id_for_context,
+					'producer'        => 'extrachill-community/mentions',
+					'idempotency_key' => 'content:' . (int) $actual_item_id_for_context,
+				)
+			);
 
 			// Priority deduplication: if the mentioned user is the topic author,
 			// remove the (more generic) reply notification the reply-capture

--- a/inc/social/notifications/capture-replies.php
+++ b/inc/social/notifications/capture-replies.php
@@ -25,6 +25,10 @@ if ( ! defined('ABSPATH') ) {
  * @param int   $reply_author   Reply author user ID
  */
 function extrachill_capture_reply_notifications($reply_id, $topic_id, $forum_id, $anonymous_data, $reply_author) {
+	if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+		return;
+	}
+
 	// Prevent self-notification (author replying to own topic)
 	if ( get_post_field('post_author', $topic_id) === $reply_author ) {
 		return;
@@ -35,14 +39,19 @@ function extrachill_capture_reply_notifications($reply_id, $topic_id, $forum_id,
 	$topic_title  = get_the_title($topic_id);
 	$reply_link   = bbp_get_reply_url($reply_id);
 
-	// Send reply notification (mention handler will deduplicate if needed)
-	do_action('extrachill_notify', $topic_author, array(
-		'actor_id'    => $reply_author,
-		'type'        => 'reply',
-		'topic_title' => $topic_title,
-		'link'        => $reply_link,
-		'post_id'     => $topic_id,
-	));
+	// Send reply notification (mention handler will deduplicate if needed).
+	ec_users_notify_with_receipts(
+		$topic_author,
+		array(
+			'actor_id'        => $reply_author,
+			'type'            => 'reply',
+			'title'           => $topic_title,
+			'link'            => $reply_link,
+			'item_id'         => $topic_id,
+			'producer'        => 'extrachill-community/replies',
+			'idempotency_key' => 'reply:' . (int) $reply_id,
+		)
+	);
 }
 
 // Hook into bbPress actions (priority 10 - before mentions at priority 12)

--- a/inc/social/notifications/capture-subscriptions.php
+++ b/inc/social/notifications/capture-subscriptions.php
@@ -6,8 +6,8 @@
  *
  * - Auto-subscribes a reply author to the topic (gated on the user preference
  *   provided by extrachill-users).
- * - Notifies all other topic subscribers when a new reply lands, routed through
- *   the shared extrachill_notify action into the network notification substrate.
+ * - Notifies all other topic subscribers when a new reply lands through the
+ *   receipt-aware network notification service.
  * - Disables bbPress's parallel subscription emails so all email flows through
  *   the existing extrachill-users digest sweep.
  *
@@ -39,6 +39,10 @@ if ( ! defined('ABSPATH') ) {
  * @param int   $reply_author   Reply author user ID.
  */
 function extrachill_capture_subscription_notifications( $reply_id, $topic_id, $forum_id, $anonymous_data, $reply_author ) {
+	if ( ! function_exists( 'ec_users_notify_with_receipts' ) ) {
+		return;
+	}
+
 	// Bail if bbPress subscriptions are disabled site-wide.
 	if ( ! function_exists( 'bbp_is_subscriptions_active' ) || ! bbp_is_subscriptions_active() ) {
 		return;
@@ -92,18 +96,18 @@ function extrachill_capture_subscription_notifications( $reply_id, $topic_id, $f
 	$topic_title = get_the_title( $topic_id );
 	$reply_link  = bbp_get_reply_url( $reply_id );
 
-	// Fire through the shared action; the extrachill-users substrate accepts a
-	// recipient array and inserts one notification row per user. Payload keys
-	// follow the legacy shape used by capture-replies/capture-mentions; the
-	// substrate reads topic_title/post_id with item_id as the canonical key.
-	do_action( 'extrachill_notify', $recipients, array(
-		'actor_id'    => $reply_author,
-		'type'        => 'subscription',
-		'topic_title' => $topic_title,
-		'link'        => $reply_link,
-		'item_id'     => $topic_id,
-		'post_id'     => $topic_id,
-	) );
+	ec_users_notify_with_receipts(
+		$recipients,
+		array(
+			'actor_id'        => $reply_author,
+			'type'            => 'subscription',
+			'title'           => $topic_title,
+			'link'            => $reply_link,
+			'item_id'         => $topic_id,
+			'producer'        => 'extrachill-community/topic-subscriptions',
+			'idempotency_key' => 'reply:' . $reply_id,
+		)
+	);
 }
 
 // Hook into bbPress actions (priority 11 - between reply@10 and mention@12).

--- a/tests/test-notification-receipts.php
+++ b/tests/test-notification-receipts.php
@@ -1,0 +1,176 @@
+<?php
+/** Standalone contract tests for receipt-aware community notification producers. */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+$GLOBALS['_notification_calls'] = array();
+$GLOBALS['_post_meta']          = array();
+$GLOBALS['_receipt']            = array( 'failed' => 0 );
+
+function add_action() {}
+function add_filter() {}
+function remove_action() {}
+function absint( $value ) {
+	return abs( (int) $value );
+}
+function current_time() {
+	return '2026-07-29 12:00:00';
+}
+function get_post_field( $field, $post_id ) {
+	return 100 === (int) $post_id ? 10 : 20;
+}
+function get_the_title( $post_id ) {
+	return 'Topic ' . (int) $post_id;
+}
+function get_permalink( $post_id ) {
+	return 'https://community.example/topic/' . (int) $post_id;
+}
+function bbp_get_reply_url( $reply_id ) {
+	return 'https://community.example/reply/' . (int) $reply_id;
+}
+function bbp_get_topic_permalink( $topic_id ) {
+	return 'https://community.example/topic/' . (int) $topic_id;
+}
+function bbp_get_topic_content() {
+	return '@topic-author welcome';
+}
+function bbp_get_reply_content() {
+	return '@topic-author thanks';
+}
+function bbp_is_user_inactive() {
+	return false;
+}
+function get_user_by( $field, $username ) {
+	return 'topic-author' === $username ? (object) array( 'ID' => 10 ) : false;
+}
+function bbp_is_subscriptions_active() {
+	return true;
+}
+function ec_users_auto_subscribe_enabled() {
+	return true;
+}
+function bbp_add_user_subscription( $user_id, $topic_id ) {
+	$GLOBALS['_subscribed'] = array( $user_id, $topic_id );
+}
+function bbp_get_subscribers() {
+	return array( 20, 10, 30, '30', 40, 0 );
+}
+function ec_users_notify_with_receipts( $recipients, array $payload ) {
+	$GLOBALS['_notification_calls'][] = array( $recipients, $payload );
+	return $GLOBALS['_receipt'];
+}
+function extrachill_users_notifications_table_name() {
+	return 'wp_notifications';
+}
+function bbp_get_public_status_id() {
+	return 'publish';
+}
+function get_post_status() {
+	return 'publish';
+}
+function get_post_meta( $post_id, $key ) {
+	return $GLOBALS['_post_meta'][ $post_id ][ $key ] ?? '';
+}
+function add_post_meta( $post_id, $key, $value ) {
+	if ( isset( $GLOBALS['_post_meta'][ $post_id ][ $key ] ) ) {
+		return false;
+	}
+	$GLOBALS['_post_meta'][ $post_id ][ $key ] = $value;
+	return true;
+}
+function delete_post_meta( $post_id, $key ) {
+	unset( $GLOBALS['_post_meta'][ $post_id ][ $key ] );
+	$GLOBALS['_deleted_meta'][] = array( $post_id, $key );
+	return true;
+}
+function get_the_terms( $post_id, $taxonomy ) {
+	return array( (object) array( 'slug' => $taxonomy . '-slug' ) );
+}
+function is_wp_error() {
+	return false;
+}
+function extrachill_users_entity_subscription_recipients( $producer, $entity_type ) {
+	return 'festival' === $entity_type ? array( 20, 30, 30 ) : array( 20, 40 );
+}
+
+class Notification_Test_DB {
+	public $queries = array();
+
+	public function prepare( $query, ...$args ) {
+		$this->queries[] = array( $query, $args );
+		return $query;
+	}
+
+	public function query( $query ) {
+		return true;
+	}
+}
+
+$wpdb = new Notification_Test_DB();
+
+require __DIR__ . '/../inc/social/notifications/capture-replies.php';
+require __DIR__ . '/../inc/social/notifications/capture-mentions.php';
+require __DIR__ . '/../inc/social/notifications/capture-subscriptions.php';
+require __DIR__ . '/../inc/social/notifications/capture-festival-topics.php';
+
+function notification_test_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		fwrite( STDERR, 'FAIL: ' . $message . "\n" );
+		exit( 1 );
+	}
+}
+
+function notification_test_canonical_payload( array $payload ) {
+	$expected = array( 'actor_id', 'type', 'title', 'link', 'item_id', 'producer', 'idempotency_key' );
+	return $expected === array_keys( $payload );
+}
+
+extrachill_capture_reply_notifications( 200, 100, 1, array(), 20 );
+list( $recipients, $payload ) = $GLOBALS['_notification_calls'][0];
+notification_test_assert( 10 === $recipients, 'Reply recipient shaping changed.' );
+notification_test_assert( notification_test_canonical_payload( $payload ), 'Reply payload is not canonical.' );
+notification_test_assert( 'extrachill-community/replies' === $payload['producer'] && 'reply:200' === $payload['idempotency_key'], 'Reply receipt identity is unstable.' );
+notification_test_assert( 100 === $payload['item_id'], 'Reply item context must remain the topic for mention deduplication.' );
+
+extrachill_capture_mention_notifications( 200, 100, 1, array(), 20 );
+list( $recipients, $payload ) = $GLOBALS['_notification_calls'][1];
+notification_test_assert( 10 === $recipients && 200 === $payload['item_id'], 'Mention content context changed.' );
+notification_test_assert( notification_test_canonical_payload( $payload ), 'Mention payload is not canonical.' );
+notification_test_assert( 'extrachill-community/mentions' === $payload['producer'] && 'content:200' === $payload['idempotency_key'], 'Mention receipt identity is unstable.' );
+notification_test_assert( 1 === count( $wpdb->queries ) && 'reply' === $wpdb->queries[0][1][2] && 100 === $wpdb->queries[0][1][3], 'Mention-over-reply deduplication did not run against the topic reply.' );
+
+extrachill_capture_mention_notifications( 101, 101, 1, array() );
+list( $recipients, $payload ) = $GLOBALS['_notification_calls'][2];
+notification_test_assert( 10 === $recipients && 101 === $payload['item_id'], 'Topic mention content context changed.' );
+notification_test_assert( 'content:101' === $payload['idempotency_key'], 'Topic mention receipt identity is unstable.' );
+
+extrachill_capture_subscription_notifications( 200, 100, 1, array(), 20 );
+list( $recipients, $payload ) = $GLOBALS['_notification_calls'][3];
+notification_test_assert( array( 30, 30, 40 ) === $recipients, 'Subscription recipient shaping changed.' );
+notification_test_assert( array( 20, 100 ) === $GLOBALS['_subscribed'], 'Reply author auto-subscription changed.' );
+notification_test_assert( notification_test_canonical_payload( $payload ), 'Subscription payload is not canonical.' );
+notification_test_assert( 'extrachill-community/topic-subscriptions' === $payload['producer'] && 'reply:200' === $payload['idempotency_key'], 'Subscription receipt identity is unstable.' );
+
+$GLOBALS['_receipt'] = array( 'failed' => 0 );
+extrachill_community_notify_festival_topic_subscribers( 300 );
+list( $recipients, $payload ) = $GLOBALS['_notification_calls'][4];
+notification_test_assert( array( 30 ) === $recipients, 'Festival recipient shaping changed.' );
+notification_test_assert( notification_test_canonical_payload( $payload ), 'Festival payload is not canonical.' );
+notification_test_assert( 'extrachill-community/festival-topics' === $payload['producer'] && 'topic:300' === $payload['idempotency_key'], 'Festival receipt identity is unstable.' );
+notification_test_assert( isset( $GLOBALS['_post_meta'][300][EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META] ), 'Successful festival receipt released its claim.' );
+
+$GLOBALS['_receipt'] = array( 'failed' => 1 );
+extrachill_community_notify_artist_topic_subscribers( 301 );
+list( $recipients, $payload ) = $GLOBALS['_notification_calls'][5];
+notification_test_assert( array( 40 ) === $recipients, 'Artist recipient shaping changed.' );
+notification_test_assert( notification_test_canonical_payload( $payload ), 'Artist payload is not canonical.' );
+notification_test_assert( 'extrachill-community/artist-topics' === $payload['producer'] && 'topic:301' === $payload['idempotency_key'], 'Artist receipt identity is unstable.' );
+notification_test_assert( ! isset( $GLOBALS['_post_meta'][301][EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META] ), 'Explicit failed artist receipt did not release its claim.' );
+
+$GLOBALS['_receipt'] = null;
+extrachill_community_notify_festival_topic_subscribers( 302 );
+notification_test_assert( isset( $GLOBALS['_post_meta'][302][EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META] ), 'Malformed festival receipt incorrectly released its claim.' );
+
+echo "PASS: Community notifications use canonical receipt identities and preserve delivery behavior.\n";


### PR DESCRIPTION
## Summary
- replace the legacy notification action and payload aliases with canonical receipt delivery
- assign stable reply, mention, subscription, festival-topic, and artist-topic producer identities
- preserve mention-over-reply deduplication and release entity claims only on explicit receipt failure

## Verification
- focused standalone receipt contract test passed
- changed PHP syntax checks passed
- `git diff --check` passed

## Rollout
Merge and deploy this consumer before Extra-Chill/extrachill-users#309 removes the legacy contracts.

Closes #250