### PR TITLE
fix: align subscription recipient test contract

### DIFF
--- a/tests/test-notification-receipts.php
+++ b/tests/test-notification-receipts.php
@@ -91,7 +91,7 @@ function get_the_terms( $post_id, $taxonomy ) {
 function is_wp_error() {
 	return false;
 }
-function extrachill_users_entity_subscription_recipients( $producer, $entity_type ) {
+function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug, $delivery = 'notification' ) {
 	return 'festival' === $entity_type ? array( 20, 30, 30 ) : array( 20, 40 );
 }
 


### PR DESCRIPTION
## Summary
- align the standalone recipient fixture with the production five-argument contract
- remove false argument-count findings from scoped release analysis

## Verification
- `php -l tests/test-notification-receipts.php`
- `php tests/test-notification-receipts.php`
- `git diff --check`
- scoped Homeboy lint passed with zero findings

Fixes #254