### PR TITLE
fix: allow homepage topic creation for participants

### DIFF
--- a/homeboy-test-manifest.json
+++ b/homeboy-test-manifest.json
@@ -25,6 +25,9 @@
     "tests/homepage-header-smoke.php": {
       "environment": "standalone-php"
     },
+    "tests/homepage-topic-form-permissions-smoke.php": {
+      "environment": "standalone-php"
+    },
     "tests/legacy-topic-redirects-smoke.php": {
       "environment": "standalone-php"
     },

--- a/inc/home/new-topic-modal.php
+++ b/inc/home/new-topic-modal.php
@@ -16,6 +16,13 @@ if ( ! defined('ABSPATH') ) {
 $discussion_continuation = extrachill_community_can_continue_discussion_composer()
 	? extrachill_community_get_discussion_composer_state()
 	: null;
+
+// bbPress otherwise treats the homepage as an edit-topic context and denies participants.
+$homepage_topic_form_access = static function () {
+	return is_user_logged_in()
+		&& bbp_is_user_active()
+		&& bbp_current_user_can_publish_topics();
+};
 ?>
 
 <div id="new-topic-modal-overlay" class="new-topic-modal-overlay"></div>
@@ -24,6 +31,10 @@ $discussion_continuation = extrachill_community_can_continue_discussion_composer
 		<button type="button" class="new-topic-modal-close" aria-label="<?php esc_attr_e( 'Close modal', 'extra-chill-community' ); ?>">&times;</button>
 		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'New Post', 'extra-chill-community' ); ?></h2>
 		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Start a new post in the community.', 'extra-chill-community' ); ?></p>
-		<?php bbp_get_template_part( 'form', 'topic' ); ?>
+		<?php
+		add_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
+		bbp_get_template_part( 'form', 'topic' );
+		remove_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
+		?>
 	</div>
 </div>

--- a/tests/discussion-composer-continuation-smoke.php
+++ b/tests/discussion-composer-continuation-smoke.php
@@ -44,6 +44,8 @@ $GLOBALS['_test_terms']       = array(
 );
 
 function add_action() {}
+function add_filter() {}
+function remove_filter() {}
 function apply_filters( $hook, $value ) {
 	return $value;
 }
@@ -87,6 +89,9 @@ function is_user_logged_in() {
 }
 function bbp_current_user_can_publish_topics() {
 	return $GLOBALS['_test_can_publish'];
+}
+function bbp_is_user_active() {
+	return true;
 }
 function ec_get_site_url() {
 	return 'https://community.extrachill.com';

--- a/tests/homepage-topic-form-permissions-smoke.php
+++ b/tests/homepage-topic-form-permissions-smoke.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Focused tests for homepage topic-form permissions.
+ *
+ * Run: php tests/homepage-topic-form-permissions-smoke.php
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+$GLOBALS['_test_filters']     = array();
+$GLOBALS['_test_logged_in']   = true;
+$GLOBALS['_test_user_active'] = true;
+$GLOBALS['_test_can_publish'] = true;
+
+function add_filter( $hook, $callback ) {
+	$GLOBALS['_test_filters'][ $hook ][] = $callback;
+}
+function remove_filter( $hook, $callback ) {
+	foreach ( $GLOBALS['_test_filters'][ $hook ] ?? array() as $index => $registered_callback ) {
+		if ( $registered_callback === $callback ) {
+			unset( $GLOBALS['_test_filters'][ $hook ][ $index ] );
+		}
+	}
+}
+function apply_filters( $hook, $value ) {
+	foreach ( $GLOBALS['_test_filters'][ $hook ] ?? array() as $callback ) {
+		$value = call_user_func( $callback, $value );
+	}
+
+	return $value;
+}
+function is_user_logged_in() {
+	return $GLOBALS['_test_logged_in'];
+}
+function bbp_is_user_active() {
+	return $GLOBALS['_test_user_active'];
+}
+function bbp_current_user_can_publish_topics() {
+	return $GLOBALS['_test_can_publish'];
+}
+function extrachill_community_can_continue_discussion_composer() {
+	return false;
+}
+function extrachill_community_get_discussion_composer_state() {
+	return null;
+}
+function esc_attr_e( $text ) {
+	echo htmlspecialchars( $text, ENT_QUOTES );
+}
+function esc_html_e( $text ) {
+	echo htmlspecialchars( $text, ENT_QUOTES );
+}
+function bbp_get_template_part() {
+	if ( apply_filters( 'bbp_current_user_can_access_create_topic_form', false ) ) {
+		echo '<form id="new-post"></form>';
+		return;
+	}
+
+	echo is_user_logged_in() ? 'You cannot create new topics.' : 'login/register';
+}
+
+$failures = 0;
+function check( $label, $condition ) {
+	global $failures;
+	if ( $condition ) {
+		echo "PASS: $label\n";
+		return;
+	}
+
+	echo "FAIL: $label\n";
+	++$failures;
+}
+
+function render_homepage_topic_modal() {
+	ob_start();
+	include dirname( __DIR__ ) . '/inc/home/new-topic-modal.php';
+	return ob_get_clean();
+}
+
+$output = render_homepage_topic_modal();
+check( 'active logged-in participant can access the homepage topic form', false !== strpos( $output, '<form id="new-post">' ) );
+check( 'homepage permission override is removed after rendering', empty( $GLOBALS['_test_filters']['bbp_current_user_can_access_create_topic_form'] ) );
+
+$GLOBALS['_test_can_publish'] = false;
+$output                       = render_homepage_topic_modal();
+check( 'user without publish_topics remains blocked', false !== strpos( $output, 'You cannot create new topics.' ) );
+
+$GLOBALS['_test_can_publish'] = true;
+$GLOBALS['_test_user_active'] = false;
+$output                       = render_homepage_topic_modal();
+check( 'inactive or spam user remains blocked', false !== strpos( $output, 'You cannot create new topics.' ) );
+
+$GLOBALS['_test_user_active'] = true;
+$GLOBALS['_test_logged_in']   = false;
+$output                       = render_homepage_topic_modal();
+check( 'logged-out user remains on the login/register path', false !== strpos( $output, 'login/register' ) );
+check( 'permission override remains scoped after every render', empty( $GLOBALS['_test_filters']['bbp_current_user_can_access_create_topic_form'] ) );
+
+if ( $failures > 0 ) {
+	exit( 1 );
+}
+
+echo "All homepage topic form permission tests passed.\n";
+exit( 0 );


### PR DESCRIPTION
## Summary
- temporarily override bbPress topic-form access only while rendering the Community homepage modal
- allow logged-in, active participants with `publish_topics` while keeping logged-out, inactive/spam, and unauthorized users blocked
- register focused standalone regression coverage for the homepage permission behavior

## Root cause

The feed-first homepage embeds `form-topic.php` outside bbPress single-forum, page, or single contexts. In that context, `bbp_current_user_can_access_create_topic_form()` falls through to `edit_topic( 0 )` instead of checking `bbp_current_user_can_publish_topics()`, so ordinary participants are denied even when they have `publish_topics`.

The override is installed only around the homepage modal template render and removed immediately afterward. bbPress retains its native submission checks, including rejecting closed selected forums. The no-JS single-forum fallback is unchanged. Main-blog and Studio publishing permissions are unchanged.

## Verification
- `php tests/homepage-topic-form-permissions-smoke.php`
- `php tests/discussion-composer-contract-smoke.php`
- `php tests/discussion-composer-continuation-smoke.php`
- `php -l inc/home/new-topic-modal.php`
- `php -l tests/homepage-topic-form-permissions-smoke.php`
- `php -l tests/discussion-composer-continuation-smoke.php`
- `git diff --check`
- validated `homeboy-test-manifest.json` and its new standalone test registration with PHP JSON parsing

Closes #259