### PR TITLE
Fix notification receipt static analysis

### DIFF
--- a/inc/social/notifications/capture-festival-topics.php
+++ b/inc/social/notifications/capture-festival-topics.php
@@ -102,7 +102,7 @@ function extrachill_community_notify_festival_topic_subscribers( $topic_id ) {
 		)
 	);
 
-	if ( is_array( $receipt ) && 0 < absint( $receipt['failed'] ?? 0 ) ) {
+	if ( 0 < $receipt['failed'] ) {
 		delete_post_meta( $topic_id, EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META );
 	}
 }
@@ -181,7 +181,7 @@ function extrachill_community_notify_artist_topic_subscribers( $topic_id ) {
 		)
 	);
 
-	if ( is_array( $receipt ) && 0 < absint( $receipt['failed'] ?? 0 ) ) {
+	if ( 0 < $receipt['failed'] ) {
 		delete_post_meta( $topic_id, EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META );
 	}
 }

--- a/inc/social/notifications/capture-replies.php
+++ b/inc/social/notifications/capture-replies.php
@@ -35,7 +35,7 @@ function extrachill_capture_reply_notifications($reply_id, $topic_id, $forum_id,
 	}
 
 	// Get topic author and topic data
-	$topic_author = get_post_field('post_author', $topic_id);
+	$topic_author = (int) get_post_field('post_author', $topic_id);
 	$topic_title  = get_the_title($topic_id);
 	$reply_link   = bbp_get_reply_url($reply_id);
 

--- a/tests/test-notification-receipts.php
+++ b/tests/test-notification-receipts.php
@@ -169,8 +169,4 @@ notification_test_assert( notification_test_canonical_payload( $payload ), 'Arti
 notification_test_assert( 'extrachill-community/artist-topics' === $payload['producer'] && 'topic:301' === $payload['idempotency_key'], 'Artist receipt identity is unstable.' );
 notification_test_assert( ! isset( $GLOBALS['_post_meta'][301][EXTRACHILL_COMMUNITY_ARTIST_TOPIC_NOTIFIED_META] ), 'Explicit failed artist receipt did not release its claim.' );
 
-$GLOBALS['_receipt'] = null;
-extrachill_community_notify_festival_topic_subscribers( 302 );
-notification_test_assert( isset( $GLOBALS['_post_meta'][302][EXTRACHILL_COMMUNITY_FESTIVAL_TOPIC_NOTIFIED_META] ), 'Malformed festival receipt incorrectly released its claim.' );
-
 echo "PASS: Community notifications use canonical receipt identities and preserve delivery behavior.\n";


### PR DESCRIPTION
## Summary
- consume the canonical typed receipt summary directly in festival topic notifications
- normalize reply notification recipients to integer user IDs
- remove malformed-receipt coverage that contradicted the canonical API contract

## Validation
- `php -l inc/social/notifications/capture-festival-topics.php`
- `php -l inc/social/notifications/capture-replies.php`
- `php -l tests/test-notification-receipts.php`
- `php tests/test-notification-receipts.php`
- `git diff --check`
- `homeboy review lint extrachill-community --path /var/lib/datamachine/workspace/extrachill-community@fix-252-receipt-static-analysis --changed-only --placement local --summary`

Scoped Homeboy lint passed PHPCS and confirmed the migration-owned PHPStan findings are resolved. It remains nonzero for two pre-existing, out-of-scope `extrachill_users_entity_subscription_recipients()` argument-count findings at `capture-festival-topics.php:60` and `capture-festival-topics.php:140`.

Fixes #252