### PR TITLE
feat: expose recent public community activity

### DIFF
--- a/extrachill-community.php
+++ b/extrachill-community.php
@@ -72,6 +72,7 @@ function extrachill_community_init() {
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/forum-queries.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/content-filters.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/recent-feed.php';
+	require_once plugin_dir_path( __FILE__ ) . 'inc/content/recent-public-activity.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/main-site-comments.php';
 	require_once plugin_dir_path( __FILE__ ) . 'inc/content/subforum-button-classes.php';
 

--- a/inc/content/recent-public-activity.php
+++ b/inc/content/recent-public-activity.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Recent Public Activity Ability
+ *
+ * Owns the portable, read-only projection of public Community activity.
+ * bbPress storage details remain contained in this file.
+ *
+ * @package ExtraChillCommunity
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_COMMUNITY_RECENT_ACTIVITY_MAX = 20;
+
+add_action( 'wp_abilities_api_init', 'extrachill_community_register_recent_public_activity_ability' );
+
+/** Register the bounded public activity projection. */
+function extrachill_community_register_recent_public_activity_ability() {
+	$nullable_url = array(
+		'oneOf' => array(
+			array( 'type' => 'null' ),
+			array(
+				'type'   => 'string',
+				'format' => 'uri',
+			),
+		),
+	);
+	$term_schema  = array(
+		'type'                 => 'object',
+		'properties'           => array(
+			'name'          => array( 'type' => 'string' ),
+			'slug'          => array( 'type' => 'string' ),
+			'canonical_url' => array(
+				'type'   => 'string',
+				'format' => 'uri',
+			),
+		),
+		'required'             => array( 'name', 'slug', 'canonical_url' ),
+		'additionalProperties' => false,
+	);
+	$item_schema  = array(
+		'type'                 => 'object',
+		'properties'           => array(
+			'canonical_url' => array(
+				'type'   => 'string',
+				'format' => 'uri',
+			),
+			'title'         => array( 'type' => 'string' ),
+			'timestamp'     => array(
+				'type'   => 'string',
+				'format' => 'date-time',
+			),
+			'activity_type' => array(
+				'type' => 'string',
+				'enum' => array( 'discussion', 'reply' ),
+			),
+			'actor'         => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'display_name' => array( 'type' => 'string' ),
+					'profile_url'  => $nullable_url,
+				),
+				'required'             => array( 'display_name', 'profile_url' ),
+				'additionalProperties' => false,
+			),
+			'relationships' => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'forum'   => $term_schema,
+					'artists' => array(
+						'type'     => 'array',
+						'items'    => $term_schema,
+						'maxItems' => 10,
+					),
+				),
+				'required'             => array( 'forum', 'artists' ),
+				'additionalProperties' => false,
+			),
+		),
+		'required'             => array( 'canonical_url', 'title', 'timestamp', 'activity_type', 'actor', 'relationships' ),
+		'additionalProperties' => false,
+	);
+
+	wp_register_ability(
+		'extrachill/community-recent-public-activity',
+		array(
+			'label'               => __( 'Get Recent Public Community Activity', 'extra-chill-community' ),
+			'description'         => __( 'Get a bounded, portable projection of recent public discussions and replies.', 'extra-chill-community' ),
+			'category'            => 'extrachill-community',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'limit'       => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => EXTRACHILL_COMMUNITY_RECENT_ACTIVITY_MAX,
+						'default' => 5,
+					),
+					'artist_slug' => array(
+						'type'      => 'string',
+						'pattern'   => '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+						'maxLength' => 200,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'schema_version' => array(
+						'type' => 'string',
+						'enum' => array( '1' ),
+					),
+					'items'          => array(
+						'type'     => 'array',
+						'items'    => $item_schema,
+						'maxItems' => EXTRACHILL_COMMUNITY_RECENT_ACTIVITY_MAX,
+					),
+				),
+				'required'             => array( 'schema_version', 'items' ),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => 'extrachill_community_ability_recent_public_activity',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Return recent public activity without exposing Community storage details.
+ *
+ * @param array $input Ability input.
+ * @return array{schema_version:string,items:array}
+ */
+function extrachill_community_ability_recent_public_activity( $input ) {
+	if ( ! function_exists( 'bbp_get_topic_post_type' ) || ! function_exists( 'bbp_get_reply_post_type' ) ) {
+		return array(
+			'schema_version' => '1',
+			'items'          => array(),
+		);
+	}
+
+	$limit       = min( EXTRACHILL_COMMUNITY_RECENT_ACTIVITY_MAX, max( 1, (int) ( $input['limit'] ?? 5 ) ) );
+	$artist_slug = isset( $input['artist_slug'] ) ? (string) $input['artist_slug'] : '';
+	$query_args  = array(
+		'post_type'              => '' === $artist_slug ? array( bbp_get_topic_post_type(), bbp_get_reply_post_type() ) : bbp_get_topic_post_type(),
+		'post_status'            => array( bbp_get_public_status_id(), bbp_get_closed_status_id() ),
+		'posts_per_page'         => $limit,
+		'orderby'                => 'date',
+		'order'                  => 'DESC',
+		'no_found_rows'          => true,
+		'ignore_sticky_posts'    => true,
+		'update_post_term_cache' => true,
+		'update_post_meta_cache' => true,
+	);
+
+	if ( '' !== $artist_slug ) {
+		$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Explicit bounded relationship filter.
+			array(
+				'taxonomy' => 'artist',
+				'field'    => 'slug',
+				'terms'    => $artist_slug,
+			),
+		);
+	}
+
+	$items = array();
+	$query = new WP_Query( $query_args );
+	foreach ( $query->posts as $activity ) {
+		$activity = $activity instanceof WP_Post ? $activity : get_post( $activity );
+		if ( ! $activity ) {
+			continue;
+		}
+		$item = extrachill_community_prepare_recent_public_activity_item( $activity );
+		if ( $item ) {
+			$items[] = $item;
+		}
+	}
+
+	return array(
+		'schema_version' => '1',
+		'items'          => $items,
+	);
+}
+
+/**
+ * Shape one public activity item.
+ *
+ * @param WP_Post $activity Activity post.
+ * @return array|null Portable item, or null when any owner visibility check fails.
+ */
+function extrachill_community_prepare_recent_public_activity_item( $activity ) {
+	$topic_type = bbp_get_topic_post_type();
+	$reply_type = bbp_get_reply_post_type();
+	$is_reply   = $reply_type === $activity->post_type;
+	$is_topic   = $topic_type === $activity->post_type;
+
+	if ( ! $is_topic && ! $is_reply ) {
+		return null;
+	}
+
+	$public_status = bbp_get_public_status_id();
+	$closed_status = bbp_get_closed_status_id();
+	if ( ( $is_reply && $public_status !== $activity->post_status ) || ( $is_topic && ! in_array( $activity->post_status, array( $public_status, $closed_status ), true ) ) ) {
+		return null;
+	}
+
+	$topic_id = $is_topic ? (int) $activity->ID : (int) bbp_get_reply_topic_id( $activity->ID );
+	$topic    = $topic_id ? get_post( $topic_id ) : null;
+	if ( ! $topic || $topic_type !== $topic->post_type || ! in_array( $topic->post_status, array( $public_status, $closed_status ), true ) ) {
+		return null;
+	}
+
+	$forum_id = (int) bbp_get_topic_forum_id( $topic_id );
+	$forum    = $forum_id ? get_post( $forum_id ) : null;
+	if ( ! $forum || bbp_get_forum_post_type() !== $forum->post_type || $public_status !== $forum->post_status ) {
+		return null;
+	}
+
+	$canonical_url = $is_reply ? bbp_get_reply_url( $activity->ID ) : bbp_get_topic_permalink( $topic_id );
+	$forum_url     = bbp_get_forum_permalink( $forum_id );
+	$activity_date = $activity->post_date_gmt ? $activity->post_date_gmt : $activity->post_date;
+	$timestamp     = mysql2date( DATE_W3C, $activity_date, false );
+	if ( ! $canonical_url || ! $forum_url || ! $timestamp ) {
+		return null;
+	}
+
+	return array(
+		'canonical_url' => (string) $canonical_url,
+		'title'         => html_entity_decode( get_the_title( $topic ), ENT_QUOTES, 'UTF-8' ),
+		'timestamp'     => $timestamp,
+		'activity_type' => $is_reply ? 'reply' : 'discussion',
+		'actor'         => extrachill_community_recent_activity_actor( $activity ),
+		'relationships' => array(
+			'forum'   => array(
+				'name'          => html_entity_decode( get_the_title( $forum ), ENT_QUOTES, 'UTF-8' ),
+				'slug'          => (string) $forum->post_name,
+				'canonical_url' => (string) $forum_url,
+			),
+			'artists' => extrachill_community_recent_activity_artists( $topic_id ),
+		),
+	);
+}
+
+/** Return the public identity displayed for an activity item. */
+function extrachill_community_recent_activity_actor( $activity ) {
+	if ( function_exists( 'extrachill_community_format_post_public_voice' ) ) {
+		$voice = extrachill_community_format_post_public_voice( $activity->ID );
+		if ( $voice ) {
+			return array(
+				'display_name' => (string) $voice['name'],
+				'profile_url'  => ! empty( $voice['url'] ) ? (string) $voice['url'] : null,
+			);
+		}
+	}
+
+	$user = get_userdata( (int) $activity->post_author );
+	if ( $user ) {
+		$profile_url = function_exists( 'extrachill_get_user_profile_url' ) ? extrachill_get_user_profile_url( $user->ID ) : '';
+		return array(
+			'display_name' => (string) $user->display_name,
+			'profile_url'  => $profile_url ? (string) $profile_url : null,
+		);
+	}
+
+	return array(
+		'display_name' => (string) get_post_meta( $activity->ID, '_bbp_anonymous_name', true ),
+		'profile_url'  => null,
+	);
+}
+
+/** Return bounded Community artist archive relationships for a topic. */
+function extrachill_community_recent_activity_artists( $topic_id ) {
+	$terms = get_the_terms( $topic_id, 'artist' );
+	if ( empty( $terms ) || is_wp_error( $terms ) ) {
+		return array();
+	}
+
+	$artists = array();
+	foreach ( array_slice( $terms, 0, 10 ) as $term ) {
+		$url = get_term_link( $term );
+		if ( is_wp_error( $url ) || ! $url ) {
+			continue;
+		}
+		$artists[] = array(
+			'name'          => html_entity_decode( (string) $term->name, ENT_QUOTES, 'UTF-8' ),
+			'slug'          => (string) $term->slug,
+			'canonical_url' => (string) $url,
+		);
+	}
+
+	return $artists;
+}

--- a/tests/recent-public-activity-smoke.php
+++ b/tests/recent-public-activity-smoke.php
@@ -1,22 +1,30 @@
 <?php
 /** Focused coverage for the bounded recent public activity owner contract. */
 
-define( 'ABSPATH', __DIR__ . '/' );
+$standalone = ! defined( 'ABSPATH' );
+if ( $standalone ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+$GLOBALS['_recent_activity_standalone'] = $standalone;
 
-class WP_Post {
-	public function __construct( array $data ) {
-		foreach ( $data as $key => $value ) {
-			$this->$key = $value;
+if ( ! class_exists( 'WP_Post' ) ) {
+	class WP_Post {
+		public function __construct( array $data ) {
+			foreach ( $data as $key => $value ) {
+				$this->$key = $value;
+			}
 		}
 	}
 }
 
-class WP_Query {
-	public $posts;
+if ( ! class_exists( 'WP_Query' ) ) {
+	class WP_Query {
+		public $posts;
 
-	public function __construct( $args ) {
-		$GLOBALS['_recent_activity_query_args'] = $args;
-		$this->posts                            = $GLOBALS['_recent_activity_query_posts'];
+		public function __construct( $args ) {
+			$GLOBALS['_recent_activity_query_args'] = $args;
+			$this->posts                            = $GLOBALS['_recent_activity_query_posts'];
+		}
 	}
 }
 
@@ -26,35 +34,66 @@ $GLOBALS['_recent_activity_query_posts'] = array();
 $GLOBALS['_recent_activity_posts']       = array();
 $GLOBALS['_recent_activity_terms']       = array();
 
-function add_action() {}
-function __( $text ) { return $text; }
-function __return_true() { return true; }
-function wp_register_ability( $name, $args ) {
-	if ( 'extrachill/community-recent-public-activity' === $name ) {
-		$GLOBALS['_recent_activity_ability'] = $args;
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) { return $text; }
+}
+if ( ! function_exists( '__return_true' ) ) {
+	function __return_true() { return true; }
+}
+if ( ! function_exists( 'wp_register_ability' ) ) {
+	function wp_register_ability( $name, $args ) {
+		if ( 'extrachill/community-recent-public-activity' === $name ) {
+			$GLOBALS['_recent_activity_ability'] = $args;
+		}
 	}
 }
-function bbp_get_topic_post_type() { return 'topic'; }
-function bbp_get_reply_post_type() { return 'reply'; }
-function bbp_get_forum_post_type() { return 'forum'; }
-function bbp_get_public_status_id() { return 'publish'; }
-function bbp_get_closed_status_id() { return 'closed'; }
-function bbp_get_reply_topic_id( $id ) { return (int) ( $GLOBALS['_recent_activity_posts'][ $id ]->topic_id ?? 0 ); }
-function bbp_get_topic_forum_id( $id ) { return (int) ( $GLOBALS['_recent_activity_posts'][ $id ]->post_parent ?? 0 ); }
-function bbp_get_reply_url( $id ) { return 'https://community.example.test/reply/' . (int) $id; }
-function bbp_get_topic_permalink( $id ) { return 'https://community.example.test/topic/' . (int) $id; }
-function bbp_get_forum_permalink( $id ) { return 'https://community.example.test/forum/' . (int) $id; }
-function get_post( $id ) { return $GLOBALS['_recent_activity_posts'][ $id ] ?? null; }
-function get_the_title( $post ) { return $post->post_title; }
-function get_userdata( $id ) { return $id ? (object) array( 'ID' => $id, 'display_name' => 'User ' . $id ) : false; }
-function extrachill_get_user_profile_url( $id ) { return 'https://community.example.test/members/' . (int) $id; }
-function get_post_meta() { return ''; }
-function get_the_terms( $id ) { return $GLOBALS['_recent_activity_terms'][ $id ] ?? array(); }
-function get_term_link( $term ) { return 'https://community.example.test/artist/' . $term->slug; }
-function is_wp_error() { return false; }
-function mysql2date( $format, $date ) { return gmdate( $format, strtotime( $date . ' UTC' ) ); }
+if ( ! function_exists( 'bbp_get_topic_post_type' ) ) {
+	function bbp_get_topic_post_type() { return 'topic'; }
+	function bbp_get_reply_post_type() { return 'reply'; }
+	function bbp_get_forum_post_type() { return 'forum'; }
+	function bbp_get_public_status_id() { return 'publish'; }
+	function bbp_get_closed_status_id() { return 'closed'; }
+	function bbp_get_reply_topic_id( $id ) { return (int) ( $GLOBALS['_recent_activity_posts'][ $id ]->topic_id ?? 0 ); }
+	function bbp_get_topic_forum_id( $id ) { return (int) ( $GLOBALS['_recent_activity_posts'][ $id ]->post_parent ?? 0 ); }
+	function bbp_get_reply_url( $id ) { return 'https://community.example.test/reply/' . (int) $id; }
+	function bbp_get_topic_permalink( $id ) { return 'https://community.example.test/topic/' . (int) $id; }
+	function bbp_get_forum_permalink( $id ) { return 'https://community.example.test/forum/' . (int) $id; }
+}
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $id ) { return $GLOBALS['_recent_activity_posts'][ $id ] ?? null; }
+	function get_the_title( $post ) { return $post->post_title; }
+	function get_userdata( $id ) { return $id ? (object) array( 'ID' => $id, 'display_name' => 'User ' . $id ) : false; }
+	function get_post_meta() { return ''; }
+	function get_the_terms( $id ) { return $GLOBALS['_recent_activity_terms'][ $id ] ?? array(); }
+	function get_term_link( $term ) { return 'https://community.example.test/artist/' . $term->slug; }
+	function is_wp_error() { return false; }
+	function mysql2date( $format, $date ) { return gmdate( $format, strtotime( $date . ' UTC' ) ); }
+}
+if ( ! function_exists( 'extrachill_get_user_profile_url' ) ) {
+	function extrachill_get_user_profile_url( $id ) { return 'https://community.example.test/members/' . (int) $id; }
+}
 
 function recent_activity_post( $id, $type, $status, $parent = 10, $author = 7 ) {
+	if ( ! $GLOBALS['_recent_activity_standalone'] ) {
+		$post_id = wp_insert_post(
+			array(
+				'import_id'    => $id,
+				'post_type'    => $type,
+				'post_status'  => $status,
+				'post_parent'  => $parent,
+				'post_author'  => $author,
+				'post_title'   => ucfirst( $type ) . ' ' . $id,
+				'post_name'    => $type . '-' . $id,
+				'post_date'    => '2026-08-01 12:00:00',
+				'post_date_gmt' => '2026-08-01 12:00:00',
+			)
+		);
+		return get_post( $post_id );
+	}
+
 	return new WP_Post(
 		array(
 			'ID'            => $id,
@@ -78,52 +117,67 @@ function recent_activity_assert( $condition, $message ) {
 }
 
 require dirname( __DIR__ ) . '/inc/content/recent-public-activity.php';
-extrachill_community_register_recent_public_activity_ability();
-
-$ability = $GLOBALS['_recent_activity_ability'];
-recent_activity_assert( true === $ability['meta']['show_in_rest'], 'Projection must use the public core ability runner.' );
-recent_activity_assert( true === $ability['meta']['annotations']['readonly'], 'Projection must remain read-only.' );
-recent_activity_assert( 20 === $ability['input_schema']['properties']['limit']['maximum'], 'Input must declare the strict limit.' );
-recent_activity_assert( 20 === $ability['output_schema']['properties']['items']['maxItems'], 'Output must declare the strict limit.' );
-recent_activity_assert( false === $ability['output_schema']['additionalProperties'], 'Top-level output must be exact.' );
+if ( $standalone ) {
+	extrachill_community_register_recent_public_activity_ability();
+	$ability = $GLOBALS['_recent_activity_ability'];
+	recent_activity_assert( true === $ability['meta']['show_in_rest'], 'Projection must use the public core ability runner.' );
+	recent_activity_assert( true === $ability['meta']['annotations']['readonly'], 'Projection must remain read-only.' );
+	recent_activity_assert( 20 === $ability['input_schema']['properties']['limit']['maximum'], 'Input must declare the strict limit.' );
+	recent_activity_assert( 20 === $ability['output_schema']['properties']['items']['maxItems'], 'Output must declare the strict limit.' );
+	recent_activity_assert( false === $ability['output_schema']['additionalProperties'], 'Top-level output must be exact.' );
+} else {
+	register_post_type( 'forum', array( 'public' => true ) );
+	register_post_type( 'topic', array( 'public' => true ) );
+	register_post_type( 'reply', array( 'public' => true ) );
+	register_post_status( 'closed', array( 'public' => true ) );
+	register_taxonomy( 'artist', 'topic', array( 'public' => true ) );
+}
 
 $forum  = recent_activity_post( 10, 'forum', 'publish', 0 );
-$public = recent_activity_post( 20, 'topic', 'publish' );
-$closed = recent_activity_post( 21, 'topic', 'closed' );
-$reply  = recent_activity_post( 30, 'reply', 'publish' );
-$reply->topic_id = 20;
-$private = recent_activity_post( 22, 'topic', 'private' );
-$draft   = recent_activity_post( 23, 'topic', 'draft' );
-$trash   = recent_activity_post( 24, 'topic', 'trash' );
-$orphan  = recent_activity_post( 31, 'reply', 'publish' );
+$public = recent_activity_post( 20, 'topic', 'publish', $forum->ID );
+$closed = recent_activity_post( 21, 'topic', 'closed', $forum->ID );
+$reply  = recent_activity_post( 30, 'reply', 'publish', $forum->ID );
+$reply->topic_id = $public->ID;
+$private = recent_activity_post( 22, 'topic', 'private', $forum->ID );
+$draft   = recent_activity_post( 23, 'topic', 'draft', $forum->ID );
+$trash   = recent_activity_post( 24, 'topic', 'trash', $forum->ID );
+$orphan  = recent_activity_post( 31, 'reply', 'publish', $forum->ID );
 $orphan->topic_id = 999;
 
 $GLOBALS['_recent_activity_posts'] = array(
-	10 => $forum,
-	20 => $public,
-	21 => $closed,
-	22 => $private,
-	23 => $draft,
-	24 => $trash,
-	30 => $reply,
-	31 => $orphan,
+	$forum->ID   => $forum,
+	$public->ID  => $public,
+	$closed->ID  => $closed,
+	$private->ID => $private,
+	$draft->ID   => $draft,
+	$trash->ID   => $trash,
+	$reply->ID   => $reply,
+	$orphan->ID  => $orphan,
 );
-$GLOBALS['_recent_activity_terms'][20] = array( (object) array( 'name' => 'Test Artist', 'slug' => 'test-artist' ) );
+$GLOBALS['_recent_activity_terms'][ $public->ID ] = array( (object) array( 'name' => 'Test Artist', 'slug' => 'test-artist' ) );
+if ( ! $standalone ) {
+	wp_set_object_terms( $public->ID, 'Test Artist', 'artist' );
+}
 $GLOBALS['_recent_activity_query_posts'] = array( $public, $closed, $reply, $private, $draft, $trash, $orphan );
 
 $result = extrachill_community_ability_recent_public_activity( array( 'limit' => 999 ) );
 recent_activity_assert( 3 === count( $result['items'] ), 'Only public, closed-public, and publicly parented reply activity may escape.' );
-recent_activity_assert( 'discussion' === $result['items'][1]['activity_type'], 'Closed discussions remain public without exposing their storage status.' );
-recent_activity_assert( 'reply' === $result['items'][2]['activity_type'], 'Public replies remain distinguishable without exposing post types.' );
-recent_activity_assert( 20 === $GLOBALS['_recent_activity_query_args']['posts_per_page'], 'Runtime must clamp callers to the strict maximum.' );
+recent_activity_assert( 2 === count( array_keys( array_column( $result['items'], 'activity_type' ), 'discussion', true ) ), 'Closed discussions remain public without exposing their storage status.' );
+recent_activity_assert( 1 === count( array_keys( array_column( $result['items'], 'activity_type' ), 'reply', true ) ), 'Public replies remain distinguishable without exposing post types.' );
+if ( $standalone ) {
+	recent_activity_assert( 20 === $GLOBALS['_recent_activity_query_args']['posts_per_page'], 'Runtime must clamp callers to the strict maximum.' );
+}
 recent_activity_assert( array( 'schema_version', 'items' ) === array_keys( $result ), 'Projection must expose only version and items at the top level.' );
 recent_activity_assert( false === strpos( serialize( $result ), 'post_status' ) && false === strpos( serialize( $result ), 'topic_id' ), 'Projection must not leak storage fields.' );
-recent_activity_assert( 'test-artist' === $result['items'][0]['relationships']['artists'][0]['slug'], 'Artist relationships must be portable owner data.' );
+$artist_rows = array_filter( $result['items'], static function ( $item ) { return ! empty( $item['relationships']['artists'] ); } );
+recent_activity_assert( 'test-artist' === reset( $artist_rows )['relationships']['artists'][0]['slug'], 'Artist relationships must be portable owner data.' );
 
 $GLOBALS['_recent_activity_query_posts'] = array( $private, $draft, $trash, $orphan );
-$empty = extrachill_community_ability_recent_public_activity( array( 'artist_slug' => 'test-artist' ) );
+$empty = extrachill_community_ability_recent_public_activity( array( 'artist_slug' => 'no-matches' ) );
 recent_activity_assert( array() === $empty['items'], 'An all-hidden query must return a versioned empty result.' );
-recent_activity_assert( 'test-artist' === $GLOBALS['_recent_activity_query_args']['tax_query'][0]['terms'], 'Artist scoping must stay inside the owner query.' );
-recent_activity_assert( 'topic' === $GLOBALS['_recent_activity_query_args']['post_type'], 'Artist scoping must query relationship-owning discussions only.' );
+if ( $standalone ) {
+	recent_activity_assert( 'no-matches' === $GLOBALS['_recent_activity_query_args']['tax_query'][0]['terms'], 'Artist scoping must stay inside the owner query.' );
+	recent_activity_assert( 'topic' === $GLOBALS['_recent_activity_query_args']['post_type'], 'Artist scoping must query relationship-owning discussions only.' );
+}
 
 echo "PASS: Recent public activity is bounded, exact, and visibility-safe.\n";

--- a/tests/recent-public-activity-smoke.php
+++ b/tests/recent-public-activity-smoke.php
@@ -1,0 +1,129 @@
+<?php
+/** Focused coverage for the bounded recent public activity owner contract. */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Post {
+	public function __construct( array $data ) {
+		foreach ( $data as $key => $value ) {
+			$this->$key = $value;
+		}
+	}
+}
+
+class WP_Query {
+	public $posts;
+
+	public function __construct( $args ) {
+		$GLOBALS['_recent_activity_query_args'] = $args;
+		$this->posts                            = $GLOBALS['_recent_activity_query_posts'];
+	}
+}
+
+$GLOBALS['_recent_activity_ability']     = null;
+$GLOBALS['_recent_activity_query_args']  = array();
+$GLOBALS['_recent_activity_query_posts'] = array();
+$GLOBALS['_recent_activity_posts']       = array();
+$GLOBALS['_recent_activity_terms']       = array();
+
+function add_action() {}
+function __( $text ) { return $text; }
+function __return_true() { return true; }
+function wp_register_ability( $name, $args ) {
+	if ( 'extrachill/community-recent-public-activity' === $name ) {
+		$GLOBALS['_recent_activity_ability'] = $args;
+	}
+}
+function bbp_get_topic_post_type() { return 'topic'; }
+function bbp_get_reply_post_type() { return 'reply'; }
+function bbp_get_forum_post_type() { return 'forum'; }
+function bbp_get_public_status_id() { return 'publish'; }
+function bbp_get_closed_status_id() { return 'closed'; }
+function bbp_get_reply_topic_id( $id ) { return (int) ( $GLOBALS['_recent_activity_posts'][ $id ]->topic_id ?? 0 ); }
+function bbp_get_topic_forum_id( $id ) { return (int) ( $GLOBALS['_recent_activity_posts'][ $id ]->post_parent ?? 0 ); }
+function bbp_get_reply_url( $id ) { return 'https://community.example.test/reply/' . (int) $id; }
+function bbp_get_topic_permalink( $id ) { return 'https://community.example.test/topic/' . (int) $id; }
+function bbp_get_forum_permalink( $id ) { return 'https://community.example.test/forum/' . (int) $id; }
+function get_post( $id ) { return $GLOBALS['_recent_activity_posts'][ $id ] ?? null; }
+function get_the_title( $post ) { return $post->post_title; }
+function get_userdata( $id ) { return $id ? (object) array( 'ID' => $id, 'display_name' => 'User ' . $id ) : false; }
+function extrachill_get_user_profile_url( $id ) { return 'https://community.example.test/members/' . (int) $id; }
+function get_post_meta() { return ''; }
+function get_the_terms( $id ) { return $GLOBALS['_recent_activity_terms'][ $id ] ?? array(); }
+function get_term_link( $term ) { return 'https://community.example.test/artist/' . $term->slug; }
+function is_wp_error() { return false; }
+function mysql2date( $format, $date ) { return gmdate( $format, strtotime( $date . ' UTC' ) ); }
+
+function recent_activity_post( $id, $type, $status, $parent = 10, $author = 7 ) {
+	return new WP_Post(
+		array(
+			'ID'            => $id,
+			'post_type'     => $type,
+			'post_status'   => $status,
+			'post_parent'   => $parent,
+			'post_author'   => $author,
+			'post_title'    => ucfirst( $type ) . ' ' . $id,
+			'post_name'     => $type . '-' . $id,
+			'post_date'     => '2026-08-01 12:00:00',
+			'post_date_gmt' => '2026-08-01 12:00:00',
+		)
+	);
+}
+
+function recent_activity_assert( $condition, $message ) {
+	if ( ! $condition ) {
+		fwrite( STDERR, "FAIL: {$message}\n" );
+		exit( 1 );
+	}
+}
+
+require dirname( __DIR__ ) . '/inc/content/recent-public-activity.php';
+extrachill_community_register_recent_public_activity_ability();
+
+$ability = $GLOBALS['_recent_activity_ability'];
+recent_activity_assert( true === $ability['meta']['show_in_rest'], 'Projection must use the public core ability runner.' );
+recent_activity_assert( true === $ability['meta']['annotations']['readonly'], 'Projection must remain read-only.' );
+recent_activity_assert( 20 === $ability['input_schema']['properties']['limit']['maximum'], 'Input must declare the strict limit.' );
+recent_activity_assert( 20 === $ability['output_schema']['properties']['items']['maxItems'], 'Output must declare the strict limit.' );
+recent_activity_assert( false === $ability['output_schema']['additionalProperties'], 'Top-level output must be exact.' );
+
+$forum  = recent_activity_post( 10, 'forum', 'publish', 0 );
+$public = recent_activity_post( 20, 'topic', 'publish' );
+$closed = recent_activity_post( 21, 'topic', 'closed' );
+$reply  = recent_activity_post( 30, 'reply', 'publish' );
+$reply->topic_id = 20;
+$private = recent_activity_post( 22, 'topic', 'private' );
+$draft   = recent_activity_post( 23, 'topic', 'draft' );
+$trash   = recent_activity_post( 24, 'topic', 'trash' );
+$orphan  = recent_activity_post( 31, 'reply', 'publish' );
+$orphan->topic_id = 999;
+
+$GLOBALS['_recent_activity_posts'] = array(
+	10 => $forum,
+	20 => $public,
+	21 => $closed,
+	22 => $private,
+	23 => $draft,
+	24 => $trash,
+	30 => $reply,
+	31 => $orphan,
+);
+$GLOBALS['_recent_activity_terms'][20] = array( (object) array( 'name' => 'Test Artist', 'slug' => 'test-artist' ) );
+$GLOBALS['_recent_activity_query_posts'] = array( $public, $closed, $reply, $private, $draft, $trash, $orphan );
+
+$result = extrachill_community_ability_recent_public_activity( array( 'limit' => 999 ) );
+recent_activity_assert( 3 === count( $result['items'] ), 'Only public, closed-public, and publicly parented reply activity may escape.' );
+recent_activity_assert( 'discussion' === $result['items'][1]['activity_type'], 'Closed discussions remain public without exposing their storage status.' );
+recent_activity_assert( 'reply' === $result['items'][2]['activity_type'], 'Public replies remain distinguishable without exposing post types.' );
+recent_activity_assert( 20 === $GLOBALS['_recent_activity_query_args']['posts_per_page'], 'Runtime must clamp callers to the strict maximum.' );
+recent_activity_assert( array( 'schema_version', 'items' ) === array_keys( $result ), 'Projection must expose only version and items at the top level.' );
+recent_activity_assert( false === strpos( serialize( $result ), 'post_status' ) && false === strpos( serialize( $result ), 'topic_id' ), 'Projection must not leak storage fields.' );
+recent_activity_assert( 'test-artist' === $result['items'][0]['relationships']['artists'][0]['slug'], 'Artist relationships must be portable owner data.' );
+
+$GLOBALS['_recent_activity_query_posts'] = array( $private, $draft, $trash, $orphan );
+$empty = extrachill_community_ability_recent_public_activity( array( 'artist_slug' => 'test-artist' ) );
+recent_activity_assert( array() === $empty['items'], 'An all-hidden query must return a versioned empty result.' );
+recent_activity_assert( 'test-artist' === $GLOBALS['_recent_activity_query_args']['tax_query'][0]['terms'], 'Artist scoping must stay inside the owner query.' );
+recent_activity_assert( 'topic' === $GLOBALS['_recent_activity_query_args']['post_type'], 'Artist scoping must query relationship-owning discussions only.' );
+
+echo "PASS: Recent public activity is bounded, exact, and visibility-safe.\n";


### PR DESCRIPTION
## Summary
- expose `extrachill/community-recent-public-activity` through the standard read-only Abilities API runner
- return a versioned, storage-agnostic activity projection for discussions and replies, with actor, forum, and artist relationship data
- enforce owner-side visibility checks and bounded query/output sizes so consumers never switch sites or query bbPress storage

## Contract
- schema version: `1`
- input: optional `limit` (default 5, maximum 20) and optional bounded `artist_slug`
- item fields: `canonical_url`, `title`, `timestamp`, semantic `activity_type`, exact `actor`, and exact `relationships`
- relationships: canonical Community forum archive plus up to 10 Community artist archive relationships
- no post IDs, post types, post statuses, bbPress metadata keys, or helper details escape the projection

## Visibility And Bounds
- published discussions and published replies under public discussions/forums are included
- closed discussions remain included because they are still publicly readable
- private, draft/unpublished, trashed/deleted, invalid-parent, and non-public-forum activity is omitted
- both the input schema and runtime clamp enforce a maximum of 20 results; output schema also declares `maxItems: 20`

## Tests
- `homeboy review --changed-since origin/main --summary --placement local`
- standalone and real-WordPress smoke coverage verifies schema exactness, REST visibility, limit clamping, artist scoping, closed/public behavior, private/draft/trash/orphan exclusion, storage-field redaction, and versioned empty results

Closes #267