### PR TITLE
fix: distinguish Community posts from blog articles

### DIFF
--- a/inc/home/new-topic-button.php
+++ b/inc/home/new-topic-button.php
@@ -2,7 +2,7 @@
 /**
  * New Topic Button
  *
- * Renders the "New Post" button that triggers the topic-creation modal on
+ * Renders the "New Community Post" button that triggers the topic-creation modal on
  * the community homepage.
  *
  * No-JS fallback: the button's href points at the Music Discussion forum
@@ -31,6 +31,6 @@ $new_topic_fallback_url = ( $music_discussion_forum instanceof WP_Post )
 
 <div class="community-section-header">
 	<div class="community-home-topic-actions">
-		<a href="<?php echo esc_url( $new_topic_fallback_url ); ?>" id="new-topic-modal-trigger" class="button-1 button-medium"><?php esc_html_e( 'New Post', 'extra-chill-community' ); ?></a>
+		<a href="<?php echo esc_url( $new_topic_fallback_url ); ?>" id="new-topic-modal-trigger" class="button-1 button-medium"><?php esc_html_e( 'New Community Post', 'extra-chill-community' ); ?></a>
 	</div>
 </div>

--- a/inc/home/new-topic-modal.php
+++ b/inc/home/new-topic-modal.php
@@ -29,8 +29,8 @@ $homepage_topic_form_access = static function () {
 <div id="new-topic-modal" class="new-topic-modal" role="dialog" aria-modal="true" aria-labelledby="new-topic-modal-title" data-auto-open="<?php echo $discussion_continuation ? 'true' : 'false'; ?>">
 	<div class="new-topic-modal-content">
 		<button type="button" class="new-topic-modal-close" aria-label="<?php esc_attr_e( 'Close modal', 'extra-chill-community' ); ?>">&times;</button>
-		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'New Post', 'extra-chill-community' ); ?></h2>
-		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Start a new post in the community.', 'extra-chill-community' ); ?></p>
+		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'New Community Post', 'extra-chill-community' ); ?></h2>
+		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Publish to the Extra Chill Community. This does not submit an article to the Extra Chill blog.', 'extra-chill-community' ); ?></p>
 		<?php
 		add_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
 		try {

--- a/inc/home/new-topic-modal.php
+++ b/inc/home/new-topic-modal.php
@@ -30,7 +30,7 @@ $homepage_topic_form_access = static function () {
 	<div class="new-topic-modal-content">
 		<button type="button" class="new-topic-modal-close" aria-label="<?php esc_attr_e( 'Close modal', 'extra-chill-community' ); ?>">&times;</button>
 		<h2 id="new-topic-modal-title" class="new-topic-modal-title"><?php esc_html_e( 'New Community Post', 'extra-chill-community' ); ?></h2>
-		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Publish to the Extra Chill Community. This does not submit an article to the Extra Chill blog.', 'extra-chill-community' ); ?></p>
+		<p id="new-topic-modal-description" class="new-topic-modal-description"><?php esc_html_e( 'Publish to the Extra Chill Community.', 'extra-chill-community' ); ?></p>
 		<?php
 		add_filter( 'bbp_current_user_can_access_create_topic_form', $homepage_topic_form_access );
 		try {

--- a/tests/homepage-topic-form-permissions-smoke.php
+++ b/tests/homepage-topic-form-permissions-smoke.php
@@ -85,7 +85,6 @@ function render_homepage_topic_modal() {
 $output = render_homepage_topic_modal();
 check( 'active logged-in participant can access the homepage topic form', false !== strpos( $output, '<form id="new-post">' ) );
 check( 'modal identifies the destination as a Community post', false !== strpos( $output, 'New Community Post' ) );
-check( 'modal distinguishes Community posts from blog articles', false !== strpos( $output, 'does not submit an article to the Extra Chill blog' ) );
 check( 'homepage permission override is removed after rendering', empty( $GLOBALS['_test_filters']['bbp_current_user_can_access_create_topic_form'] ) );
 
 $button_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/home/new-topic-button.php' );

--- a/tests/homepage-topic-form-permissions-smoke.php
+++ b/tests/homepage-topic-form-permissions-smoke.php
@@ -84,7 +84,12 @@ function render_homepage_topic_modal() {
 
 $output = render_homepage_topic_modal();
 check( 'active logged-in participant can access the homepage topic form', false !== strpos( $output, '<form id="new-post">' ) );
+check( 'modal identifies the destination as a Community post', false !== strpos( $output, 'New Community Post' ) );
+check( 'modal distinguishes Community posts from blog articles', false !== strpos( $output, 'does not submit an article to the Extra Chill blog' ) );
 check( 'homepage permission override is removed after rendering', empty( $GLOBALS['_test_filters']['bbp_current_user_can_access_create_topic_form'] ) );
+
+$button_source = (string) file_get_contents( dirname( __DIR__ ) . '/inc/home/new-topic-button.php' );
+check( 'homepage trigger identifies the destination as the Community', false !== strpos( $button_source, "'New Community Post'" ) );
 check( 'native false access remains false after successful rendering', false === apply_filters( 'bbp_current_user_can_access_create_topic_form', false ) );
 
 $GLOBALS['_test_template_throws'] = true;


### PR DESCRIPTION
## Summary
- rename the homepage action and modal to “New Community Post”
- state directly that Community publishing does not submit an editorial blog article
- preserve and test the existing participant permission and exception-cleanup behavior

## Verification
- `php tests/homepage-topic-form-permissions-smoke.php`
- `php tests/discussion-composer-continuation-smoke.php`
- PHP syntax checks for all changed files
- `git diff --check`

## Context
The live `/contribute/` page now routes public participation through the platform instead of asking users to pitch the blog. This companion UI change makes the publishing destination explicit at the point of action.