### PR TITLE
fix: restore homepage topic form filter after errors

### DIFF
--- a/inc/home/new-topic-modal.php
+++ b/inc/home/new-topic-modal.php
@@ -33,8 +33,11 @@ $homepage_topic_form_access = static function () {
 		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Start a new post in the community.', 'extra-chill-community' ); ?></p>
 		<?php
 		add_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
-		bbp_get_template_part( 'form', 'topic' );
-		remove_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
+		try {
+			bbp_get_template_part( 'form', 'topic' );
+		} finally {
+			remove_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
+		}
 		?>
 	</div>
 </div>

--- a/tests/homepage-topic-form-permissions-smoke.php
+++ b/tests/homepage-topic-form-permissions-smoke.php
@@ -7,10 +7,11 @@
 
 define( 'ABSPATH', __DIR__ );
 
-$GLOBALS['_test_filters']     = array();
-$GLOBALS['_test_logged_in']   = true;
-$GLOBALS['_test_user_active'] = true;
-$GLOBALS['_test_can_publish'] = true;
+$GLOBALS['_test_filters']         = array();
+$GLOBALS['_test_logged_in']       = true;
+$GLOBALS['_test_user_active']     = true;
+$GLOBALS['_test_can_publish']     = true;
+$GLOBALS['_test_template_throws'] = false;
 
 function add_filter( $hook, $callback ) {
 	$GLOBALS['_test_filters'][ $hook ][] = $callback;
@@ -51,6 +52,10 @@ function esc_html_e( $text ) {
 	echo htmlspecialchars( $text, ENT_QUOTES );
 }
 function bbp_get_template_part() {
+	if ( $GLOBALS['_test_template_throws'] ) {
+		throw new RuntimeException( 'Template rendering failed.' );
+	}
+
 	if ( apply_filters( 'bbp_current_user_can_access_create_topic_form', false ) ) {
 		echo '<form id="new-post"></form>';
 		return;
@@ -80,6 +85,23 @@ function render_homepage_topic_modal() {
 $output = render_homepage_topic_modal();
 check( 'active logged-in participant can access the homepage topic form', false !== strpos( $output, '<form id="new-post">' ) );
 check( 'homepage permission override is removed after rendering', empty( $GLOBALS['_test_filters']['bbp_current_user_can_access_create_topic_form'] ) );
+check( 'native false access remains false after successful rendering', false === apply_filters( 'bbp_current_user_can_access_create_topic_form', false ) );
+
+$GLOBALS['_test_template_throws'] = true;
+$template_exception_caught        = false;
+ob_start();
+try {
+	include dirname( __DIR__ ) . '/inc/home/new-topic-modal.php';
+} catch ( RuntimeException $exception ) {
+	$template_exception_caught = true;
+} finally {
+	ob_end_clean();
+}
+$GLOBALS['_test_template_throws'] = false;
+
+check( 'template rendering exception propagates', $template_exception_caught );
+check( 'homepage permission override is removed after rendering throws', empty( $GLOBALS['_test_filters']['bbp_current_user_can_access_create_topic_form'] ) );
+check( 'native false access remains false after rendering throws', false === apply_filters( 'bbp_current_user_can_access_create_topic_form', false ) );
 
 $GLOBALS['_test_can_publish'] = false;
 $output                       = render_homepage_topic_modal();


### PR DESCRIPTION
## Root cause

The homepage modal registered `bbp_current_user_can_access_create_topic_form`, rendered the bbPress topic template, and only then removed the callback. An exception from template rendering skipped `remove_filter()`, leaving the permissive homepage callback active for the rest of the request.

## Behavior change

- Wrap `bbp_get_template_part( 'form', 'topic' )` in `try/finally` so the temporary callback is always removed.
- Preserve exception propagation rather than swallowing rendering failures.
- Extend the focused permission smoke test to verify cleanup and native false access after both successful rendering and a thrown exception.

## Test evidence

- `php tests/homepage-topic-form-permissions-smoke.php`
- All 17 standalone PHP smoke tests registered in `homeboy-test-manifest.json`
- `php -l inc/home/new-topic-modal.php`
- `php -l tests/homepage-topic-form-permissions-smoke.php`
- `git diff --check`

## Security scope

This closes the request-scoped authorization-filter leak that could expose create-topic forms or alter later same-request bbPress access checks. It does not broaden capabilities or weaken native bbPress submission validation: users still need `publish_topics`, must be active and logged in, and remain subject to selected-forum constraints.

Fixes #261