### PR TITLE
Refactor Community settings after email-sharing retirement

### DIFF
--- a/src/blocks/user-settings/view.tsx
+++ b/src/blocks/user-settings/view.tsx
@@ -37,8 +37,6 @@ import type {
 	UserProfile,
 	ChangeEmailResponse,
 	ChangePasswordResponse,
-	UserSubscriptions,
-	ArtistEmailConsent,
 	RequestArtistAccessResponse,
 	NotificationPreferences,
 	EntitySubscriptionStatus,
@@ -51,6 +49,10 @@ const client = new WPNativeClient( new WpApiFetchTransport( apiFetch ), {
 	validateAbilityNames: false,
 } );
 const LOCATION_SEARCH_DEBOUNCE_MS = 250;
+const RETIRED_EMAIL_SHARING_TYPES = new Set( [
+	'artist-email-sharing',
+	'venue-email-sharing',
+] );
 
 interface LocalScene {
 	term_id: number;
@@ -566,11 +568,6 @@ function SubscriptionsTab() {
 	const [ subscriptions, setSubscriptions ] = useState<
 		ResolvedSubscriptionEntity[]
 	>( [] );
-	const [ legacyArtistConsents, setLegacyArtistConsents ] = useState<
-		ArtistEmailConsent[]
-	>( [] );
-	const [ compatibilityArtistConsents, setCompatibilityArtistConsents ] =
-		useState< ArtistEmailConsent[] >( [] );
 	const [ loading, setLoading ] = useState( true );
 	const [ removing, setRemoving ] = useState< string | null >( null );
 	const [ notice, setNotice ] = useState< {
@@ -589,7 +586,14 @@ function SubscriptionsTab() {
 							'extrachill/list-entity-subscriptions',
 							{ page, per_page: 100 }
 						);
-					identities.push( ...result.subscriptions );
+					identities.push(
+						...result.subscriptions.filter(
+							( item ) =>
+								! RETIRED_EMAIL_SHARING_TYPES.has(
+									item.entity_type
+								)
+						)
+					);
 					totalPages = Math.max( 1, result.total_pages );
 					page += 1;
 				} while ( page <= totalPages );
@@ -624,46 +628,6 @@ function SubscriptionsTab() {
 				setSubscriptions(
 					enriched.flatMap( ( result ) => result.entities )
 				);
-
-				const compatibility = await client
-					.execute< UserSubscriptions >(
-						'extrachill/get-subscriptions'
-					)
-					.catch( () => ( { user_id: 0 } ) );
-				const canonicalArtistSlugs = new Set(
-					identities
-						.filter(
-							( item ) =>
-								item.entity_type === 'artist-email-sharing'
-						)
-						.map( ( item ) => item.slug )
-				);
-				const compatibleArtists =
-					compatibility.artist_email_consents ??
-					compatibility.followed_artists ??
-					[];
-				setCompatibilityArtistConsents( compatibleArtists );
-				setLegacyArtistConsents(
-					compatibleArtists.filter( ( artist ) => {
-						let slug = '';
-						try {
-							slug =
-								new URL(
-									artist.url,
-									window.location.href
-								).pathname
-									.split( '/' )
-									.filter( Boolean )
-									.pop() ?? '';
-						} catch {
-							// Keep malformed legacy rows visible so access can be removed.
-						}
-						return (
-							artist.email_consent &&
-							( ! slug || ! canonicalArtistSlugs.has( slug ) )
-						);
-					} )
-				);
 			} catch ( err ) {
 				setNotice( {
 					type: 'error',
@@ -681,16 +645,6 @@ function SubscriptionsTab() {
 
 	const identityKey = ( item: EntitySubscriptionIdentity ) =>
 		`${ item.entity_type }/${ item.taxonomy }/${ item.slug }`;
-	const emailTypes = new Set( [
-		'artist-email-sharing',
-		'venue-email-sharing',
-	] );
-	const updateSubscriptions = subscriptions.filter(
-		( item ) => ! emailTypes.has( item.entity_type )
-	);
-	const emailPermissions = subscriptions.filter( ( item ) =>
-		emailTypes.has( item.entity_type )
-	);
 
 	const unsubscribe = useCallback(
 		async ( item: ResolvedSubscriptionEntity ) => {
@@ -722,42 +676,6 @@ function SubscriptionsTab() {
 			setRemoving( null );
 		},
 		[]
-	);
-
-	const removeLegacyConsent = useCallback(
-		async ( artistId: number ) => {
-			setRemoving( `legacy-${ artistId }` );
-			setNotice( null );
-			try {
-				await client.execute( 'extrachill/update-subscriptions', {
-					consented_artists: compatibilityArtistConsents
-						.filter( ( artist ) => artist.artist_id !== artistId )
-						.map( ( artist ) => artist.artist_id ),
-				} );
-				setLegacyArtistConsents( ( current ) =>
-					current.filter(
-						( artist ) => artist.artist_id !== artistId
-					)
-				);
-				setCompatibilityArtistConsents( ( current ) =>
-					current.filter(
-						( artist ) => artist.artist_id !== artistId
-					)
-				);
-				setNotice( {
-					type: 'success',
-					message: 'Email access removed.',
-				} );
-			} catch ( err ) {
-				setNotice( {
-					type: 'error',
-					message:
-						err instanceof Error ? err.message : 'Update failed.',
-				} );
-			}
-			setRemoving( null );
-		},
-		[ compatibilityArtistConsents ]
 	);
 
 	if ( loading ) {
@@ -807,7 +725,7 @@ function SubscriptionsTab() {
 
 	return (
 		<Panel>
-			<PanelHeader description="Review your private Extra Chill update subscriptions and email-sharing permissions." />
+			<PanelHeader description="Review your private Extra Chill notification subscriptions." />
 			{ notice && (
 				<Notice type={ notice.type } message={ notice.message } />
 			) }
@@ -816,58 +734,13 @@ function SubscriptionsTab() {
 				Private subscriptions used by Extra Chill to send updates you
 				explicitly requested.
 			</p>
-			{ updateSubscriptions.length === 0 ? (
+			{ subscriptions.length === 0 ? (
 				<p style={ styles.mutedText }>
 					You are not subscribed to any entity updates.
 				</p>
 			) : (
 				<ul style={ styles.checkboxList }>
-					{ updateSubscriptions.map( renderEntity ) }
-				</ul>
-			) }
-			<h3>Email-sharing permissions</h3>
-			<p style={ styles.mutedText }>
-				These permissions grant the named artist or venue access to your
-				current account email. They do not subscribe you to Extra Chill
-				updates.
-			</p>
-			{ emailPermissions.length === 0 &&
-			legacyArtistConsents.length === 0 ? (
-				<p style={ styles.mutedText }>
-					You have not shared your email with any artists or venues.
-				</p>
-			) : (
-				<ul style={ styles.checkboxList }>
-					{ emailPermissions.map( renderEntity ) }
-					{ legacyArtistConsents.map( ( artist ) => (
-						<li
-							key={ `legacy-${ artist.artist_id }` }
-							style={ styles.checkboxItem }
-						>
-							<div style={ { flex: 1 } }>
-								<strong>
-									<a href={ artist.url }>{ artist.name }</a>
-								</strong>
-								<div style={ styles.mutedText }>
-									This artist may access your current account
-									email.
-								</div>
-							</div>
-							<button
-								className="button button-small"
-								disabled={
-									removing === `legacy-${ artist.artist_id }`
-								}
-								onClick={ () =>
-									removeLegacyConsent( artist.artist_id )
-								}
-							>
-								{ removing === `legacy-${ artist.artist_id }`
-									? 'Removing...'
-									: 'Remove access' }
-							</button>
-						</li>
-					) ) }
+					{ subscriptions.map( renderEntity ) }
 				</ul>
 			) }
 		</Panel>

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -121,22 +121,6 @@ export interface UserProfile {
 	artist_access: ArtistAccessStatus;
 }
 
-// ─── User Subscriptions ───────────────────────────────────────────────────────
-
-export interface ArtistEmailConsent {
-	artist_id: number;
-	name: string;
-	url: string;
-	email_consent: boolean;
-}
-
-export interface UserSubscriptions {
-	user_id: number;
-	artist_email_consents?: ArtistEmailConsent[];
-	/** @deprecated Compatibility field from extrachill-users. */
-	followed_artists?: ArtistEmailConsent[];
-}
-
 export interface EntitySubscriptionIdentity {
 	entity_type: string;
 	taxonomy: string;

--- a/tests/js/user-settings-subscription-inventory.test.tsx
+++ b/tests/js/user-settings-subscription-inventory.test.tsx
@@ -62,7 +62,7 @@ const settings = {
 };
 
 function installMocks( identities: Array< Record< string, string > > ) {
-	mockExecute.mockImplementation( ( ability: string ) => {
+	mockExecute.mockImplementation( ( ability: string, input?: unknown ) => {
 		if ( ability === 'extrachill/get-user-settings' ) {
 			return Promise.resolve( settings );
 		}
@@ -83,8 +83,11 @@ function installMocks( identities: Array< Record< string, string > > ) {
 		if (
 			ability === 'extrachill/community-resolve-subscription-entities'
 		) {
+			const resolvedIdentities = (
+				input as { identities: Array< Record< string, string > > }
+			 ).identities;
 			return Promise.resolve( {
-				entities: identities.map( ( item ) => ( {
+				entities: resolvedIdentities.map( ( item ) => ( {
 					...item,
 					name:
 						item.slug === 'missing'
@@ -97,9 +100,6 @@ function installMocks( identities: Array< Record< string, string > > ) {
 					resolved: item.slug !== 'missing',
 				} ) ),
 			} );
-		}
-		if ( ability === 'extrachill/get-subscriptions' ) {
-			return Promise.resolve( { user_id: 7, artist_email_consents: [] } );
 		}
 		return Promise.resolve( { success: true } );
 	} );
@@ -135,27 +135,66 @@ describe( 'subscription inventory', () => {
 		document.body.innerHTML = '';
 	} );
 
-	it( 'groups update and email-sharing purposes without follower language', async () => {
+	it( 'suppresses retired email-sharing rows while preserving notifications', async () => {
 		installMocks( [
 			{ entity_type: 'artist', taxonomy: 'artist', slug: 'kid-lake' },
 			{
+				entity_type: 'festival',
+				taxonomy: 'festival',
+				slug: 'high-water',
+			},
+			{
+				entity_type: 'venue',
+				taxonomy: 'venue',
+				slug: 'music-farm',
+			},
+			{
+				entity_type: 'artist-email-sharing',
+				taxonomy: 'artist',
+				slug: 'retired-artist',
+			},
+			{
 				entity_type: 'venue-email-sharing',
 				taxonomy: 'venue',
-				slug: 'royal-american',
+				slug: 'retired-venue',
 			},
 		] );
 		const { container, root } = await renderInventory();
 		expect( container.textContent ).toContain(
 			'Extra Chill update subscriptions'
 		);
-		expect( container.textContent ).toContain(
+		expect( container.textContent ).toContain( 'kid lake' );
+		expect( container.textContent ).toContain( 'high water' );
+		expect( container.textContent ).toContain( 'music farm' );
+		expect( container.textContent ).not.toContain( 'retired artist' );
+		expect( container.textContent ).not.toContain( 'retired venue' );
+		expect( container.textContent ).not.toContain(
 			'Email-sharing permissions'
 		);
-		expect( container.textContent ).toContain(
-			'grant the named artist or venue access to your current account email'
+		expect( mockExecute ).toHaveBeenCalledWith(
+			'extrachill/community-resolve-subscription-entities',
+			{
+				identities: [
+					{
+						entity_type: 'artist',
+						taxonomy: 'artist',
+						slug: 'kid-lake',
+					},
+					{
+						entity_type: 'festival',
+						taxonomy: 'festival',
+						slug: 'high-water',
+					},
+					{
+						entity_type: 'venue',
+						taxonomy: 'venue',
+						slug: 'music-farm',
+					},
+				],
+			}
 		);
-		expect( container.textContent ).not.toMatch(
-			/\bfollow(?:er|ers|ing|s|ed)?\b/i
+		expect( mockExecute ).not.toHaveBeenCalledWith(
+			'extrachill/get-subscriptions'
 		);
 		act( () => root.unmount() );
 	} );
@@ -221,49 +260,5 @@ describe( 'subscription inventory', () => {
 			rendered.container.querySelector( '[role="alert"]' )?.textContent
 		).toContain( 'Inventory unavailable' );
 		act( () => rendered.root.unmount() );
-	} );
-
-	it( 'preserves canonical artist permissions when removing legacy consent', async () => {
-		installMocks( [
-			{
-				entity_type: 'artist-email-sharing',
-				taxonomy: 'artist',
-				slug: 'canonical-artist',
-			},
-		] );
-		const implementation = mockExecute.getMockImplementation();
-		mockExecute.mockImplementation( ( ability: string, input: unknown ) => {
-			if ( ability === 'extrachill/get-subscriptions' ) {
-				return Promise.resolve( {
-					user_id: 7,
-					artist_email_consents: [
-						{
-							artist_id: 10,
-							name: 'Canonical Artist',
-							url: 'https://artist.example.com/canonical-artist/',
-							email_consent: true,
-						},
-						{
-							artist_id: 20,
-							name: 'Legacy Artist',
-							url: 'https://artist.example.com/legacy-artist/',
-							email_consent: true,
-						},
-					],
-				} );
-			}
-			return implementation?.( ability, input );
-		} );
-
-		const { container, root } = await renderInventory();
-		const removeAccess = Array.from(
-			container.querySelectorAll( 'button' )
-		).find( ( button ) => button.textContent === 'Remove access' );
-		await act( async () => removeAccess?.click() );
-		expect( mockExecute ).toHaveBeenCalledWith(
-			'extrachill/update-subscriptions',
-			{ consented_artists: [ 10 ] }
-		);
-		act( () => root.unmount() );
 	} );
 } );


### PR DESCRIPTION
## Summary
- remove canonical and legacy artist/venue email-sharing permissions, compatibility types, UI, and revoke calls from Community settings
- preserve generic artist, festival, venue, Local Scene digest, unknown-identity, notification-email, and bbPress subscription behavior
- temporarily suppress persisted `artist-email-sharing` and `venue-email-sharing` rows before entity resolution until Extra Chill Users issue #316 purges them, preventing stale consent rows from masquerading as notifications

## Tests
- `npm run test:js` (17 tests passed)
- `npm run lint:js`
- `npm run build`
- `php tests/subscription-inventory-smoke.php`
- `php tests/local-scene-digest-settings-smoke.php`
- `php tests/notification-receipts-smoke.php`
- `php tests/content-filters-smoke.php`
- source and generated-asset greps confirm retired UI/legacy APIs are absent and generic notification inventory remains

## Notes
- `build/` was regenerated successfully but is ignored and has no tracked files in this repository.
- Standalone `tsc --noEmit` remains blocked by existing repository-wide WordPress block-editor declaration/config errors and the existing ES2020 `replaceAll` mismatch.
- Homeboy's test umbrella reports no canonical PHPUnit tests despite the checked-in standalone manifest; the relevant manifest tests were run directly above.

Closes #264